### PR TITLE
lore: return an error on a malformed IPC message header

### DIFF
--- a/lore/src/remote/message.rs
+++ b/lore/src/remote/message.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Epic Games, Inc.
+// SPDX-FileCopyrightText: 2026 glitch-ux
 // SPDX-License-Identifier: MIT
 use std::io::ErrorKind;
 use std::io::Read;
@@ -49,7 +50,7 @@ pub fn blocking_read_v1_message<Message: for<'a> Deserialize<'a>, Reader: Read +
     reader
         .read_exact(&mut header_bytes)
         .internal("reading message header")?;
-    let header = V1Header::from_bytes(&header_bytes).unwrap();
+    let header = V1Header::from_bytes(&header_bytes)?;
 
     let mut message_bytes = vec![0; header.payload_size as usize];
     reader

--- a/lore/tests/remote_message.rs
+++ b/lore/tests/remote_message.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Epic Games, Inc.
+// SPDX-FileCopyrightText: 2026 glitch-ux
 // SPDX-License-Identifier: MIT
 use lore::remote::command::LoreCommand;
 use lore::remote::message::MessageError;
@@ -27,6 +28,20 @@ fn header_to_and_from_bytes() {
     let bad_processed_header = V1Header::from_bytes(&bad_bytes);
 
     assert!(bad_processed_header.is_err());
+}
+
+#[test]
+fn errors_on_invalid_serialization_type_in_header() {
+    // A valid V1 version byte (0), a zero payload size, and 0xff as the
+    // serialization-type byte, which is not a valid SerializationType. Reading a
+    // message with such a header must surface a recoverable error rather than
+    // panicking the process.
+    let bytes: [u8; 6] = [0, 0, 0, 0, 0, 0xff];
+
+    let result: Result<Option<(V1Header, MessageToServer)>, MessageError> =
+        blocking_read_v1_message(&mut bytes.as_slice());
+
+    assert!(result.is_err());
 }
 
 #[tokio::test]


### PR DESCRIPTION
## What

Make `blocking_read_v1_message` return a recoverable error on a malformed V1 IPC
message header instead of panicking, and add a regression test.

## Why

`blocking_read_v1_message` (`lore/src/remote/message.rs`) reads the 5-byte V1
header off the local IPC socket (the `lore` CLI ↔ local `lore service`) and
unwrapped the parsed header:

```rust
let header = V1Header::from_bytes(&header_bytes).unwrap();
```

`V1Header::from_bytes` returns `Err(MessageError)` for a header whose
serialization-type byte isn't a known value, but the caller `.unwrap()`s it, so
a corrupted/partial frame — or a version-mismatched local service — panics the
process instead of surfacing that descriptive error. The enclosing function
already returns `Result<Option<(V1Header, Message)>, MessageError>` and every
other read in it uses `?`, so the recoverable path already exists; the
`.unwrap()` simply bypassed it.

Fixes #15.

## How

`V1Header::from_bytes(&header_bytes).unwrap()` → `V1Header::from_bytes(&header_bytes)?`.
The error type already matches `MessageError`, so no mapping is needed — the
descriptive error (`"Message received with invalid serialization type: …"`) now
reaches the caller. No public API, wire-protocol, or on-disk-format change.

## Testing

- Added `errors_on_invalid_serialization_type_in_header` to
  `lore/tests/remote_message.rs`: it feeds a header with an invalid
  serialization-type byte (`0xff`) through `blocking_read_v1_message` and asserts
  it returns `Err`. Before this change that path panics at the `unwrap`.
- `cargo test -p lore --test remote_message` → 3 passed.
- `cargo clippy -p lore --all-targets -- -D warnings --no-deps` → clean.
- `cargo +nightly fmt --all --check` → clean.
- pre-commit file hooks (end-of-file-fixer, trailing-whitespace, codespell, …) → pass.

## AI assistance

This change was prepared with the help of an AI coding assistant (Claude Code),
in keeping with the project's AI assistance policy. The diff was built and
verified locally as shown in **Testing**, and is submitted under my
responsibility.
