### PR TITLE
fix(ci): harden publish-docs workflow security and update actions

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -8,10 +8,7 @@ on:
       - docs/**
   workflow_dispatch:
 
-permissions:
-  contents: read
-  pages: write
-  id-token: write
+permissions: {}
 
 concurrency:
   group: pages
@@ -20,10 +17,14 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # Clone the repository
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
-      - uses: actions/configure-pages@v5
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+      - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
       - run: >
           uvx
           --with mkdocs-material
@@ -33,16 +34,19 @@ jobs:
           mkdocs build --strict
         env:
           DISABLE_MKDOCS_2_WARNING: "true"
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: site
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      pages: write    # Deploy to GitHub Pages
+      id-token: write # Federate via OIDC for Pages deployment
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,8 @@
 
 Welcome to the Lore documentation. The pages below cover everything from your first install through the internal design, organized into a consistent structure that helps you find what you need.
 
+Test Test Test
+
 ## Get started
 
 - [Quickstart](tutorials/quickstart.md) — create your first Lore repository.

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,8 +2,6 @@
 
 Welcome to the Lore documentation. The pages below cover everything from your first install through the internal design, organized into a consistent structure that helps you find what you need.
 
-Test Test Test
-
 ## Get started
 
 - [Quickstart](tutorials/quickstart.md) — create your first Lore repository.


### PR DESCRIPTION
Similar to #7 but use full SHAs for actions

## What/Why

Reduce blast radius of a compromised action by moving permissions to job level with least-privilege grants, disabling credential persistence on checkout, and pinning all actions to SHA at their latest versions.

## Proof it works

actionlint passes clean. Workflow is push-to-main only so will be validated on merge.

## Risk + AI role

Low -- workflow-only change, no application code affected. AI-assisted (Claude Opus 4.6).

## Review focus

Verify the major version bumps (checkout v4->v6, setup-uv v5->v8, configure-pages v5->v6, upload-pages-artifact v3->v5, deploy-pages v4->v5) don't introduce breaking changes for this usage.