### PR TITLE
Fix broken log

### DIFF
--- a/lore-base/src/log/mod.rs
+++ b/lore-base/src/log/mod.rs
@@ -79,19 +79,12 @@ pub fn dispatch_log(level: LoreLogLevel, location: &str, message: &str) {
 
 #[macro_export]
 macro_rules! lore_trace {
-    ($fmt:expr $(, $arg:expr)* $(,)?) => {{
-        #[cfg(not(feature = "trace_log"))]
-        if false {
-            let _ = core::format_args!($fmt $(, $arg)*);
-        }
-        #[cfg(feature = "trace_log")]
-        if true {
-            $crate::lore_log_event!(
-                $crate::log::LoreLogLevel::Trace,
-                $fmt $(, $arg)*
-            )
-        }
-    }};
+    ($fmt:expr $(, $arg:expr)* $(,)?) => {
+        $crate::lore_log_event!(
+            $crate::log::LoreLogLevel::Trace,
+            $fmt $(, $arg)*
+        )
+    };
 }
 
 #[macro_export]

--- a/lore-client/src/cli/client_main.rs
+++ b/lore-client/src/cli/client_main.rs
@@ -41,7 +41,6 @@ pub fn client_main() -> ExitCode {
         cli.non_interactive,
     );
 
-    lore::log::initialize();
     lore::log::configure(&log_config);
 
     if let Some(max_threads) = cli.max_threads {

--- a/lore/src/log.rs
+++ b/lore/src/log.rs
@@ -64,14 +64,16 @@ pub fn log_level() -> LoreLogLevel {
 pub fn configure(config: &LoreLogConfig) {
     initialize();
 
-    if config.file == 0 {
-        return;
-    }
-
     let mut config = config.clone();
 
     if config.level == LoreLogLevel::None {
         config.level = LoreLogLevel::Info;
+    }
+
+    lore_base::log::set_log_level(config.level);
+
+    if config.file == 0 {
+        return;
     }
 
     let prefix = if !config.file_prefix.is_empty() {


### PR DESCRIPTION
Currently the log level is not being set to anything but debug, also you have a bit of duplications.

configure calls initialize but you call initialize in client_main, a redundant call.

Also the trace_log feature gives the compiler a bunch of warnings when you want to trace in lore-client. It seems that there is quite a bit of mess going on. For example lore_repository reexports the same bindings in lore_base to import from them instead of lore_base, there is a separate tracing crate used in lore_server that uses the same macro but from tracing instead.

