### PR TITLE
Fix lore-server build without tokio_unstable

### DIFF
--- a/lore-server/src/protocol/replication_store/exists_batch.rs
+++ b/lore-server/src/protocol/replication_store/exists_batch.rs
@@ -19,6 +19,7 @@ use tracing::info_span;
 use tracing::warn;
 
 use crate::protocol::replication_store::REPLICATION_SERVICE_USER_ID;
+use crate::protocol::replication_store::header::REPLICATION_HEADER_SIZE;
 use crate::protocol::replication_store::header::ReplicationHeader;
 use crate::protocol::storage::messages::MessageParseError;
 use crate::quic::replication_store_service::client::ReplicationStoreClientError;
@@ -28,7 +29,7 @@ use crate::util::setup_execution;
 
 pub const MAX_ADDRESSES: usize = 100;
 
-pub const BASE_REQUEST_SIZE: usize = size_of::<ReplicationHeader>() +
+pub const BASE_REQUEST_SIZE: usize = REPLICATION_HEADER_SIZE +
         // store match byte
         1 +
         // at least 1 address
@@ -46,7 +47,7 @@ impl ExistsBatch {
         let store_match_num: u8 = self.store_match.into();
         [
             Bytes::default(), // command header
-            Bytes::from_owner(self.header),
+            self.header.to_bytes(),
             Bytes::copy_from_slice(&[store_match_num]),
             Bytes::from_owner(VecBytes(self.addresses)),
         ]
@@ -57,7 +58,7 @@ impl ExistsBatch {
             return Err(MessageParseError::InvalidFieldLength);
         };
 
-        let header: ReplicationHeader = bytes.split_to(size_of::<ReplicationHeader>()).into();
+        let header: ReplicationHeader = bytes.split_to(REPLICATION_HEADER_SIZE).into();
         let store_match: StoreMatch = {
             let raw_value = bytes[0];
             bytes.advance(1);

--- a/lore-server/src/protocol/replication_store/get.rs
+++ b/lore-server/src/protocol/replication_store/get.rs
@@ -20,6 +20,7 @@ use tracing::warn;
 use zerocopy::IntoBytes;
 
 use crate::protocol::replication_store::REPLICATION_SERVICE_USER_ID;
+use crate::protocol::replication_store::header::REPLICATION_HEADER_SIZE;
 use crate::protocol::replication_store::header::ReplicationHeader;
 use crate::protocol::storage::messages::MessageParseError;
 use crate::quic::replication_store_service::client::ReplicationStoreClientError;
@@ -27,7 +28,7 @@ use crate::quic::replication_store_service::server::ParsedReplicationStoreReques
 use crate::quic::replication_store_service::server::RequestHandler;
 use crate::util::setup_execution;
 
-pub const BASE_REQUEST_SIZE: usize = size_of::<ReplicationHeader>() +
+pub const BASE_REQUEST_SIZE: usize = REPLICATION_HEADER_SIZE +
         size_of::<Address>() +
         // match_required byte
         1;
@@ -44,7 +45,7 @@ impl Get {
         let match_required_num: u8 = self.match_required.into();
         [
             Bytes::default(), // command header
-            Bytes::from_owner(self.header),
+            self.header.to_bytes(),
             Bytes::from_owner(self.address),
             Bytes::copy_from_slice(&[match_required_num]),
         ]
@@ -55,7 +56,7 @@ impl Get {
             return Err(MessageParseError::InvalidFieldLength);
         };
 
-        let header: ReplicationHeader = bytes.split_to(size_of::<ReplicationHeader>()).into();
+        let header: ReplicationHeader = bytes.split_to(REPLICATION_HEADER_SIZE).into();
         let address: Address = bytes.split_to(size_of::<Address>()).into();
         let match_required: StoreMatch = {
             let raw_value = bytes[0];

--- a/lore-server/src/protocol/replication_store/header.rs
+++ b/lore-server/src/protocol/replication_store/header.rs
@@ -1,13 +1,17 @@
 // SPDX-FileCopyrightText: 2026 Epic Games, Inc.
 // SPDX-License-Identifier: MIT
+use std::mem::size_of;
+
 use bytes::Bytes;
 use lore_base::types::Context;
 use uuid::Uuid;
-use zerocopy::FromBytes;
-use zerocopy::Immutable;
-use zerocopy::IntoBytes;
 
-#[derive(Clone, Debug, Default, IntoBytes, FromBytes, Immutable, PartialEq)]
+const UUID_SIZE: usize = 16;
+pub const REPLICATION_HEADER_SIZE: usize = UUID_SIZE + size_of::<Context>();
+const _: [(); UUID_SIZE] = [(); size_of::<Uuid>()];
+
+#[repr(C)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct ReplicationHeader {
     pub correlation_id: Uuid,
     pub repository: Context,
@@ -15,20 +19,51 @@ pub struct ReplicationHeader {
 
 impl From<&[u8]> for ReplicationHeader {
     fn from(bytes: &[u8]) -> Self {
-        ReplicationHeader::read_from_prefix(bytes)
-            .unwrap_or_default()
-            .0
+        if bytes.len() < REPLICATION_HEADER_SIZE {
+            return ReplicationHeader::default();
+        }
+
+        let mut correlation_id = [0; UUID_SIZE];
+        correlation_id.copy_from_slice(&bytes[..UUID_SIZE]);
+        let repository = Context::from(&bytes[UUID_SIZE..REPLICATION_HEADER_SIZE]);
+
+        ReplicationHeader {
+            correlation_id: Uuid::from_bytes(correlation_id),
+            repository,
+        }
     }
 }
 
 impl From<Bytes> for ReplicationHeader {
     fn from(bytes: Bytes) -> Self {
-        bytes.as_bytes().into()
+        bytes.as_ref().into()
     }
 }
 
-impl AsRef<[u8]> for ReplicationHeader {
-    fn as_ref(&self) -> &[u8] {
-        self.as_bytes()
+impl ReplicationHeader {
+    pub fn to_bytes(&self) -> Bytes {
+        let mut bytes = [0; REPLICATION_HEADER_SIZE];
+        bytes[..UUID_SIZE].copy_from_slice(self.correlation_id.as_bytes());
+        bytes[UUID_SIZE..].copy_from_slice(self.repository.as_ref());
+        Bytes::copy_from_slice(&bytes)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn replication_header_roundtrips_bytes() {
+        let correlation_id = Uuid::from_bytes([1; UUID_SIZE]);
+        let repository = Context::from([2; 16]);
+        let header = ReplicationHeader {
+            correlation_id,
+            repository,
+        };
+
+        let bytes = header.to_bytes();
+        assert_eq!(bytes.len(), REPLICATION_HEADER_SIZE);
+        assert_eq!(ReplicationHeader::from(bytes), header);
     }
 }

--- a/lore-server/src/protocol/replication_store/obliterate.rs
+++ b/lore-server/src/protocol/replication_store/obliterate.rs
@@ -20,6 +20,7 @@ use zerocopy::FromBytes;
 use zerocopy::IntoBytes;
 
 use crate::protocol::replication_store::REPLICATION_SERVICE_USER_ID;
+use crate::protocol::replication_store::header::REPLICATION_HEADER_SIZE;
 use crate::protocol::replication_store::header::ReplicationHeader;
 use crate::protocol::storage::messages::MessageParseError;
 use crate::quic::replication_store_service::client::ReplicationStoreClientError;
@@ -27,7 +28,7 @@ use crate::quic::replication_store_service::server::ParsedReplicationStoreReques
 use crate::quic::replication_store_service::server::RequestHandler;
 use crate::util::setup_execution;
 
-pub const BASE_REQUEST_SIZE: usize = size_of::<ReplicationHeader>() + size_of::<Address>();
+pub const BASE_REQUEST_SIZE: usize = REPLICATION_HEADER_SIZE + size_of::<Address>();
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct Obliterate {
@@ -39,7 +40,7 @@ impl Obliterate {
     pub fn to_quic_chunks(self) -> [Bytes; 3] {
         [
             Bytes::default(), // command header
-            Bytes::from_owner(self.header),
+            self.header.to_bytes(),
             Bytes::from_owner(self.address),
         ]
     }
@@ -50,7 +51,7 @@ pub fn parse(mut bytes: Bytes) -> Result<Obliterate, MessageParseError> {
         return Err(MessageParseError::InvalidFieldLength);
     };
 
-    let header: ReplicationHeader = bytes.split_to(size_of::<ReplicationHeader>()).into();
+    let header: ReplicationHeader = bytes.split_to(REPLICATION_HEADER_SIZE).into();
     let address: Address = bytes.split_to(size_of::<Address>()).into();
 
     Ok(Obliterate { header, address })

--- a/lore-server/src/protocol/replication_store/put.rs
+++ b/lore-server/src/protocol/replication_store/put.rs
@@ -17,13 +17,14 @@ use tracing::debug;
 use tracing::info_span;
 
 use crate::protocol::replication_store::REPLICATION_SERVICE_USER_ID;
+use crate::protocol::replication_store::header::REPLICATION_HEADER_SIZE;
 use crate::protocol::replication_store::header::ReplicationHeader;
 use crate::protocol::storage::messages::MessageParseError;
 use crate::quic::replication_store_service::server::ParsedReplicationStoreRequest;
 use crate::quic::replication_store_service::server::RequestHandler;
 use crate::util::setup_execution;
 
-pub const BASE_REQUEST_SIZE: usize = size_of::<ReplicationHeader>() +
+pub const BASE_REQUEST_SIZE: usize = REPLICATION_HEADER_SIZE +
         size_of::<Address>() +
         size_of::<Fragment>() +
         // flags
@@ -42,7 +43,7 @@ impl Put {
     pub fn to_quic_chunks(self) -> [Bytes; 6] {
         [
             Bytes::default(), // command header
-            Bytes::from_owner(self.header),
+            self.header.to_bytes(),
             Bytes::from_owner(self.address),
             Bytes::from_owner(self.fragment),
             Bytes::copy_from_slice(&[self.flags]),
@@ -73,7 +74,7 @@ pub fn parse(mut bytes: Bytes) -> Result<Put, MessageParseError> {
         return Err(MessageParseError::InvalidFieldLength);
     };
 
-    let header: ReplicationHeader = bytes.split_to(size_of::<ReplicationHeader>()).into();
+    let header: ReplicationHeader = bytes.split_to(REPLICATION_HEADER_SIZE).into();
     let address: Address = bytes.split_to(size_of::<Address>()).into();
     let fragment: Fragment = bytes.split_to(size_of::<Fragment>()).into();
     let flags: u8 = {

--- a/lore-server/src/server.rs
+++ b/lore-server/src/server.rs
@@ -105,6 +105,7 @@ use crate::settings::Settings;
 use crate::store::replica_factory::ReplicationStoreTargetFactory;
 use crate::store::replicated_store::ReplicatedStore;
 use crate::store::resolve_plugin_config_with_fallback;
+#[cfg(tokio_unstable)]
 use crate::telemetry::OtelTokioRuntimeMetrics;
 use crate::telemetry::ResourceDetectorProvider;
 use crate::telemetry::TelemetryInitializer;
@@ -1606,17 +1607,20 @@ async fn async_main(settings: (Settings, StringHash), config: ServerConfig) -> R
     // Enforce repository isolation in local store by default
     lore_storage::concurrency::LOCAL_ISOLATION.store(true, std::sync::atomic::Ordering::Release);
 
-    let execution = execution_context();
-    let runtime_monitor = tokio_metrics::RuntimeMonitor::new(&runtime);
-
-    let metrics_bridge = OtelTokioRuntimeMetrics::new(&lore_telemetry::meter("tokio_runtime"));
     let frequency = Duration::from_millis(metrics_config.export_interval_millis);
-    runtime.spawn(LORE_CONTEXT.scope(execution.clone(), async move {
-        for metrics in runtime_monitor.intervals() {
-            metrics_bridge.record(metrics);
-            tokio::time::sleep(frequency).await;
-        }
-    }));
+    #[cfg(tokio_unstable)]
+    {
+        let execution = execution_context();
+        let runtime_monitor = tokio_metrics::RuntimeMonitor::new(&runtime);
+
+        let metrics_bridge = OtelTokioRuntimeMetrics::new(&lore_telemetry::meter("tokio_runtime"));
+        runtime.spawn(LORE_CONTEXT.scope(execution.clone(), async move {
+            for metrics in runtime_monitor.intervals() {
+                metrics_bridge.record(metrics);
+                tokio::time::sleep(frequency).await;
+            }
+        }));
+    }
 
     if let Some(mode) = settings
         .environment


### PR DESCRIPTION
## What

Fixes the `lore-server` build failure reported in #14.

## Why

A normal build failed because `OtelTokioRuntimeMetrics` was used even when the
`tokio_unstable` cfg was not enabled. The replication store header also derivedzerocopy traits through `uuid::Uuid`, which does not satisfy the requiredzerocopy trait bounds.

Fixes #14.

## How

- Gate Tokio runtime metrics import and polling behind `#[cfg(tokio_unstable)]`.
- Keep the QUIC launch frequency available outside that cfg block.
- Replace zerocopy-derived `ReplicationHeader` byte conversion with explicit
  32-byte wire serialization: 16 bytes correlation UUID plus 16 bytes repository
  context.
- Update replication request parsers/encoders to use the explicit header wire
  size.
- Add a header byte roundtrip unit test.

## Testing

- `cargo +nightly fmt --all --check`
- `cargo check -p lore-server`
- `cargo clippy -p lore-server --lib -- -D warnings --no-deps`
- `git diff --check`

Attempted:

- `cargo test -p lore-server replication_header_roundtrips_bytes --lib`

This did not complete locally because `rustc`/LLVM ran out of memory whilecompiling the `lore-server` test binary; the test itself did not fail.

## AI Assistance

Used OpenAI Codex to inspect the issue, elaborate the fix, and run local checks.

Codex reviewed all changes before submission.