### PR TITLE
Fix two typos

### DIFF
--- a/lore-revision/src/nametable.rs
+++ b/lore-revision/src/nametable.rs
@@ -219,7 +219,7 @@ impl NameTable {
     /// (entries are never removed or relocated), and all callers immediately
     /// copy the result to an owned `String` before the borrow expires.
     pub fn load(&self, hash: u64) -> &str {
-        // TODO(mjansson): Garbage collect nametable by iterating entire merkle tree and rebuiling
+        // TODO(mjansson): Garbage collect nametable by iterating entire merkle tree and rebuilding
         // nametable, cleaning out stale entries
         let data = self.data.read();
         let entry = data.entry_buffer.as_type_slice::<NameTableEntry>();

--- a/lore-server/src/settings.rs
+++ b/lore-server/src/settings.rs
@@ -306,7 +306,7 @@ pub struct QuicSettings {
     pub port: i32,
     pub transport_bits_per_second: Option<usize>,
     pub transport_rtt: Option<usize>,
-    /// Keep below a threshold for whatever Load Balancer sits infront of the server
+    /// Keep below a threshold for whatever Load Balancer sits in front of the server
     /// or is expecting responses. If request handlers exceed this reasonable threshold
     /// then assume something has gone wrong and return a timeout response so we can get metrics
     /// and clients don't hang forever


### PR DESCRIPTION
You should get some github actions to run codespell or similar tools. Once you go down the github actions route though, consider using zizmor to lint said actions. See what we do [over here](https://github.com/letsencrypt/boulder/blob/main/.github/workflows/zizmor.yml).