### PR TITLE
chore(ci): add dependabot config for automated dependency updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,21 +1,6 @@
 ---
 version: 2
 updates:
-  - package-ecosystem: "cargo"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    cooldown:
-      default-days: 7
-    commit-message:
-      prefix: "chore(deps)"
-    labels: ["rust", "dependencies"]
-    groups:
-      dependencies:
-        applies-to: version-updates
-        update-types:
-          - "minor"
-          - "patch"
   - package-ecosystem: "uv"
     directory: "/"
     schedule:

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,78 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    commit-message:
+      prefix: "chore(deps)"
+    labels: ["rust", "dependencies"]
+    groups:
+      dependencies:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    commit-message:
+      prefix: "chore(deps)"
+    labels: ["python", "dependencies"]
+    groups:
+      dependencies:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    commit-message:
+      prefix: "chore(deps)"
+    labels: ["github_actions", "dependencies"]
+    groups:
+      dependencies:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+  - package-ecosystem: "docker"
+    directory: "/lore-server"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    commit-message:
+      prefix: "chore(deps)"
+    labels: ["docker", "dependencies"]
+    groups:
+      dependencies:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+  - package-ecosystem: "docker"
+    directory: "/lore-revision"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    commit-message:
+      prefix: "chore(deps)"
+    labels: ["docker", "dependencies"]
+    groups:
+      dependencies:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## What/Why

Add Dependabot configuration to automate dependency update PRs across ecosystems in the repo: uv (Python), github-actions, and docker (lore-server, lore-revision). Cargo was excluded per maintainer feedback.

## Proof it works

YAML validates cleanly. Dependabot will pick up the config on merge and begin scanning on its weekly schedule.

## Risk + AI role

Low -- config-only addition, no code changes. AI-assisted (Claude Opus 4.6).

## Review focus

- Confirm the grouped minor+patch strategy is appropriate and that no ecosystems were missed.
- The labels (python, github_actions, docker, dependencies) must exist in the repo or be created before merge, otherwise Dependabot PRs will fail to apply them.