### PR TITLE
docs: Update Install Lore CLI with RUSTFLAGS Note

### DIFF
--- a/docs/how-to/install-lore-cli.md
+++ b/docs/how-to/install-lore-cli.md
@@ -47,6 +47,15 @@ Pick this path for a normal install from a published release.
 
 Pick this path to run a CLI built from your own checkout.
 
+0. **If RUSTFLAGS environment variable is set:**
+
+    Unset it or run the following command prior to building in next step:
+
+    ```bash
+    export RUSTFLAGS="$RUSTFLAGS --cfg tokio_unstable --cfg uuid_unstable"
+    ```
+
+
 1. **Build the binary.**
 
     From the Lore repository root:


### PR DESCRIPTION
Closes #14 

RUSTFLAGS environment variable breaks build due to how `.cargo/config.toml` is read

Adding a note, as suggested by the original issue creator, is the simplest and most straightforward way to fix the problem.