### PR TITLE
Fix typo: ayload -> payload

### DIFF
--- a/lore-revision/README-PROTOCOLS.md
+++ b/lore-revision/README-PROTOCOLS.md
@@ -172,7 +172,7 @@ Reply payload
 ### Branch destroy
 Destroy a named branch
 
-Command ayload
+Command payload
 ```
 [16 bytes] Branch identifier
 [32 bytes] Current latest pointer


### PR DESCRIPTION
Fixed typo in documentation: `lore-revision/README-PROTOCOLS.md`