### PR TITLE
gitignore: Ignore entire .claude/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -153,7 +153,7 @@ xcuserdata
 
 # claude
 *.local.*
-.claude/skills/review-feedback/
+.claude/
 .claude-worktrees/
 
 # test report


### PR DESCRIPTION
Upon request in #44 thread by @peter-lockhart-pub 

Local Claude Code skills and settings live under .claude/ and shouldn't be tracked. The prior rule only covered one skill subdirectory; broaden it to the whole directory

Just an fyi, these skills that were gitignored are used to help assist in the codebase, such as finding good issues to tackle and understanding what the codebase does from a technical standpoint. Some do assist in code, where disclaimers will be written when done so, but code will still carefully be checked, reviewed, and tested via a human before sending in a PR