### PR TITLE
docs: add Scoop install option for Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 **/target/
 *.dSYM
 
+# mkdocs build output
+/site/
+
 # Local files
 lore-server/config/local*.toml
 **/.grafana.local.yaml

--- a/docs/how-to/deploy-local-lore-server.md
+++ b/docs/how-to/deploy-local-lore-server.md
@@ -39,6 +39,12 @@ The binary and Docker paths are mutually exclusive, and each is complete on its 
     $env:LORE_SERVER=1; irm https://raw.githubusercontent.com/EpicGames/lore/main/scripts/install.ps1 | iex
     ```
 
+    Or install with [Scoop](https://scoop.sh):
+
+    ```powershell
+    scoop install loreserver
+    ```
+
     <!-- tabs:end -->
 
 2. **Run it with default settings.**

--- a/docs/how-to/install-lore-cli.md
+++ b/docs/how-to/install-lore-cli.md
@@ -39,6 +39,12 @@ Pick this path for a normal install from a published release.
     irm https://raw.githubusercontent.com/EpicGames/lore/main/scripts/install.ps1 | iex
     ```
 
+    Or install with [Scoop](https://scoop.sh):
+
+    ```powershell
+    scoop install lore
+    ```
+
     <!-- tabs:end -->
 
     The installer downloads the binary for your platform and adds it to your PATH. Open a new terminal session for the PATH change to take effect.


### PR DESCRIPTION
The Scoop maintainers decided to allow support directly in the `main` bucket:

- https://github.com/ScoopInstaller/Main/pull/8173
- https://github.com/ScoopInstaller/Main/pull/8175

I personally would prefer that as the recommended installation method but I didn't want to make that change without express approval first.

Also, I noticed that the default docs build output directory wasn't ignored by Git so I fixed that while I was here 🙂 