### PR TITLE
lore-web: add self-hosted browser UI for Lore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,3 +164,6 @@ ctrf/
 
 # lychee link checker cache
 .lycheecache
+
+# lore folders
+.lore

--- a/lore-web/.gitignore
+++ b/lore-web/.gitignore
@@ -1,0 +1,6 @@
+# Installed by `npm install` from the registry — not committed.
+node_modules/
+
+# Local runtime state.
+*.log
+.data/

--- a/lore-web/.gitignore
+++ b/lore-web/.gitignore
@@ -4,3 +4,7 @@ node_modules/
 # Local runtime state.
 *.log
 .data/
+
+# Lore files
+.lore/
+.loreignore

--- a/lore-web/README.md
+++ b/lore-web/README.md
@@ -1,0 +1,81 @@
+# lore-web
+
+A self-hosted browser UI for the [Lore](https://epicgames.github.io/lore/) version
+control system. It drives Lore through the same `@lore-vcs/sdk` engine the
+official desktop app uses, but with refresh logic that never serves a stale
+cache — lists update live from disk and after every action.
+
+It runs identically on two kinds of machine:
+
+- **Host** — a machine with a local `lore-server`. lore-web manages local working
+  copies and is the push/sync target for collaborators.
+- **Collaborator** — a machine with no server. lore-web drives `clone` / `sync` /
+  `push` against a host's server over the network. It needs only the SDK
+  dependency and a one-time `lore login`.
+
+## Why this exists
+
+The official desktop app persists its entire UI state to SQLite and rehydrates
+it on launch, with no file watching — so repository and revision lists go stale
+until you restart or clear the cache, and it refuses to remove a repository whose
+folder was deleted. lore-web fixes these by owning the refresh path: see
+[docs/explanation/architecture.md](docs/explanation/architecture.md).
+
+## Quick start
+
+### Windows (no terminal needed)
+
+1. Double-click **`setup.bat`** — checks for Node.js and the `lore` CLI (offering
+   to install anything missing) and installs the SDK.
+2. Double-click **`start.bat`** — launches the app and opens
+   `http://127.0.0.1:7420`. (It also runs setup automatically on first use, so you
+   can skip step 1 and just run `start.bat`.)
+
+### Any platform (terminal)
+
+```sh
+cd lore-web
+npm install       # pulls @lore-vcs/sdk (and its native lorelib) from npm
+npm start         # launch the server and open http://127.0.0.1:7420
+```
+
+Then click **Add**, paste the path to a Lore working copy, and you're in.
+
+> **Sharing with a collaborator:** the `lore-web` folder is self-contained — send
+> just that folder (no need to clone this repository). They run `setup.bat` (or
+> `npm install`) once, then `lore login lore://<your-host>:41337`. See the
+> [how-to guide](docs/how-to/run-lore-web.md).
+
+- Run headless (no browser auto-open): `npm run serve`
+- Run the tests: `npm test`
+- Smoke-test the SDK against a repo: `npm run smoke -- "D:\path\to\repo"`
+
+## Configuration
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `LORE_WEB_PORT` | `7420` | HTTP port |
+| `LORE_WEB_HOST` | `127.0.0.1` | bind address — keep it loopback |
+| `LORE_WEB_LOG_LEVEL` | `info` | `trace`…`error` |
+| `LORE_WEB_STORE` | `~/.lore-web/store.json` | tracked-repo list location |
+| `LORE_CLI` | `lore` | path to the `lore` CLI (login/service fallback) |
+
+> **Security:** lore-web exposes full read/write access to your repositories and
+> is bound to loopback only. Never expose it on a network. The *Lore server* is
+> the networked component, not lore-web.
+
+## The SDK dependency
+
+lore-web does not depend on any other Lore client. Its one runtime dependency is
+[`@lore-vcs/sdk`](https://www.npmjs.com/package/@lore-vcs/sdk) from the public npm
+registry; `npm install` also pulls the platform-specific native library
+(`lorelib`) and `koffi` automatically. No binaries are committed to the repo.
+
+Keep the SDK **version-matched to the Lore server** you talk to (currently
+`0.8.4`). To upgrade, bump the version in `package.json` and re-run `npm install`.
+
+## Documentation
+
+- [How to run lore-web](docs/how-to/run-lore-web.md) — setup, and collaborator login
+- [HTTP API reference](docs/reference/http-api.md) — every endpoint
+- [Architecture](docs/explanation/architecture.md) — how it works and why

--- a/lore-web/README.md
+++ b/lore-web/README.md
@@ -58,7 +58,16 @@ Then click **Add**, paste the path to a Lore working copy, and you're in.
 | `LORE_WEB_HOST` | `127.0.0.1` | bind address — keep it loopback |
 | `LORE_WEB_LOG_LEVEL` | `info` | `trace`…`error` |
 | `LORE_WEB_STORE` | `~/.lore-web/store.json` | tracked-repo list location |
+| `LORE_WEB_DEFAULT_REMOTE` | none | initial remote server URL, seen once on first run |
 | `LORE_CLI` | `lore` | path to the `lore` CLI (login/service fallback) |
+
+The remote server (the `lore://host:port` a new repository is created under, and
+where **Server repositories…**/**Clone from URL…** look) is set from the app
+itself: click the **⚙** button beside the `lore web` logo. This is how a
+collaborator points lore-web at their host's server — see
+[Set up a collaborator](docs/how-to/run-lore-web.md#set-up-a-collaborator-no-server).
+`LORE_WEB_DEFAULT_REMOTE` only seeds the value before it has ever been set
+through the app; once configured, the app's own setting takes over.
 
 > **Security:** lore-web exposes full read/write access to your repositories and
 > is bound to loopback only. Never expose it on a network. The *Lore server* is

--- a/lore-web/README.md
+++ b/lore-web/README.md
@@ -29,7 +29,7 @@ folder was deleted. lore-web fixes these by owning the refresh path: see
    to install anything missing) and installs the SDK.
 2. Double-click **`start.bat`** — launches the app and opens
    `http://127.0.0.1:7420`. (It also runs setup automatically on first use, so you
-   can skip step 1 and just run `start.bat`.)
+   can skip step 1 and run `start.bat` directly.)
 
 ### Any platform (terminal)
 
@@ -42,7 +42,7 @@ npm start         # launch the server and open http://127.0.0.1:7420
 Then click **Add**, paste the path to a Lore working copy, and you're in.
 
 > **Sharing with a collaborator:** the `lore-web` folder is self-contained — send
-> just that folder (no need to clone this repository). They run `setup.bat` (or
+> only that folder (no need to clone this repository). They run `setup.bat` (or
 > `npm install`) once, then `lore login lore://<your-host>:41337`. See the
 > [how-to guide](docs/how-to/run-lore-web.md).
 

--- a/lore-web/docs/explanation/architecture.md
+++ b/lore-web/docs/explanation/architecture.md
@@ -1,0 +1,70 @@
+# Architecture
+
+This page explains how lore-web is built and why it avoids the staleness and
+delete bugs of the official desktop client.
+
+## The shape of the app
+
+lore-web is a small Node process with two halves:
+
+- A **server** (`server/`) built on Node's standard library only — `http` for
+  routing, `fs.watch` for file watching, a JSON file for the tracked-repo list.
+  Its one non-stdlib dependency is `@lore-vcs/sdk` (from npm), which loads the
+  native `lorelib` through koffi (FFI). No web framework, no database, no build.
+- A **browser SPA** (`web/`) of plain ES modules — no framework, no bundler.
+
+The browser talks to the server over JSON and two streaming channels: Server-Sent
+Events for change notifications, and newline-delimited JSON for live operation
+progress.
+
+## The engine
+
+Every Lore operation flows through `server/sdk.mjs`, which wraps the SDK's fluent
+API (`lore.<verb>(globalArgs, args)`). Two helpers cover all needs: `collect()`
+runs a verb to completion and returns its events; `stream()` yields events as
+they arrive for long operations. The SDK reads working copies directly on disk,
+so no running server is required for local reads and writes — only remote
+operations (`clone`, `push`, `sync`) contact a Lore server, whose address comes
+from the repository's own config.
+
+Failures follow Lore's error contract: a verb's outcome is canonical on its
+`COMPLETE` event status, with human-readable detail on `ERROR` events. The
+wrapper captures both and raises one typed error, which the routes surface as a
+clean message — never a swallowed exception.
+
+## Why it stays fresh
+
+The desktop client this replaces persists its whole UI state to SQLite and
+rehydrates on launch, and watches nothing. The result: repository and revision
+lists reflect a past snapshot until you restart or clear the cache.
+
+lore-web inverts that. **It persists no view state** — only the set of repo
+paths you've added. Every view is fetched live, and four triggers keep it
+current:
+
+1. **On demand** — selecting a repo, or any explicit refresh, refetches.
+2. **On disk change** — `fs.watch` on each repo's working tree and `.lore`
+   directory emits a scoped SSE `refresh`; the SPA refetches the affected views.
+   This catches revisions committed by the CLI or arriving from a push.
+3. **On focus** — regaining the window refetches, covering anything missed while
+   the app was in the background.
+4. **On a slow poll** — history refetches periodically, catching revisions a
+   collaborator pushed to the server (a change with no local filesystem event).
+
+## Why deleting a missing repo works
+
+Removing a repository only edits the tracked-repo list; it never depends on the
+folder still existing. A dangling entry is always removable — the opposite of the
+desktop client, which ran a repository-status check first and refused to remove
+the entry when that check failed on a missing folder.
+
+## What's intentionally out of scope
+
+Organization rename is a hosted-account operation with no verb in the Lore SDK or
+the open-source server, so lore-web cannot implement it; it surfaces org names as
+read-only.
+
+## Related
+
+- [HTTP API reference](../reference/http-api.md)
+- [How to run lore-web](../how-to/run-lore-web.md)

--- a/lore-web/docs/explanation/architecture.md
+++ b/lore-web/docs/explanation/architecture.md
@@ -60,9 +60,18 @@ the entry when that check failed on a missing folder.
 
 ## What's intentionally out of scope
 
-Organization rename is a hosted-account operation with no verb in the Lore SDK or
-the open-source server, so lore-web cannot implement it; it surfaces org names as
-read-only.
+A repository's organization is the `org/` prefix of its `name` metadata, set from
+the path of the create or clone URL. lore-web reads it through the SDK's
+`repositoryMetadataGet` verb and surfaces it per repository. Lore makes `name`
+read-only after creation, so changing the organization is not a metadata edit: it
+rebuilds the working copy's `.lore` under a new URL (preserving the repository id
+and remote), the same mechanism repository repair uses. That rebuild discards
+local committed revisions, so the UI confirms the loss before proceeding and the
+repository should be fully pushed to its remote first.
+
+Renaming an organization across a hosted account — which would retag every repo it
+owns — has no verb in the Lore SDK or the open-source server and stays out of
+scope.
 
 ## Related
 

--- a/lore-web/docs/how-to/run-lore-web.md
+++ b/lore-web/docs/how-to/run-lore-web.md
@@ -1,0 +1,52 @@
+# Run lore-web
+
+Use this guide to start lore-web on your own machine, and to set up a
+collaborator who syncs with your server but runs no server of their own.
+
+## Before you start
+
+- Node.js 18–24 is installed.
+- You can reach the npm registry to install the SDK (one time).
+- For collaborators: the `lore` CLI is on `PATH` and this machine can reach the
+  host's server over the network.
+
+## Run it on the host
+
+1. Install dependencies:
+   ```sh
+   cd lore-web
+   npm install
+   ```
+2. Start the app:
+   ```sh
+   npm start
+   ```
+   Your browser opens `http://127.0.0.1:7420`.
+3. Click **Add**, paste the path to a Lore working copy (a folder containing a
+   `.lore` directory), and select it.
+
+## Set up a collaborator (no server)
+
+1. Send the `lore-web` folder to the collaborator (it is self-contained — they do
+   not need to clone the repository). They run `setup.bat` (or `npm install`) once.
+2. Authenticate the CLI against the host's server once, in a terminal:
+   ```sh
+   lore login lore://<host>:41337
+   ```
+   This stores an identity the SDK reuses for `clone`, `sync`, and `push`.
+3. Start lore-web (`npm start`) and clone the host's repository: click
+   **Clone a repository…**, enter the remote URL
+   (`lore://<host>:41337/<org>/<repo>`) and a destination folder.
+4. Work normally. Use **Push** to send commits to the host and **Sync** to pull
+   the host's latest revision. Progress streams live in the dialog.
+
+## Result
+
+Both machines drive the same repository: the host serves it, the collaborator
+clones and pushes to it, and each side's lists refresh live as the other pushes.
+
+## See also
+
+- [HTTP API reference](../reference/http-api.md)
+- [Architecture](../explanation/architecture.md)
+- Lore CLI: [authentication](https://epicgames.github.io/lore/)

--- a/lore-web/docs/how-to/run-lore-web.md
+++ b/lore-web/docs/how-to/run-lore-web.md
@@ -43,6 +43,22 @@ collaborator who syncs with your server but runs no server of their own.
 4. Work normally. Use **Push** to send commits to the host and **Sync** to pull
    the host's latest revision. Progress streams live in the dialog.
 
+## Change a repository's organization
+
+A repository's organization is the `org/` prefix of its name (the `acme` in
+`acme/widgets`), shown as a pill beside the branch and as a badge in the sidebar.
+
+1. Select the repository, then click the organization pill (it reads
+   **Set organization…** when the name has no prefix yet).
+2. Enter the new organization and confirm.
+
+> [!CAUTION]
+> The organization is part of a repository's read-only identity, fixed when the
+> repository is created. Changing it rebuilds the local repository — preserving its
+> id and remote but discarding local committed revisions. Push everything to the
+> remote first, and only change the organization when you accept that local
+> history loss.
+
 ## Result
 
 Both machines drive the same repository: the host serves it, the collaborator

--- a/lore-web/docs/how-to/run-lore-web.md
+++ b/lore-web/docs/how-to/run-lore-web.md
@@ -35,12 +35,17 @@ collaborator who syncs with your server but runs no server of their own.
    lore login lore://<host>:41337
    ```
    This stores an identity the SDK reuses for `clone`, `sync`, and `push`.
-3. Start lore-web (`npm start`) and clone the host's repository: click
-   **Server repositories…** to browse the host's repositories, then **Clone** the
-   one you want and pick a destination folder. (Already-cloned repos are tagged, and
-   each row's ✕ deletes that repository from the server.) To clone a known URL
-   directly instead, use **Clone from URL…**.
-4. Work normally. Use **Push** to send commits to the host and **Sync** to pull
+3. Start lore-web (`npm start`), click the **⚙** button beside the `lore web`
+   logo, and enter the host's server URL (`lore://<host>:41337`). Click **Search
+   again** first — lore-web checks common local addresses and lists any it finds,
+   so you may only need to select one. Without this step, lore-web defaults to a
+   local server address that will not reach the host's machine.
+4. Clone the host's repository: click **Server repositories…** to browse the
+   host's repositories, then **Clone** the one you want and pick a destination
+   folder. (Already-cloned repos are tagged, and each row's ✕ deletes that
+   repository from the server.) To clone a known URL directly instead, use
+   **Clone from URL…**.
+5. Work normally. Use **Push** to send commits to the host and **Sync** to pull
    the host's latest revision. Progress streams live in the dialog.
 
 ## Change a repository's organization

--- a/lore-web/docs/how-to/run-lore-web.md
+++ b/lore-web/docs/how-to/run-lore-web.md
@@ -29,14 +29,17 @@ collaborator who syncs with your server but runs no server of their own.
 
 1. Send the `lore-web` folder to the collaborator (it is self-contained — they do
    not need to clone the repository). They run `setup.bat` (or `npm install`) once.
-2. Authenticate the CLI against the host's server once, in a terminal:
+2. If the host's server requires authentication, sign in once against it in a
+   terminal (servers with no auth configured can skip this):
    ```sh
    lore login lore://<host>:41337
    ```
    This stores an identity the SDK reuses for `clone`, `sync`, and `push`.
 3. Start lore-web (`npm start`) and clone the host's repository: click
-   **Clone a repository…**, enter the remote URL
-   (`lore://<host>:41337/<org>/<repo>`) and a destination folder.
+   **Server repositories…** to browse the host's repositories, then **Clone** the
+   one you want and pick a destination folder. (Already-cloned repos are tagged, and
+   each row's ✕ deletes that repository from the server.) To clone a known URL
+   directly instead, use **Clone from URL…**.
 4. Work normally. Use **Push** to send commits to the host and **Sync** to pull
    the host's latest revision. Progress streams live in the dialog.
 

--- a/lore-web/docs/reference/http-api.md
+++ b/lore-web/docs/reference/http-api.md
@@ -18,7 +18,7 @@ is read live from the Lore SDK on each request; nothing is cached server-side.
 
 | Method | Path | Body / query | Description |
 | --- | --- | --- | --- |
-| GET | `/api/repos` | — | List tracked repos, each enriched with live `branch` and `exists`. |
+| GET | `/api/repos` | — | List tracked repos, each enriched with live `branch`, `exists`, and `organization`. |
 | POST | `/api/repos` | `{ path, label }` | Start tracking a working copy. Rejects non-repos. |
 | DELETE | `/api/repos` | `{ path }` | Stop tracking. Always succeeds, even if the folder is gone. |
 
@@ -31,6 +31,7 @@ is read live from the Lore SDK on each request; nothing is cached server-side.
 | GET | `/api/branches` | `path` | Branch list. |
 | GET | `/api/diff` | `path`, `file` | Unified diff for one file. |
 | GET | `/api/auth` | — | `{ loggedIn }` — whether the CLI has a stored identity. |
+| GET | `/api/org` | `path` | `{ organization, repoName, name }` for a repo. The organization is the prefix of the repo's `name` metadata (`org/repo`); `repoName` is the part after the slash. `organization` is empty when the name has no slash. |
 | GET | `/api/remote-repos` | `url?` | Repositories a Lore server hosts, for picking one to clone or delete. `url` is the server base; omitted, it defaults to the same remote the Add flow suggests. Returns `{ base, repos }` where each repo is `{ id, name, url, idUrl, tracked }` — `url` is the name-based clone URL, `idUrl` the id-based one, and `tracked` is true when the repo is one of this machine's working copies (matched by `.lore/id`). |
 | DELETE | `/api/remote-repos` | `{ id, base? }` | Delete a repository from its server by `id` (names of repos created without an owner do not resolve). `base` defaults to the suggested remote. Returns `{ ok: true }`, confirmed by re-listing — the underlying CLI reports a spurious error and exit 0 even on success, so its status is ignored. |
 
@@ -45,6 +46,7 @@ is read live from the Lore SDK on each request; nothing is cached server-side.
 | POST | `/api/ignore` | `{ path, pattern }` | Append a gitignore-style `pattern` (file, `folder/`, or `*.ext`) to `.loreignore`, creating it if absent. Returns `{ ok, added }`. |
 | POST | `/api/init-loreignore` | `{ path }` | Set up `.loreignore` (seeded from `.gitignore` when present) and keep each tool's metadata out of the other's history. Returns `{ ok, created, gitignoreUpdated }`. |
 | POST | `/api/repair` | `{ path }` | Rebuild the working copy's `.lore` in place to purge unremovable stale index entries, preserving the repository id and remote. Refused (409) when there is committed history. Returns `{ ok, id }`. |
+| POST | `/api/org` | `{ path, organization }` | Change a repo's organization. A repo's org is the `org/` prefix of its `name`, which Lore makes read-only after creation, so this rebuilds the working copy's `.lore` under a new URL (preserving the repository id and remote), which discards local committed revisions. The caller must confirm that loss first. `organization` cannot be empty or contain a slash. Returns `{ organization, repoName, name, id }`. |
 
 ### Remote operations (streamed)
 

--- a/lore-web/docs/reference/http-api.md
+++ b/lore-web/docs/reference/http-api.md
@@ -22,6 +22,14 @@ is read live from the Lore SDK on each request; nothing is cached server-side.
 | POST | `/api/repos` | `{ path, label }` | Start tracking a working copy. Rejects non-repos. |
 | DELETE | `/api/repos` | `{ path }` | Stop tracking. Always succeeds, even if the folder is gone. |
 
+### Configuration
+
+| Method | Path | Body / query | Description |
+| --- | --- | --- | --- |
+| GET | `/api/config` | — | Get the configured default remote server and list of auto-discovered servers. Returns `{ defaultRemote, discoveredServers }` where `discoveredServers` is an array of `{ url, label }`. |
+| POST | `/api/config` | `{ defaultRemote }` | Set the default remote server URL. Validates URL format. Returns `{ ok: true }`. |
+| GET | `/api/discover` | — | Manually trigger discovery of Lore servers on the local network and return the list. Returns `{ discoveredServers }`. |
+
 ### Reads
 
 | Method | Path | Query | Description |

--- a/lore-web/docs/reference/http-api.md
+++ b/lore-web/docs/reference/http-api.md
@@ -31,6 +31,8 @@ is read live from the Lore SDK on each request; nothing is cached server-side.
 | GET | `/api/branches` | `path` | Branch list. |
 | GET | `/api/diff` | `path`, `file` | Unified diff for one file. |
 | GET | `/api/auth` | — | `{ loggedIn }` — whether the CLI has a stored identity. |
+| GET | `/api/remote-repos` | `url?` | Repositories a Lore server hosts, for picking one to clone or delete. `url` is the server base; omitted, it defaults to the same remote the Add flow suggests. Returns `{ base, repos }` where each repo is `{ id, name, url, idUrl, tracked }` — `url` is the name-based clone URL, `idUrl` the id-based one, and `tracked` is true when the repo is one of this machine's working copies (matched by `.lore/id`). |
+| DELETE | `/api/remote-repos` | `{ id, base? }` | Delete a repository from its server by `id` (names of repos created without an owner do not resolve). `base` defaults to the suggested remote. Returns `{ ok: true }`, confirmed by re-listing — the underlying CLI reports a spurious error and exit 0 even on success, so its status is ignored. |
 
 ### Writes
 

--- a/lore-web/docs/reference/http-api.md
+++ b/lore-web/docs/reference/http-api.md
@@ -1,0 +1,64 @@
+# lore-web HTTP API
+
+The lore-web server exposes a small JSON + streaming API on `127.0.0.1:7420`
+(configurable). The browser SPA is its only intended client. All repository data
+is read live from the Lore SDK on each request; nothing is cached server-side.
+
+## Conventions
+
+- Request and response bodies are JSON unless noted.
+- Errors return a non-2xx status with `{ "error": "<message>" }`, where the
+  message is the underlying Lore failure detail.
+- `path` is an absolute path to a Lore working copy. Pass it as a query
+  parameter on GETs and in the body on POSTs.
+
+## Endpoints
+
+### Repositories
+
+| Method | Path | Body / query | Description |
+| --- | --- | --- | --- |
+| GET | `/api/repos` | — | List tracked repos, each enriched with live `branch` and `exists`. |
+| POST | `/api/repos` | `{ path, label }` | Start tracking a working copy. Rejects non-repos. |
+| DELETE | `/api/repos` | `{ path }` | Stop tracking. Always succeeds, even if the folder is gone. |
+
+### Reads
+
+| Method | Path | Query | Description |
+| --- | --- | --- | --- |
+| GET | `/api/status` | `path` | Current branch plus staged/unstaged changed files. |
+| GET | `/api/history` | `path`, `length` | Revision history (default 50), with message and timestamp. |
+| GET | `/api/branches` | `path` | Branch list. |
+| GET | `/api/diff` | `path`, `file` | Unified diff for one file. |
+| GET | `/api/auth` | — | `{ loggedIn }` — whether the CLI has a stored identity. |
+
+### Writes
+
+| Method | Path | Body | Description |
+| --- | --- | --- | --- |
+| POST | `/api/stage` | `{ path, files }` | Stage the given files. |
+| POST | `/api/unstage` | `{ path, files }` | Unstage the given files. |
+| POST | `/api/reset` | `{ path, files }` | Discard working changes to the given files. |
+| POST | `/api/commit` | `{ path, message }` | Commit the staged revision. |
+
+### Remote operations (streamed)
+
+These respond with `application/x-ndjson`: one normalized Lore event per line,
+ending with a `{ "tag": "DONE", "data": { "ok", "status", "message" } }` marker.
+
+| Method | Path | Body | Description |
+| --- | --- | --- | --- |
+| POST | `/api/sync` | `{ path, revision?, reset? }` | Sync the working copy to a revision. |
+| POST | `/api/push` | `{ path, branch?, fastForwardMerge? }` | Push commits to the remote. |
+| POST | `/api/clone` | `{ url, dest }` | Clone a remote repository into `dest`. |
+
+### Events
+
+| Method | Path | Description |
+| --- | --- | --- |
+| GET | `/events` | Server-Sent Events. Emits `{ "type": "refresh", "repo", "reason" }` when a tracked repo changes on disk, so the SPA refetches. |
+
+## See also
+
+- [How to run lore-web](../how-to/run-lore-web.md)
+- [Architecture](../explanation/architecture.md)

--- a/lore-web/docs/reference/http-api.md
+++ b/lore-web/docs/reference/http-api.md
@@ -49,7 +49,7 @@ is read live from the Lore SDK on each request; nothing is cached server-side.
 | --- | --- | --- | --- |
 | POST | `/api/stage` | `{ path, files }` | Stage the given files. |
 | POST | `/api/unstage` | `{ path, files }` | Unstage the given files. |
-| POST | `/api/reset` | `{ path, files }` | Discard working changes to the given files. |
+| POST | `/api/reset` | `{ path, files }` | Discard working changes to the given files, including removing newly added (untracked) files and folders. |
 | POST | `/api/ignore` | `{ path, pattern }` | Append a gitignore-style `pattern` (file, `folder/`, or `*.ext`) to `.loreignore`, creating it if absent. Returns `{ ok, added }`. |
 | POST | `/api/init-loreignore` | `{ path }` | Set up `.loreignore` (seeded from `.gitignore` and `.p4ignore` when present) and keep each tool's metadata out of the other's history. Returns `{ ok, created, gitignoreUpdated, gitignoreBlocked, p4ignoreUpdated, p4ignoreBlocked }`. A `*Blocked` flag is `true` when that ignore file exists but is read-only (Perforce keeps `.p4ignore` read-only until `p4 edit`), so Lore's entries could not be added — seeding `.loreignore` still succeeds. |
 | POST | `/api/repair` | `{ path }` | Rebuild the working copy's `.lore` in place to purge unremovable stale index entries, preserving the repository id and remote. Refused (409) when there is committed history. Returns `{ ok, id }`. |

--- a/lore-web/docs/reference/http-api.md
+++ b/lore-web/docs/reference/http-api.md
@@ -26,7 +26,7 @@ is read live from the Lore SDK on each request; nothing is cached server-side.
 
 | Method | Path | Query | Description |
 | --- | --- | --- | --- |
-| GET | `/api/status` | `path` | Current branch plus staged/unstaged changed files. |
+| GET | `/api/status` | `path` | Current branch plus staged/unstaged changed files. Also returns `hasLoreignore`/`hasGitignore` flags, and marks each changed entry that is itself a nested Lore working copy with `nested: true`. |
 | GET | `/api/history` | `path`, `length` | Revision history (default 50), with message and timestamp. |
 | GET | `/api/branches` | `path` | Branch list. |
 | GET | `/api/diff` | `path`, `file` | Unified diff for one file. |
@@ -40,6 +40,9 @@ is read live from the Lore SDK on each request; nothing is cached server-side.
 | POST | `/api/unstage` | `{ path, files }` | Unstage the given files. |
 | POST | `/api/reset` | `{ path, files }` | Discard working changes to the given files. |
 | POST | `/api/commit` | `{ path, message }` | Commit the staged revision. |
+| POST | `/api/ignore` | `{ path, pattern }` | Append a gitignore-style `pattern` (file, `folder/`, or `*.ext`) to `.loreignore`, creating it if absent. Returns `{ ok, added }`. |
+| POST | `/api/init-loreignore` | `{ path }` | Set up `.loreignore` (seeded from `.gitignore` when present) and keep each tool's metadata out of the other's history. Returns `{ ok, created, gitignoreUpdated }`. |
+| POST | `/api/repair` | `{ path }` | Rebuild the working copy's `.lore` in place to purge unremovable stale index entries, preserving the repository id and remote. Refused (409) when there is committed history. Returns `{ ok, id }`. |
 
 ### Remote operations (streamed)
 

--- a/lore-web/docs/reference/http-api.md
+++ b/lore-web/docs/reference/http-api.md
@@ -50,19 +50,21 @@ is read live from the Lore SDK on each request; nothing is cached server-side.
 | POST | `/api/stage` | `{ path, files }` | Stage the given files. |
 | POST | `/api/unstage` | `{ path, files }` | Unstage the given files. |
 | POST | `/api/reset` | `{ path, files }` | Discard working changes to the given files. |
-| POST | `/api/commit` | `{ path, message }` | Commit the staged revision. |
 | POST | `/api/ignore` | `{ path, pattern }` | Append a gitignore-style `pattern` (file, `folder/`, or `*.ext`) to `.loreignore`, creating it if absent. Returns `{ ok, added }`. |
 | POST | `/api/init-loreignore` | `{ path }` | Set up `.loreignore` (seeded from `.gitignore` and `.p4ignore` when present) and keep each tool's metadata out of the other's history. Returns `{ ok, created, gitignoreUpdated, gitignoreBlocked, p4ignoreUpdated, p4ignoreBlocked }`. A `*Blocked` flag is `true` when that ignore file exists but is read-only (Perforce keeps `.p4ignore` read-only until `p4 edit`), so Lore's entries could not be added — seeding `.loreignore` still succeeds. |
 | POST | `/api/repair` | `{ path }` | Rebuild the working copy's `.lore` in place to purge unremovable stale index entries, preserving the repository id and remote. Refused (409) when there is committed history. Returns `{ ok, id }`. |
 | POST | `/api/org` | `{ path, organization }` | Change a repo's organization. A repo's org is the `org/` prefix of its `name`, which Lore makes read-only after creation, so this rebuilds the working copy's `.lore` under a new URL (preserving the repository id and remote), which discards local committed revisions. The caller must confirm that loss first. `organization` cannot be empty or contain a slash. Returns `{ organization, repoName, name, id }`. |
 
-### Remote operations (streamed)
+### Streamed operations
 
 These respond with `application/x-ndjson`: one normalized Lore event per line,
 ending with a `{ "tag": "DONE", "data": { "ok", "status", "message" } }` marker.
+Long-running verbs also emit `*_BEGIN`/`*_PROGRESS`/`*_END` events carrying
+file and byte counts, which the web UI renders as a progress bar.
 
 | Method | Path | Body | Description |
 | --- | --- | --- | --- |
+| POST | `/api/commit` | `{ path, message }` | Commit the staged revision. |
 | POST | `/api/sync` | `{ path, revision?, reset? }` | Sync the working copy to a revision. |
 | POST | `/api/push` | `{ path, branch?, fastForwardMerge? }` | Push commits to the remote. |
 | POST | `/api/clone` | `{ url, dest }` | Clone a remote repository into `dest`. |

--- a/lore-web/docs/reference/http-api.md
+++ b/lore-web/docs/reference/http-api.md
@@ -34,7 +34,7 @@ is read live from the Lore SDK on each request; nothing is cached server-side.
 
 | Method | Path | Query | Description |
 | --- | --- | --- | --- |
-| GET | `/api/status` | `path` | Current branch plus staged/unstaged changed files. Also returns `hasLoreignore`/`hasGitignore` flags, and marks each changed entry that is itself a nested Lore working copy with `nested: true`. |
+| GET | `/api/status` | `path` | Current branch plus staged/unstaged changed files. Also returns `hasLoreignore`, `hasGitignore`, and `hasP4ignore` flags, and marks each changed entry that is itself a nested Lore working copy with `nested: true`. |
 | GET | `/api/history` | `path`, `length` | Revision history (default 50), with message and timestamp. |
 | GET | `/api/branches` | `path` | Branch list. |
 | GET | `/api/diff` | `path`, `file` | Unified diff for one file. |
@@ -52,7 +52,7 @@ is read live from the Lore SDK on each request; nothing is cached server-side.
 | POST | `/api/reset` | `{ path, files }` | Discard working changes to the given files. |
 | POST | `/api/commit` | `{ path, message }` | Commit the staged revision. |
 | POST | `/api/ignore` | `{ path, pattern }` | Append a gitignore-style `pattern` (file, `folder/`, or `*.ext`) to `.loreignore`, creating it if absent. Returns `{ ok, added }`. |
-| POST | `/api/init-loreignore` | `{ path }` | Set up `.loreignore` (seeded from `.gitignore` when present) and keep each tool's metadata out of the other's history. Returns `{ ok, created, gitignoreUpdated }`. |
+| POST | `/api/init-loreignore` | `{ path }` | Set up `.loreignore` (seeded from `.gitignore` and `.p4ignore` when present) and keep each tool's metadata out of the other's history. Returns `{ ok, created, gitignoreUpdated, gitignoreBlocked, p4ignoreUpdated, p4ignoreBlocked }`. A `*Blocked` flag is `true` when that ignore file exists but is read-only (Perforce keeps `.p4ignore` read-only until `p4 edit`), so Lore's entries could not be added — seeding `.loreignore` still succeeds. |
 | POST | `/api/repair` | `{ path }` | Rebuild the working copy's `.lore` in place to purge unremovable stale index entries, preserving the repository id and remote. Refused (409) when there is committed history. Returns `{ ok, id }`. |
 | POST | `/api/org` | `{ path, organization }` | Change a repo's organization. A repo's org is the `org/` prefix of its `name`, which Lore makes read-only after creation, so this rebuilds the working copy's `.lore` under a new URL (preserving the repository id and remote), which discards local committed revisions. The caller must confirm that loss first. `organization` cannot be empty or contain a slash. Returns `{ organization, repoName, name, id }`. |
 

--- a/lore-web/package-lock.json
+++ b/lore-web/package-lock.json
@@ -1,0 +1,95 @@
+{
+  "name": "lore-web",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "lore-web",
+      "version": "0.1.0",
+      "dependencies": {
+        "@lore-vcs/sdk": "0.8.4"
+      },
+      "engines": {
+        "node": ">=18 <25"
+      }
+    },
+    "node_modules/@lore-vcs/sdk": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/@lore-vcs/sdk/-/sdk-0.8.4.tgz",
+      "integrity": "sha512-exxAjXsDYlO68nb9i8vHx31V9KXEgGQtiQghVQgHnj5koPTpQ3Iu2VJpHHu5BQ06KSlbBUK0DfHKSFEJK96T7g==",
+      "license": "MIT",
+      "dependencies": {
+        "koffi": "2.16.2"
+      },
+      "optionalDependencies": {
+        "@lore-vcs/sdk-amd64-unknown-linux": "v0.8.4",
+        "@lore-vcs/sdk-amd64-unknown-windows": "v0.8.4",
+        "@lore-vcs/sdk-arm64-apple-darwin": "v0.8.4",
+        "@lore-vcs/sdk-arm64-graviton-linux": "v0.8.4"
+      }
+    },
+    "node_modules/@lore-vcs/sdk-amd64-unknown-linux": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/@lore-vcs/sdk-amd64-unknown-linux/-/sdk-amd64-unknown-linux-0.8.4.tgz",
+      "integrity": "sha512-L7D8MVWhHCAjj56ePcKQZEaQMsxDlJSPIwC42IZAPlBgq/H0WJKBcrqi9DeIiw5u2n/s8NotNP0ATlM2YVAKXw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@lore-vcs/sdk-amd64-unknown-windows": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/@lore-vcs/sdk-amd64-unknown-windows/-/sdk-amd64-unknown-windows-0.8.4.tgz",
+      "integrity": "sha512-fSui3sWXt8UyEZ/xsww4MPq2WAPofJ80PH713Lg42pFAQIJ0WVKfmusmlS8a+ADAr/oKhsLkZbGodQ3VOH+eEQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@lore-vcs/sdk-arm64-apple-darwin": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/@lore-vcs/sdk-arm64-apple-darwin/-/sdk-arm64-apple-darwin-0.8.4.tgz",
+      "integrity": "sha512-z5Ra+U+IVHqhmCldMuuu/9Q4gUWln4yh9yd0YI70kt6M0LlhuaWfIXtroyfty3H1IYjd1RDTQNKMZ3dYSnwKjw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@lore-vcs/sdk-arm64-graviton-linux": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/@lore-vcs/sdk-arm64-graviton-linux/-/sdk-arm64-graviton-linux-0.8.4.tgz",
+      "integrity": "sha512-+d3rZ71FCLpkqr0NKw6m+ty6B2vMeTBBEXBbu73n0nc/FbY0ZLQTnT6eeDF/vUUrLbgkwLkNKni0ffyiUQb4cQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/koffi": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/koffi/-/koffi-2.16.2.tgz",
+      "integrity": "sha512-owU0MRwv6xkrVqCd+33uw6BaYppkTRXbO/rVdJNI2dvZG0gzyRhYwW25eWtc5pauwK8TGh3AbkFONSezdykfSA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    }
+  }
+}

--- a/lore-web/package.json
+++ b/lore-web/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "lore-web",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Self-hosted browser UI for the Lore version control system",
+  "type": "module",
+  "engines": {
+    "node": ">=18 <25"
+  },
+  "scripts": {
+    "start": "node server/start.mjs",
+    "serve": "node server/index.mjs",
+    "smoke": "node server/smoke.mjs",
+    "test": "node --test test/*.test.mjs"
+  },
+  "dependencies": {
+    "@lore-vcs/sdk": "0.8.4"
+  }
+}

--- a/lore-web/server/cli.mjs
+++ b/lore-web/server/cli.mjs
@@ -11,7 +11,7 @@ const LORE_BIN = process.env.LORE_CLI ?? "lore";
 
 /**
  * Run a `lore` subcommand to completion, capturing its output.
- * @param {string[]} args CLI arguments, e.g. ["auth", "list"]
+ * @param {string[]} args CLI arguments, such as ["auth", "list"]
  * @param {{ repoPath?: string }} [opts]
  * @returns {Promise<{ code: number, stdout: string, stderr: string }>}
  */
@@ -32,7 +32,7 @@ export function runCli(args, opts = {}) {
 }
 
 /**
- * Report whether the CLI has any stored identity (i.e. the user has logged in).
+ * Report whether the CLI has any stored identity — whether the user has logged in.
  * @returns {Promise<boolean>}
  */
 export async function isLoggedIn() {

--- a/lore-web/server/cli.mjs
+++ b/lore-web/server/cli.mjs
@@ -1,0 +1,41 @@
+// Fallback to the installed `lore` CLI for the few things better handled by the
+// real process than the in-process SDK: interactive browser login and the
+// service lifecycle. The SDK is the primary engine; this is the hybrid escape
+// hatch. The CLI emits no machine-readable output, so callers treat results as
+// status + text, not structured data.
+
+import { spawn } from "node:child_process";
+import { log } from "./log.mjs";
+
+const LORE_BIN = process.env.LORE_CLI ?? "lore";
+
+/**
+ * Run a `lore` subcommand to completion, capturing its output.
+ * @param {string[]} args CLI arguments, e.g. ["auth", "list"]
+ * @param {{ repoPath?: string }} [opts]
+ * @returns {Promise<{ code: number, stdout: string, stderr: string }>}
+ */
+export function runCli(args, opts = {}) {
+  const full = opts.repoPath ? ["--repository", opts.repoPath, ...args] : args;
+  return new Promise((resolve) => {
+    const child = spawn(LORE_BIN, full, { windowsHide: true });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (d) => (stdout += d));
+    child.stderr.on("data", (d) => (stderr += d));
+    child.on("error", (err) => {
+      log.warn("lore cli spawn failed", { error: err.message });
+      resolve({ code: -1, stdout, stderr: String(err.message) });
+    });
+    child.on("close", (code) => resolve({ code: code ?? -1, stdout, stderr }));
+  });
+}
+
+/**
+ * Report whether the CLI has any stored identity (i.e. the user has logged in).
+ * @returns {Promise<boolean>}
+ */
+export async function isLoggedIn() {
+  const { code, stdout } = await runCli(["auth", "list", "--no-pager"]);
+  return code === 0 && /\S/.test(stdout) && !/no identities/i.test(stdout);
+}

--- a/lore-web/server/discovery.mjs
+++ b/lore-web/server/discovery.mjs
@@ -1,0 +1,73 @@
+/**
+ * Auto-discovery of Lore servers on the local network. Attempts to find Lore
+ * backend servers without user configuration, falling back to manual entry.
+ */
+
+import { createConnection } from "node:net";
+import { log } from "./log.mjs";
+
+/**
+ * Test if a Lore server is reachable at the given address.
+ * @param {string} host hostname or IP address
+ * @param {number} port port number
+ * @param {number} timeout milliseconds to wait before considering unreachable
+ * @returns {Promise<boolean>} true if server responds, false otherwise
+ */
+function testServer(host, port, timeout = 1000) {
+  return new Promise((resolve) => {
+    const socket = createConnection({ host, port, timeout });
+    const timer = setTimeout(() => {
+      socket.destroy();
+      resolve(false);
+    }, timeout);
+
+    socket.on("connect", () => {
+      clearTimeout(timer);
+      socket.destroy();
+      resolve(true);
+    });
+
+    socket.on("error", () => {
+      clearTimeout(timer);
+      resolve(false);
+    });
+  });
+}
+
+/**
+ * Discover Lore servers on the local network. Tries common addresses and
+ * returns a list of reachable servers with their full URLs.
+ * @param {Object} options
+ * @param {number} options.timeout milliseconds to wait per host (default: 500)
+ * @returns {Promise<Array<{url: string, label: string}>>} discovered server URLs
+ */
+export async function discoverServers(options = {}) {
+  const { timeout = 500 } = options;
+  const discovered = [];
+
+  const candidates = [
+    { host: "localhost", port: 41337, label: "localhost" },
+    { host: "127.0.0.1", port: 41337, label: "127.0.0.1" },
+    { host: "lore.local", port: 41337, label: "lore.local" },
+  ];
+
+  const results = await Promise.all(
+    candidates.map(async (c) => {
+      const reachable = await testServer(c.host, c.port, timeout);
+      if (reachable) {
+        return { url: `lore://${c.host}:${c.port}`, label: c.label };
+      }
+      return null;
+    }),
+  );
+
+  for (const result of results) {
+    if (result) discovered.push(result);
+  }
+
+  if (discovered.length > 0) {
+    log.debug("discovered Lore servers", { count: discovered.length, servers: discovered });
+  }
+
+  return discovered;
+}

--- a/lore-web/server/events.mjs
+++ b/lore-web/server/events.mjs
@@ -1,0 +1,43 @@
+// Server-Sent Events hub. lore-web pushes two kinds of messages to the browser:
+//   - "refresh": a tracked repo changed on disk (from the file watcher) so the
+//     SPA should refetch the affected views. This is what keeps lists live
+//     instead of stale-until-restart.
+//   - operation progress: streamed per-request from a long-running verb (sync,
+//     push, clone) on its own dedicated SSE response, handled in routes.
+// This module owns the shared "refresh" channel.
+
+import { log } from "./log.mjs";
+
+/** @type {Set<import("node:http").ServerResponse>} */
+const clients = new Set();
+
+/**
+ * Register an HTTP response as an SSE subscriber to the refresh channel.
+ * @param {import("node:http").ServerResponse} res
+ */
+export function addClient(res) {
+  res.writeHead(200, {
+    "Content-Type": "text/event-stream",
+    "Cache-Control": "no-cache",
+    Connection: "keep-alive",
+  });
+  res.write(": connected\n\n");
+  clients.add(res);
+  log.debug("sse client connected", { clients: clients.size });
+  const keepAlive = setInterval(() => res.write(": ping\n\n"), 25_000);
+  res.on("close", () => {
+    clearInterval(keepAlive);
+    clients.delete(res);
+    log.debug("sse client disconnected", { clients: clients.size });
+  });
+}
+
+/**
+ * Broadcast a refresh notification to every connected browser.
+ * @param {string} repoPath the repo whose data changed (or "*" for all)
+ * @param {string} [reason]
+ */
+export function broadcastRefresh(repoPath, reason = "change") {
+  const payload = JSON.stringify({ type: "refresh", repo: repoPath, reason });
+  for (const res of clients) res.write(`data: ${payload}\n\n`);
+}

--- a/lore-web/server/index.mjs
+++ b/lore-web/server/index.mjs
@@ -17,7 +17,7 @@ import * as xform from "./transforms.mjs";
 import { addClient, broadcastRefresh } from "./events.mjs";
 import { watchRepo, unwatchRepo } from "./watcher.mjs";
 import { isLoggedIn, runCli } from "./cli.mjs";
-import { setupLoreignore, appendIgnorePattern, hasLoreignore, hasGitignore } from "./loreignore.mjs";
+import { setupLoreignore, appendIgnorePattern, hasLoreignore, hasGitignore, hasP4ignore } from "./loreignore.mjs";
 import { discoverServers } from "./discovery.mjs";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
@@ -597,6 +597,7 @@ const server = createServer(async (req, res) => {
       // The UI offers an "Initialize .loreignore" action when one is absent.
       out.hasLoreignore = repoPath ? hasLoreignore(repoPath) : false;
       out.hasGitignore = repoPath ? hasGitignore(repoPath) : false;
+      out.hasP4ignore = repoPath ? hasP4ignore(repoPath) : false;
       // Flag entries that are themselves Lore working copies (a directory holding
       // its own .lore). The UI prompts to ignore these *while they still exist* —
       // the only way to avoid the unremovable "zombie" entry Lore leaves behind if

--- a/lore-web/server/index.mjs
+++ b/lore-web/server/index.mjs
@@ -650,7 +650,10 @@ const server = createServer(async (req, res) => {
     }
     if (p === "/api/reset" && req.method === "POST") {
       const { path: rp, files } = await readBody(req);
-      await collect("fileReset", { repositoryPath: rp }, { paths: absFiles(rp, files) });
+      // purge is required to discard newly added (untracked) files/folders — without
+      // it, fileReset only reverts already-tracked modified content and silently
+      // leaves added entries dirty.
+      await collect("fileReset", { repositoryPath: rp }, { paths: absFiles(rp, files), purge: true });
       broadcastRefresh(rp, "reset");
       return sendJson(res, 200, { ok: true });
     }

--- a/lore-web/server/index.mjs
+++ b/lore-web/server/index.mjs
@@ -158,17 +158,80 @@ async function listRepos(res) {
     repos.map(async (r) => {
       const exists = isRepo(r.path);
       let info = {};
+      let organization = "";
       if (exists) {
         try {
           info = xform.repoSummary(await collect("repositoryStatus", { repositoryPath: r.path }, { staged: false }));
         } catch (err) {
           log.debug("repo enrich failed", { path: r.path });
         }
+        try {
+          organization = (await readOrg(r.path)).organization;
+        } catch (err) {
+          log.debug("repo org read failed", { path: r.path });
+        }
       }
-      return { ...r, exists, ...info };
+      return { ...r, exists, organization, ...info };
     }),
   );
   sendJson(res, 200, { repos: enriched });
+}
+
+/**
+ * Read a repository's organization, parsed from its `name` metadata. Lore stores
+ * the name as an `org/repo` value; the prefix before the first slash is the
+ * organization. Reads local metadata only (the working copy), matching what the
+ * desktop client surfaces.
+ * @param {string} repoPath path to a Lore working copy
+ * @returns {Promise<{ organization: string, repoName: string, name: string }>}
+ */
+async function readOrg(repoPath) {
+  const events = await collect("repositoryMetadataGet", { repositoryPath: repoPath, local: true }, { key: "name" });
+  return xform.splitOrg(xform.metadata(events).name);
+}
+
+/**
+ * GET /api/org — the organization and repository name for a tracked repo.
+ * @param {import("node:http").ServerResponse} res
+ * @param {string|null} repoPath the `path` query parameter
+ */
+async function getOrg(res, repoPath) {
+  if (!repoPath) return sendJson(res, 400, { error: "path required" });
+  return sendJson(res, 200, await readOrg(repoPath));
+}
+
+/**
+ * POST /api/org — change a repository's organization. A repo's org is the `org/`
+ * prefix of its `name` metadata, which Lore makes read-only after creation: it is
+ * set from the path of the create URL and cannot be edited via metadata. The only
+ * way to change it in place is to recreate the working copy's `.lore` under a new
+ * URL (preserving the repository id), which discards local committed history. The
+ * caller must therefore confirm the destructive nature first; this endpoint
+ * performs the recreate unconditionally.
+ *
+ * The body is `{ path, organization }`. An organization cannot be empty or contain
+ * a slash, since the slash separates it from the repository name.
+ * @param {import("node:http").IncomingMessage} req
+ * @param {import("node:http").ServerResponse} res
+ */
+async function setOrg(req, res) {
+  const body = await readBody(req);
+  const path = typeof body.path === "string" ? toUnixPath(body.path) : "";
+  if (!path) return sendJson(res, 400, { error: "path required" });
+  if (!existsSync(path)) return sendJson(res, 400, { error: "path does not exist" });
+  if (!isRepo(path)) return sendJson(res, 400, { error: "not a Lore repository" });
+  const organization = typeof body.organization === "string" ? body.organization.trim() : "";
+  if (!organization) return sendJson(res, 400, { error: "organization required" });
+  if (organization.includes("/")) return sendJson(res, 400, { error: "organization cannot contain '/'" });
+  const current = await readOrg(path);
+  const repoName = current.repoName || path.split(/[\\/]/).filter(Boolean).pop() || path;
+  const remote = readRepoRemote(path);
+  const base = remote ? remoteBase(remote) : defaultRemoteBase().replace(/\/+$/, "");
+  const repositoryUrl = `${base}/${organization}/${repoName}`;
+  log.info("changing organization", { path, from: current.organization, to: organization });
+  const id = await recreateLore(path, repositoryUrl);
+  broadcastRefresh("*", "repos");
+  return sendJson(res, 200, { ...xform.splitOrg(`${organization}/${repoName}`), id });
 }
 
 /**
@@ -221,6 +284,28 @@ async function repairRepo(path, res) {
       error: "repository has committed revisions; repair would lose them — re-clone from the remote instead",
     });
   }
+  const remote = readRepoRemote(path);
+  const label = path.split(/[\\/]/).filter(Boolean).pop() || path;
+  const repositoryUrl = `${remote ? remoteBase(remote) : defaultRemoteBase().replace(/\/+$/, "")}/${label}`;
+  const id = await recreateLore(path, repositoryUrl);
+  broadcastRefresh(path, "repair");
+  sendJson(res, 200, { ok: true, id });
+}
+
+/**
+ * Rebuild a working copy's `.lore` in place, re-registering it under
+ * `repositoryUrl` while preserving its existing repository id. The old `.lore` is
+ * moved aside and restored if the rebuild throws, so a failure never leaves the
+ * folder without a repository. The rebuild runs offline so it never re-registers
+ * on (or conflicts with) the remote — the repo already exists there.
+ *
+ * This discards any local committed history (a fresh `.lore` has none), so callers
+ * must guard against or warn about that before invoking it.
+ * @param {string} path a Lore working copy
+ * @param {string} repositoryUrl the URL whose path component becomes the repo name
+ * @returns {Promise<string>} the preserved repository id (hex), or "" if none existed
+ */
+async function recreateLore(path, repositoryUrl) {
   const dot = join(path, ".lore");
   let id = "";
   try {
@@ -228,14 +313,7 @@ async function repairRepo(path, res) {
   } catch {
     // no id file — let create mint a fresh one
   }
-  const remote = readRepoRemote(path);
-  const label = path.split(/[\\/]/).filter(Boolean).pop() || path;
-  const repositoryUrl = `${remote ? remoteBase(remote) : defaultRemoteBase().replace(/\/+$/, "")}/${label}`;
-  log.info("repairing repository", { path, repositoryUrl, id });
-  // Recreate offline so we never re-register on (or conflict with) the remote —
-  // the repo already exists there; we are only rebuilding the local .lore. Move
-  // the old .lore aside first and restore it if the rebuild fails, so a failure
-  // never leaves the working copy without a repository.
+  log.info("recreating repository .lore", { path, repositoryUrl, id });
   const backup = `${dot}.repair-bak`;
   rmSync(backup, { recursive: true, force: true });
   renameSync(dot, backup);
@@ -248,8 +326,7 @@ async function repairRepo(path, res) {
   }
   rmSync(backup, { recursive: true, force: true });
   setupLoreignore(path);
-  broadcastRefresh(path, "repair");
-  sendJson(res, 200, { ok: true, id });
+  return id;
 }
 
 /**
@@ -448,6 +525,9 @@ const server = createServer(async (req, res) => {
     if (p === "/api/repos" && req.method === "GET") return await listRepos(res);
     if (p === "/api/repos" && req.method === "POST") return await addRepo(req, res);
     if (p === "/api/repos" && req.method === "DELETE") return await deleteRepo(req, res);
+
+    if (p === "/api/org" && req.method === "GET") return await getOrg(res, repoPath);
+    if (p === "/api/org" && req.method === "POST") return await setOrg(req, res);
 
     if (p === "/api/history" && req.method === "GET") {
       const length = Number(q.get("length") ?? 50);

--- a/lore-web/server/index.mjs
+++ b/lore-web/server/index.mjs
@@ -682,9 +682,7 @@ const server = createServer(async (req, res) => {
     if (p === "/api/commit" && req.method === "POST") {
       const { path: rp, message } = await readBody(req);
       if (!message) return sendJson(res, 400, { error: "commit message required" });
-      await collect("revisionCommit", { repositoryPath: rp }, { message });
-      broadcastRefresh(rp, "commit");
-      return sendJson(res, 200, { ok: true });
+      return await streamOp(res, "revisionCommit", { repositoryPath: rp }, { message }, rp);
     }
 
     // Remote operations stream their progress back as NDJSON.

--- a/lore-web/server/index.mjs
+++ b/lore-web/server/index.mjs
@@ -4,10 +4,11 @@
 // and must never be reachable off-host.
 
 import { createServer } from "node:http";
-import { readFile, stat } from "node:fs/promises";
-import { existsSync } from "node:fs";
-import { join, extname, normalize as normalizePath, dirname } from "node:path";
+import { readFile, stat, readdir } from "node:fs/promises";
+import { existsSync, readFileSync } from "node:fs";
+import { join, extname, normalize as normalizePath, dirname, parse as parsePath, sep } from "node:path";
 import { fileURLToPath } from "node:url";
+import { homedir } from "node:os";
 
 import { log } from "./log.mjs";
 import { collect, stream, configureSdk, shutdownSdk } from "./sdk.mjs";
@@ -20,11 +21,54 @@ import { isLoggedIn } from "./cli.mjs";
 const HERE = dirname(fileURLToPath(import.meta.url));
 const WEB_DIR = join(HERE, "..", "web");
 const HOST = process.env.LORE_WEB_HOST ?? "127.0.0.1";
-const PORT = Number(process.env.LORE_WEB_PORT ?? 7420);
+const PORT = Number(process.env.LORE_WEB_PORT ?? process.env.PORT ?? 7420);
 
 /** A path is a Lore working copy if it holds a .lore (or legacy .urc) dir. */
 function isRepo(path) {
   return existsSync(join(path, ".lore")) || existsSync(join(path, ".urc"));
+}
+
+/**
+ * The remote server base to assign when initializing a brand-new repository, so
+ * the user never types one. We reuse the remote of an already-tracked repo
+ * (almost always the same self-hosted server), falling back to an env override
+ * and finally the default local Lore server. The repo name is appended later;
+ * repositoryCreate mints the per-repo UUID that distinguishes repos on a server.
+ * @returns {string} a remote base URL with no trailing repo-name path component
+ */
+function defaultRemoteBase() {
+  for (const r of store.listRepos()) {
+    for (const name of ["config.toml", "config"]) {
+      const cfg = join(r.path, ".lore", name);
+      if (!existsSync(cfg)) continue;
+      try {
+        const m = readFileSync(cfg, "utf8").match(/^\s*remote_url\s*=\s*"([^"]+)"/m);
+        if (m && m[1]) return m[1];
+      } catch {
+        // unreadable config — keep looking
+      }
+    }
+  }
+  return process.env.LORE_WEB_DEFAULT_REMOTE ?? "lore://127.0.0.1:41337";
+}
+
+/**
+ * The repository URL suggested when initializing a folder named `label`, of the
+ * form <server-base>/<label>. This is what the Add flow shows for review.
+ * @param {string} label the repo name (usually the folder's last path segment)
+ * @returns {string} a full repository URL
+ */
+function suggestInitUrl(label) {
+  return `${defaultRemoteBase().replace(/\/+$/, "")}/${label}`;
+}
+
+/**
+ * Forward-slash form of a path — the native lib drops Windows backslashes.
+ * @param {string} p a filesystem path, possibly using backslash separators
+ * @returns {string} the same path with every backslash replaced by a slash
+ */
+function toUnixPath(p) {
+  return p.replace(/\\/g, "/");
 }
 
 function sendJson(res, status, body) {
@@ -105,16 +149,96 @@ async function listRepos(res) {
   sendJson(res, 200, { repos: enriched });
 }
 
-/** POST /api/repos — start tracking a working copy. */
+/**
+ * POST /api/repos — start tracking a folder, smartly. If the folder is already a
+ * Lore working copy it is just tracked; otherwise a new repository is initialized
+ * there first (with an auto-generated remote URL) so the user can point at any
+ * folder without caring whether it has been set up yet.
+ */
 async function addRepo(req, res) {
-  const { path, label } = await readBody(req);
+  let { path, url } = await readBody(req);
   if (!path || typeof path !== "string") return sendJson(res, 400, { error: "path required" });
+  // The native lib mangles backslash paths; forward slashes are the store's
+  // convention and what every other verb here is given.
+  path = toUnixPath(path);
   if (!existsSync(path)) return sendJson(res, 400, { error: "path does not exist" });
-  if (!isRepo(path)) return sendJson(res, 400, { error: "not a Lore repository (no .lore directory)" });
+  const label = path.split(/[\\/]/).filter(Boolean).pop() || path;
+  let initialized = false;
+  if (!isRepo(path)) {
+    // Use the caller's reviewed URL when given, else the generated suggestion.
+    // A bare host is rejected as invalid, so the name is part of the suggestion.
+    const repositoryUrl = (typeof url === "string" && url.trim()) || suggestInitUrl(label);
+    log.info("initializing repository", { path, repositoryUrl });
+    await collect("repositoryCreate", { repositoryPath: path }, { repositoryUrl, id: "" });
+    initialized = true;
+  }
   const entry = store.addRepo(path, label);
   watchRepo(path, () => broadcastRefresh(path, "fs"));
   broadcastRefresh("*", "repos");
-  sendJson(res, 200, { repo: entry });
+  sendJson(res, 200, { repo: entry, initialized });
+}
+
+/**
+ * Drive roots present on this machine, used as the picker's top "This PC" level.
+ * @returns {string[]} drive-root paths (Windows: C:\ … Z:\; POSIX: just "/")
+ */
+function listDrives() {
+  if (process.platform !== "win32") return ["/"];
+  const drives = [];
+  for (let c = 67; c <= 90; c++) {
+    const d = `${String.fromCharCode(c)}:\\`;
+    if (existsSync(d)) drives.push(d);
+  }
+  return drives;
+}
+
+/**
+ * GET /api/browse?path= — list the sub-folders of a directory so the UI can offer
+ * a native-feeling folder picker (the browser can't hand us a real fs path). An
+ * empty path returns the drive roots ("This PC"). Each entry is flagged when it
+ * is itself a Lore repo. Only directories are returned — this is a folder picker.
+ * @param {import("node:http").ServerResponse} res
+ * @param {string|null} rawPath directory to list; empty/null lists the roots
+ */
+async function browse(res, rawPath) {
+  let path = (rawPath || "").trim();
+  // Empty path → the roots level (drives on Windows, "/" on POSIX).
+  if (!path) {
+    const entries = listDrives().map((d) => ({ name: d, path: d, isRepo: isRepo(d) }));
+    return sendJson(res, 200, { path: "", parent: null, sep, entries });
+  }
+  const norm = normalizePath(path);
+  let info;
+  try {
+    info = await stat(norm);
+  } catch {
+    return sendJson(res, 400, { error: "path does not exist" });
+  }
+  if (!info.isDirectory()) return sendJson(res, 400, { error: "not a directory" });
+  // Parent: the drives/roots level when we're at a drive root, else dirname.
+  const atRoot = parsePath(norm).root === norm || norm === "/";
+  const parent = atRoot ? "" : dirname(norm);
+  let entries = [];
+  try {
+    const dirents = await readdir(norm, { withFileTypes: true });
+    entries = dirents
+      .filter((d) => {
+        try {
+          return d.isDirectory();
+        } catch {
+          return false;
+        }
+      })
+      .filter((d) => !d.name.startsWith("."))
+      .map((d) => {
+        const full = join(norm, d.name);
+        return { name: d.name, path: full, isRepo: isRepo(full) };
+      })
+      .sort((a, b) => a.name.localeCompare(b.name));
+  } catch (err) {
+    return sendJson(res, 400, { error: err instanceof Error ? err.message : "cannot read directory" });
+  }
+  sendJson(res, 200, { path: norm, parent, sep, isRepo: isRepo(norm), entries });
 }
 
 /**
@@ -167,11 +291,22 @@ const server = createServer(async (req, res) => {
     const repoPath = q.get("path");
     const globalArgs = repoPath ? { repositoryPath: repoPath } : {};
 
-    // --- API ---
     if (p === "/events" && req.method === "GET") return addClient(res);
 
     if (p === "/api/auth" && req.method === "GET") {
       return sendJson(res, 200, { loggedIn: await isLoggedIn() });
+    }
+
+    if (p === "/api/browse" && req.method === "GET") return await browse(res, q.get("path"));
+
+    // Pre-flight for the Add flow: report whether a folder is already a repo and,
+    // if not, the URL it would be initialized with (editable before confirming).
+    if (p === "/api/init-url" && req.method === "GET") {
+      const target = toUnixPath(q.get("path") || "");
+      if (!target || !existsSync(target)) return sendJson(res, 400, { error: "path does not exist" });
+      const already = isRepo(target);
+      const label = target.split(/[\\/]/).filter(Boolean).pop() || target;
+      return sendJson(res, 200, { isRepo: already, url: already ? null : suggestInitUrl(label) });
     }
 
     if (p === "/api/repos" && req.method === "GET") return await listRepos(res);
@@ -212,7 +347,8 @@ const server = createServer(async (req, res) => {
       return sendJson(res, 200, { files: xform.revisionFiles(events) });
     }
 
-    // --- write actions (quick; respond with refreshed nothing, broadcast refresh) ---
+    // Quick mutating actions answer immediately and broadcast a refresh so every
+    // client refetches; the response body itself carries no refreshed state.
     if (p === "/api/stage" && req.method === "POST") {
       const { path: rp, files } = await readBody(req);
       await collect("fileStage", { repositoryPath: rp }, { paths: absFiles(rp, files), scan: true });
@@ -239,7 +375,7 @@ const server = createServer(async (req, res) => {
       return sendJson(res, 200, { ok: true });
     }
 
-    // --- remote operations (streamed progress as NDJSON) ---
+    // Remote operations stream their progress back as NDJSON.
     if (p === "/api/sync" && req.method === "POST") {
       const { path: rp, revision, reset } = await readBody(req);
       return await streamOp(res, "revisionSync", { repositoryPath: rp }, { revision, reset: !!reset }, rp);
@@ -251,10 +387,10 @@ const server = createServer(async (req, res) => {
     if (p === "/api/clone" && req.method === "POST") {
       const { url, dest } = await readBody(req);
       if (!url || !dest) return sendJson(res, 400, { error: "url and dest required" });
-      return await streamOp(res, "repositoryClone", { repositoryPath: dest }, { repositoryUrl: url }, null);
+      return await streamOp(res, "repositoryClone", { repositoryPath: toUnixPath(dest) }, { repositoryUrl: url }, null);
     }
 
-    // --- static SPA ---
+    // Anything else is a static asset request, falling back to the SPA shell.
     if (req.method === "GET") return await serveStatic(req, res, p);
     sendJson(res, 404, { error: "not found" });
   } catch (err) {

--- a/lore-web/server/index.mjs
+++ b/lore-web/server/index.mjs
@@ -1,0 +1,285 @@
+// lore-web HTTP server. Built on Node's stdlib http only (no web framework) so
+// the whole tool runs on any machine with Node + the vendored SDK, no build and
+// no extra native deps. Bound to 127.0.0.1: it exposes full repo write access
+// and must never be reachable off-host.
+
+import { createServer } from "node:http";
+import { readFile, stat } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { join, extname, normalize as normalizePath, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { log } from "./log.mjs";
+import { collect, stream, configureSdk, shutdownSdk } from "./sdk.mjs";
+import * as store from "./store.mjs";
+import * as xform from "./transforms.mjs";
+import { addClient, broadcastRefresh } from "./events.mjs";
+import { watchRepo, unwatchRepo } from "./watcher.mjs";
+import { isLoggedIn } from "./cli.mjs";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const WEB_DIR = join(HERE, "..", "web");
+const HOST = process.env.LORE_WEB_HOST ?? "127.0.0.1";
+const PORT = Number(process.env.LORE_WEB_PORT ?? 7420);
+
+/** A path is a Lore working copy if it holds a .lore (or legacy .urc) dir. */
+function isRepo(path) {
+  return existsSync(join(path, ".lore")) || existsSync(join(path, ".urc"));
+}
+
+function sendJson(res, status, body) {
+  const text = JSON.stringify(body);
+  res.writeHead(status, { "Content-Type": "application/json" });
+  res.end(text);
+}
+
+/** Translate a thrown error into a typed JSON error response (never crash). */
+function sendError(res, err) {
+  const message = err instanceof Error ? err.message : String(err);
+  const status = err && typeof err === "object" && "httpStatus" in err ? err.httpStatus : 500;
+  log.warn("request failed", { message });
+  sendJson(res, status, { error: message });
+}
+
+async function readBody(req) {
+  const chunks = [];
+  for await (const c of req) chunks.push(c);
+  if (chunks.length === 0) return {};
+  try {
+    return JSON.parse(Buffer.concat(chunks).toString("utf8"));
+  } catch {
+    return {};
+  }
+}
+
+const MIME = {
+  ".html": "text/html; charset=utf-8",
+  ".js": "text/javascript; charset=utf-8",
+  ".css": "text/css; charset=utf-8",
+  ".svg": "image/svg+xml",
+  ".json": "application/json",
+  ".ico": "image/x-icon",
+};
+
+/** Serve a static asset from web/, defaulting to index.html (SPA fallback). */
+async function serveStatic(req, res, pathname) {
+  let rel = pathname === "/" ? "/index.html" : pathname;
+  // Contain the path within WEB_DIR.
+  const filePath = join(WEB_DIR, normalizePath(rel).replace(/^(\.\.[/\\])+/, ""));
+  if (!filePath.startsWith(WEB_DIR)) return sendJson(res, 403, { error: "forbidden" });
+  try {
+    const info = await stat(filePath);
+    if (info.isDirectory()) throw new Error("dir");
+    const body = await readFile(filePath);
+    res.writeHead(200, { "Content-Type": MIME[extname(filePath)] ?? "application/octet-stream" });
+    res.end(body);
+  } catch {
+    // SPA fallback for unknown non-API paths.
+    try {
+      const index = await readFile(join(WEB_DIR, "index.html"));
+      res.writeHead(200, { "Content-Type": MIME[".html"] });
+      res.end(index);
+    } catch {
+      sendJson(res, 404, { error: "not found" });
+    }
+  }
+}
+
+/** GET /api/repos — tracked repos, each enriched with live branch/exists. */
+async function listRepos(res) {
+  const repos = store.listRepos();
+  const enriched = await Promise.all(
+    repos.map(async (r) => {
+      const exists = isRepo(r.path);
+      let info = {};
+      if (exists) {
+        try {
+          info = xform.repoSummary(await collect("repositoryStatus", { repositoryPath: r.path }, { staged: false }));
+        } catch (err) {
+          log.debug("repo enrich failed", { path: r.path });
+        }
+      }
+      return { ...r, exists, ...info };
+    }),
+  );
+  sendJson(res, 200, { repos: enriched });
+}
+
+/** POST /api/repos — start tracking a working copy. */
+async function addRepo(req, res) {
+  const { path, label } = await readBody(req);
+  if (!path || typeof path !== "string") return sendJson(res, 400, { error: "path required" });
+  if (!existsSync(path)) return sendJson(res, 400, { error: "path does not exist" });
+  if (!isRepo(path)) return sendJson(res, 400, { error: "not a Lore repository (no .lore directory)" });
+  const entry = store.addRepo(path, label);
+  watchRepo(path, () => broadcastRefresh(path, "fs"));
+  broadcastRefresh("*", "repos");
+  sendJson(res, 200, { repo: entry });
+}
+
+/**
+ * DELETE /api/repos — stop tracking a repo. Always succeeds, even if the folder
+ * is gone (issue #4: the desktop refused to remove a repo with a missing folder).
+ */
+async function deleteRepo(req, res) {
+  const { path } = await readBody(req);
+  if (!path) return sendJson(res, 400, { error: "path required" });
+  unwatchRepo(path);
+  const removed = store.removeRepo(path);
+  broadcastRefresh("*", "repos");
+  sendJson(res, 200, { removed });
+}
+
+/** Resolve repo-relative file paths to absolute (the native lib uses cwd). */
+function absFiles(repoPath, files) {
+  if (!Array.isArray(files)) return undefined;
+  return files.map((f) => (repoPath ? join(repoPath, f) : f));
+}
+
+/**
+ * Run a streaming verb and pipe its events to the client as newline-delimited
+ * JSON (one normalized event per line). Used for long operations (sync, push,
+ * clone) so the browser can render live progress. Ends with the DONE marker.
+ * @param {import("node:http").ServerResponse} res
+ * @param {string} verb
+ * @param {Record<string, unknown>} globalArgs
+ * @param {Record<string, unknown>} args
+ * @param {string|null} repoPath repo to refresh on completion
+ */
+async function streamOp(res, verb, globalArgs, args, repoPath) {
+  res.writeHead(200, { "Content-Type": "application/x-ndjson", "Cache-Control": "no-cache" });
+  let ok = false;
+  for await (const ev of stream(verb, globalArgs, args)) {
+    if (ev.tag === "DONE") ok = ev.data?.ok;
+    res.write(JSON.stringify(ev) + "\n");
+  }
+  res.end();
+  // A mutating op changes repo state; tell every client to refetch.
+  if (repoPath) broadcastRefresh(repoPath, verb);
+  log.info("stream op finished", { verb, ok });
+}
+
+const server = createServer(async (req, res) => {
+  try {
+    const url = new URL(req.url, `http://${req.headers.host}`);
+    const p = url.pathname;
+    const q = url.searchParams;
+    const repoPath = q.get("path");
+    const globalArgs = repoPath ? { repositoryPath: repoPath } : {};
+
+    // --- API ---
+    if (p === "/events" && req.method === "GET") return addClient(res);
+
+    if (p === "/api/auth" && req.method === "GET") {
+      return sendJson(res, 200, { loggedIn: await isLoggedIn() });
+    }
+
+    if (p === "/api/repos" && req.method === "GET") return await listRepos(res);
+    if (p === "/api/repos" && req.method === "POST") return await addRepo(req, res);
+    if (p === "/api/repos" && req.method === "DELETE") return await deleteRepo(req, res);
+
+    if (p === "/api/history" && req.method === "GET") {
+      const length = Number(q.get("length") ?? 50);
+      const events = await collect("revisionHistory", globalArgs, { length });
+      return sendJson(res, 200, { revisions: xform.history(events) });
+    }
+    if (p === "/api/status" && req.method === "GET") {
+      const events = await collect("repositoryStatus", globalArgs, { staged: true, scan: true });
+      return sendJson(res, 200, xform.status(events));
+    }
+    if (p === "/api/branches" && req.method === "GET") {
+      const events = await collect("branchList", globalArgs, {});
+      return sendJson(res, 200, { branches: xform.branches(events) });
+    }
+    if (p === "/api/diff" && req.method === "GET") {
+      const file = q.get("file");
+      // The native lib resolves relative path args against process.cwd(); anchor
+      // them to the repo by passing an absolute path instead.
+      const abs = file && repoPath ? join(repoPath, file) : file;
+      const events = await collect("fileDiff", globalArgs, abs ? { paths: [abs] } : {});
+      return sendJson(res, 200, { diff: xform.diff(events) });
+    }
+
+    // --- write actions (quick; respond with refreshed nothing, broadcast refresh) ---
+    if (p === "/api/stage" && req.method === "POST") {
+      const { path: rp, files } = await readBody(req);
+      await collect("fileStage", { repositoryPath: rp }, { paths: absFiles(rp, files), scan: true });
+      broadcastRefresh(rp, "stage");
+      return sendJson(res, 200, { ok: true });
+    }
+    if (p === "/api/unstage" && req.method === "POST") {
+      const { path: rp, files } = await readBody(req);
+      await collect("fileUnstage", { repositoryPath: rp }, { paths: absFiles(rp, files) });
+      broadcastRefresh(rp, "unstage");
+      return sendJson(res, 200, { ok: true });
+    }
+    if (p === "/api/reset" && req.method === "POST") {
+      const { path: rp, files } = await readBody(req);
+      await collect("fileReset", { repositoryPath: rp }, { paths: absFiles(rp, files) });
+      broadcastRefresh(rp, "reset");
+      return sendJson(res, 200, { ok: true });
+    }
+    if (p === "/api/commit" && req.method === "POST") {
+      const { path: rp, message } = await readBody(req);
+      if (!message) return sendJson(res, 400, { error: "commit message required" });
+      await collect("revisionCommit", { repositoryPath: rp }, { message });
+      broadcastRefresh(rp, "commit");
+      return sendJson(res, 200, { ok: true });
+    }
+
+    // --- remote operations (streamed progress as NDJSON) ---
+    if (p === "/api/sync" && req.method === "POST") {
+      const { path: rp, revision, reset } = await readBody(req);
+      return await streamOp(res, "revisionSync", { repositoryPath: rp }, { revision, reset: !!reset }, rp);
+    }
+    if (p === "/api/push" && req.method === "POST") {
+      const { path: rp, branch, fastForwardMerge } = await readBody(req);
+      return await streamOp(res, "branchPush", { repositoryPath: rp }, { branch, fastForwardMerge: !!fastForwardMerge }, rp);
+    }
+    if (p === "/api/clone" && req.method === "POST") {
+      const { url, dest } = await readBody(req);
+      if (!url || !dest) return sendJson(res, 400, { error: "url and dest required" });
+      return await streamOp(res, "repositoryClone", { repositoryPath: dest }, { repositoryUrl: url }, null);
+    }
+
+    // --- static SPA ---
+    if (req.method === "GET") return await serveStatic(req, res, p);
+    sendJson(res, 404, { error: "not found" });
+  } catch (err) {
+    sendError(res, err);
+  }
+});
+
+// On startup, begin watching every already-tracked repo so refresh works before
+// the user touches anything.
+function startWatchers() {
+  for (const r of store.listRepos()) {
+    if (isRepo(r.path)) watchRepo(r.path, () => broadcastRefresh(r.path, "fs"));
+  }
+}
+
+server.on("error", (err) => {
+  if (err && err.code === "EADDRINUSE") {
+    log.error("port already in use — is lore-web already running?", { host: HOST, port: PORT });
+    process.exit(1);
+  }
+  log.error("server error", { error: err instanceof Error ? err.message : String(err) });
+  process.exit(1);
+});
+
+configureSdk();
+startWatchers();
+server.listen(PORT, HOST, () => {
+  log.info("lore-web listening", { url: `http://${HOST}:${PORT}` });
+});
+
+function shutdown() {
+  log.info("shutting down");
+  server.close();
+  shutdownSdk();
+  process.exit(0);
+}
+process.on("SIGINT", shutdown);
+process.on("SIGTERM", shutdown);
+
+export { server, stream };

--- a/lore-web/server/index.mjs
+++ b/lore-web/server/index.mjs
@@ -5,7 +5,7 @@
 
 import { createServer } from "node:http";
 import { readFile, stat, readdir } from "node:fs/promises";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, rmSync, renameSync } from "node:fs";
 import { join, extname, normalize as normalizePath, dirname, parse as parsePath, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import { homedir } from "node:os";
@@ -17,6 +17,7 @@ import * as xform from "./transforms.mjs";
 import { addClient, broadcastRefresh } from "./events.mjs";
 import { watchRepo, unwatchRepo } from "./watcher.mjs";
 import { isLoggedIn } from "./cli.mjs";
+import { setupLoreignore, appendIgnorePattern, hasLoreignore, hasGitignore } from "./loreignore.mjs";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const WEB_DIR = join(HERE, "..", "web");
@@ -50,6 +51,27 @@ function defaultRemoteBase() {
     }
   }
   return process.env.LORE_WEB_DEFAULT_REMOTE ?? "lore://127.0.0.1:41337";
+}
+
+/** The remote_url recorded in a repo's .lore config, or null if none/unreadable. */
+function readRepoRemote(repoPath) {
+  for (const name of ["config.toml", "config"]) {
+    const cfg = join(repoPath, ".lore", name);
+    if (!existsSync(cfg)) continue;
+    try {
+      const m = readFileSync(cfg, "utf8").match(/^\s*remote_url\s*=\s*"([^"]+)"/m);
+      if (m && m[1]) return m[1];
+    } catch {
+      // unreadable — fall through
+    }
+  }
+  return null;
+}
+
+/** The scheme://authority prefix of a URL, with any path/repo component dropped. */
+function remoteBase(url) {
+  const m = url.match(/^([a-z][a-z0-9+.-]*:\/\/[^/]+)/i);
+  return m ? m[1] : url.replace(/\/+$/, "");
 }
 
 /**
@@ -170,12 +192,64 @@ async function addRepo(req, res) {
     const repositoryUrl = (typeof url === "string" && url.trim()) || suggestInitUrl(label);
     log.info("initializing repository", { path, repositoryUrl });
     await collect("repositoryCreate", { repositoryPath: path }, { repositoryUrl, id: "" });
+    // Seed .loreignore (from .gitignore when present) and keep each tool's
+    // metadata out of the other's history.
+    setupLoreignore(path);
     initialized = true;
   }
   const entry = store.addRepo(path, label);
   watchRepo(path, () => broadcastRefresh(path, "fs"));
   broadcastRefresh("*", "repos");
   sendJson(res, 200, { repo: entry, initialized });
+}
+
+/**
+ * POST /api/repair — rebuild a working copy's .lore in place. Lore can leave
+ * "zombie" status entries (e.g. a nested repo that was indexed then deleted) that
+ * no reset/stage/commit/obliterate can remove; the only cure is recreating .lore.
+ * We do that while preserving the repository id and remote, so the repo keeps its
+ * identity. Refused when there is committed history (which a rebuild would drop) —
+ * such a repo should be re-cloned from its remote instead.
+ */
+async function repairRepo(path, res) {
+  if (!existsSync(path)) return sendJson(res, 400, { error: "path does not exist" });
+  if (!isRepo(path)) return sendJson(res, 400, { error: "not a Lore repository" });
+  // Guard: never destroy committed history.
+  const hist = xform.history(await collect("revisionHistory", { repositoryPath: path }, { length: 1 }));
+  if (hist.length > 0) {
+    return sendJson(res, 409, {
+      error: "repository has committed revisions; repair would lose them — re-clone from the remote instead",
+    });
+  }
+  const dot = join(path, ".lore");
+  let id = "";
+  try {
+    id = readFileSync(join(dot, "id")).toString("hex");
+  } catch {
+    // no id file — let create mint a fresh one
+  }
+  const remote = readRepoRemote(path);
+  const label = path.split(/[\\/]/).filter(Boolean).pop() || path;
+  const repositoryUrl = `${remote ? remoteBase(remote) : defaultRemoteBase().replace(/\/+$/, "")}/${label}`;
+  log.info("repairing repository", { path, repositoryUrl, id });
+  // Recreate offline so we never re-register on (or conflict with) the remote —
+  // the repo already exists there; we are only rebuilding the local .lore. Move
+  // the old .lore aside first and restore it if the rebuild fails, so a failure
+  // never leaves the working copy without a repository.
+  const backup = `${dot}.repair-bak`;
+  rmSync(backup, { recursive: true, force: true });
+  renameSync(dot, backup);
+  try {
+    await collect("repositoryCreate", { repositoryPath: path, offline: true }, { repositoryUrl, id });
+  } catch (err) {
+    rmSync(dot, { recursive: true, force: true });
+    renameSync(backup, dot);
+    throw err;
+  }
+  rmSync(backup, { recursive: true, force: true });
+  setupLoreignore(path);
+  broadcastRefresh(path, "repair");
+  sendJson(res, 200, { ok: true, id });
 }
 
 /**
@@ -320,7 +394,20 @@ const server = createServer(async (req, res) => {
     }
     if (p === "/api/status" && req.method === "GET") {
       const events = await collect("repositoryStatus", globalArgs, { staged: true, scan: true });
-      return sendJson(res, 200, xform.status(events));
+      const out = xform.status(events);
+      // The UI offers an "Initialize .loreignore" action when one is absent.
+      out.hasLoreignore = repoPath ? hasLoreignore(repoPath) : false;
+      out.hasGitignore = repoPath ? hasGitignore(repoPath) : false;
+      // Flag entries that are themselves Lore working copies (a directory holding
+      // its own .lore). The UI prompts to ignore these *while they still exist* —
+      // the only way to avoid the unremovable "zombie" entry Lore leaves behind if
+      // an indexed nested repo is later deleted.
+      if (repoPath) {
+        for (const f of out.files) {
+          if (f.type === 0 && isRepo(join(repoPath, f.path))) f.nested = true;
+        }
+      }
+      return sendJson(res, 200, out);
     }
     if (p === "/api/branches" && req.method === "GET") {
       const events = await collect("branchList", globalArgs, {});
@@ -366,6 +453,31 @@ const server = createServer(async (req, res) => {
       await collect("fileReset", { repositoryPath: rp }, { paths: absFiles(rp, files) });
       broadcastRefresh(rp, "reset");
       return sendJson(res, 200, { ok: true });
+    }
+    // Add a file/folder/extension pattern to .loreignore (created if absent).
+    if (p === "/api/ignore" && req.method === "POST") {
+      const { path: rp, pattern } = await readBody(req);
+      if (!rp || !pattern) return sendJson(res, 400, { error: "path and pattern required" });
+      const added = appendIgnorePattern(toUnixPath(rp), pattern);
+      broadcastRefresh(rp, "ignore");
+      return sendJson(res, 200, { ok: true, added });
+    }
+    // Seed/repair .loreignore for an already-initialized repo (the same setup the
+    // Add flow runs on init).
+    if (p === "/api/init-loreignore" && req.method === "POST") {
+      const { path: rp } = await readBody(req);
+      if (!rp) return sendJson(res, 400, { error: "path required" });
+      const result = setupLoreignore(toUnixPath(rp));
+      broadcastRefresh(rp, "ignore");
+      return sendJson(res, 200, { ok: true, ...result });
+    }
+    // Rebuild a repo's .lore in place to purge unremovable zombie index entries
+    // (Lore has no command to drop them). Guarded: refuses if there is committed
+    // history to lose. Preserves the repository id and remote so identity is kept.
+    if (p === "/api/repair" && req.method === "POST") {
+      const { path: rp } = await readBody(req);
+      if (!rp) return sendJson(res, 400, { error: "path required" });
+      return await repairRepo(toUnixPath(rp), res);
     }
     if (p === "/api/commit" && req.method === "POST") {
       const { path: rp, message } = await readBody(req);

--- a/lore-web/server/index.mjs
+++ b/lore-web/server/index.mjs
@@ -16,7 +16,7 @@ import * as store from "./store.mjs";
 import * as xform from "./transforms.mjs";
 import { addClient, broadcastRefresh } from "./events.mjs";
 import { watchRepo, unwatchRepo } from "./watcher.mjs";
-import { isLoggedIn } from "./cli.mjs";
+import { isLoggedIn, runCli } from "./cli.mjs";
 import { setupLoreignore, appendIgnorePattern, hasLoreignore, hasGitignore } from "./loreignore.mjs";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
@@ -173,7 +173,7 @@ async function listRepos(res) {
 
 /**
  * POST /api/repos — start tracking a folder, smartly. If the folder is already a
- * Lore working copy it is just tracked; otherwise a new repository is initialized
+ * Lore working copy it is tracked as-is; otherwise a new repository is initialized
  * there first (with an auto-generated remote URL) so the user can point at any
  * folder without caring whether it has been set up yet.
  */
@@ -205,7 +205,7 @@ async function addRepo(req, res) {
 
 /**
  * POST /api/repair — rebuild a working copy's .lore in place. Lore can leave
- * "zombie" status entries (e.g. a nested repo that was indexed then deleted) that
+ * "zombie" status entries (for example, a nested repo that was indexed then deleted) that
  * no reset/stage/commit/obliterate can remove; the only cure is recreating .lore.
  * We do that while preserving the repository id and remote, so the repo keeps its
  * identity. Refused when there is committed history (which a rebuild would drop) —
@@ -253,8 +253,67 @@ async function repairRepo(path, res) {
 }
 
 /**
+ * GET /api/remote-repos?url= — ask a Lore server which repositories it hosts, so
+ * the user can pick one to clone instead of typing its full URL. The server base
+ * comes from the query, falling back to the same default the Add flow suggests
+ * (the remote of an already-tracked repo, an env override, or the local server).
+ * Each entry is returned with a ready-to-clone URL of the form <base>/<name>.
+ * @param {import("node:http").ServerResponse} res
+ * @param {string|null} rawUrl the server URL to query; empty/null uses the default
+ */
+async function listRemoteRepos(res, rawUrl) {
+  const base = remoteBase((rawUrl || "").trim() || defaultRemoteBase());
+  const events = await collect("repositoryList", {}, { url: base });
+  const local = localRepoIds();
+  // Address each repo by its id (server-listed names do not resolve for repos
+  // created without an owner — see deleteRemoteRepo) but offer the name-based
+  // URL for cloning, which the user expects to look like the real remote.
+  const repos = xform.remoteRepos(events).map((r) => ({
+    ...r,
+    url: `${base}/${r.name}`,
+    idUrl: `${base}/${r.id}`,
+    tracked: local.has(r.id),
+  }));
+  sendJson(res, 200, { base, repos });
+}
+
+/** Repository ids of every tracked local working copy (from each .lore/id). */
+function localRepoIds() {
+  const ids = new Set();
+  for (const r of store.listRepos()) {
+    try {
+      const id = readFileSync(join(r.path, ".lore", "id")).toString("hex");
+      if (id) ids.add(id);
+    } catch {
+      // no id file / not a working copy — nothing to match
+    }
+  }
+  return ids;
+}
+
+/**
+ * DELETE /api/remote-repos — remove a repository from its server by id. Two Lore
+ * quirks force the shape of this: (1) repos created without an owner do not
+ * resolve by their listed name, only by id; (2) `lore repository delete` prints
+ * a spurious "Not found" and exits 0 even when it succeeded. So we delete by id
+ * and ignore the CLI's status entirely, confirming the outcome by re-listing —
+ * the delete worked iff the id is gone.
+ */
+async function deleteRemoteRepo(req, res) {
+  const { id, base: rawBase } = await readBody(req);
+  if (!id) return sendJson(res, 400, { error: "id required" });
+  const base = remoteBase((rawBase || "").trim() || defaultRemoteBase());
+  log.info("deleting remote repository", { base, id });
+  await runCli(["repository", "delete", `${base}/${id}`]);
+  const events = await collect("repositoryList", {}, { url: base });
+  const stillThere = xform.remoteRepos(events).some((r) => r.id === id);
+  if (stillThere) return sendJson(res, 500, { error: "server did not delete the repository" });
+  sendJson(res, 200, { ok: true });
+}
+
+/**
  * Drive roots present on this machine, used as the picker's top "This PC" level.
- * @returns {string[]} drive-root paths (Windows: C:\ … Z:\; POSIX: just "/")
+ * @returns {string[]} drive-root paths (Windows: C:\ … Z:\; POSIX: "/")
  */
 function listDrives() {
   if (process.platform !== "win32") return ["/"];
@@ -382,6 +441,9 @@ const server = createServer(async (req, res) => {
       const label = target.split(/[\\/]/).filter(Boolean).pop() || target;
       return sendJson(res, 200, { isRepo: already, url: already ? null : suggestInitUrl(label) });
     }
+
+    if (p === "/api/remote-repos" && req.method === "GET") return await listRemoteRepos(res, q.get("url"));
+    if (p === "/api/remote-repos" && req.method === "DELETE") return await deleteRemoteRepo(req, res);
 
     if (p === "/api/repos" && req.method === "GET") return await listRepos(res);
     if (p === "/api/repos" && req.method === "POST") return await addRepo(req, res);

--- a/lore-web/server/index.mjs
+++ b/lore-web/server/index.mjs
@@ -196,8 +196,20 @@ const server = createServer(async (req, res) => {
       // The native lib resolves relative path args against process.cwd(); anchor
       // them to the repo by passing an absolute path instead.
       const abs = file && repoPath ? join(repoPath, file) : file;
-      const events = await collect("fileDiff", globalArgs, abs ? { paths: [abs] } : {});
+      const args = abs ? { paths: [abs] } : {};
+      // Optional revision range: diff a file between two revisions instead of the
+      // working tree (used to show what a historical revision changed).
+      const source = q.get("source");
+      const target = q.get("target");
+      if (source) args.sourceRevision = source;
+      if (target) args.targetRevision = target;
+      const events = await collect("fileDiff", globalArgs, args);
       return sendJson(res, 200, { diff: xform.diff(events) });
+    }
+    if (p === "/api/revision" && req.method === "GET") {
+      const revision = q.get("revision");
+      const events = await collect("revisionInfo", globalArgs, { revision, delta: true });
+      return sendJson(res, 200, { files: xform.revisionFiles(events) });
     }
 
     // --- write actions (quick; respond with refreshed nothing, broadcast refresh) ---

--- a/lore-web/server/index.mjs
+++ b/lore-web/server/index.mjs
@@ -18,6 +18,7 @@ import { addClient, broadcastRefresh } from "./events.mjs";
 import { watchRepo, unwatchRepo } from "./watcher.mjs";
 import { isLoggedIn, runCli } from "./cli.mjs";
 import { setupLoreignore, appendIgnorePattern, hasLoreignore, hasGitignore } from "./loreignore.mjs";
+import { discoverServers } from "./discovery.mjs";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const WEB_DIR = join(HERE, "..", "web");
@@ -31,13 +32,16 @@ function isRepo(path) {
 
 /**
  * The remote server base to assign when initializing a brand-new repository, so
- * the user never types one. We reuse the remote of an already-tracked repo
- * (almost always the same self-hosted server), falling back to an env override
- * and finally the default local Lore server. The repo name is appended later;
- * repositoryCreate mints the per-repo UUID that distinguishes repos on a server.
+ * the user never types one. Reads from configured default remote, falls back to
+ * an already-tracked repo's remote, or the default local Lore server. The repo
+ * name is appended later; repositoryCreate mints the per-repo UUID that
+ * distinguishes repos on a server.
  * @returns {string} a remote base URL with no trailing repo-name path component
  */
 function defaultRemoteBase() {
+  const configured = store.getDefaultRemote();
+  if (configured) return configured;
+
   for (const r of store.listRepos()) {
     for (const name of ["config.toml", "config"]) {
       const cfg = join(r.path, ".lore", name);
@@ -50,7 +54,7 @@ function defaultRemoteBase() {
       }
     }
   }
-  return process.env.LORE_WEB_DEFAULT_REMOTE ?? "lore://127.0.0.1:41337";
+  return "lore://127.0.0.1:41337";
 }
 
 /** The remote_url recorded in a repo's .lore config, or null if none/unreadable. */
@@ -163,12 +167,12 @@ async function listRepos(res) {
         try {
           info = xform.repoSummary(await collect("repositoryStatus", { repositoryPath: r.path }, { staged: false }));
         } catch (err) {
-          log.debug("repo enrich failed", { path: r.path });
+          log.debug("repo enrich failed", { path: r.path, message: err instanceof Error ? err.message : String(err) });
         }
         try {
           organization = (await readOrg(r.path)).organization;
         } catch (err) {
-          log.debug("repo org read failed", { path: r.path });
+          log.debug("repo org read failed", { path: r.path, message: err instanceof Error ? err.message : String(err) });
         }
       }
       return { ...r, exists, organization, ...info };
@@ -389,6 +393,55 @@ async function deleteRemoteRepo(req, res) {
 }
 
 /**
+ * GET /api/config — return the configured default remote server and discovered servers.
+ * @param {import("node:http").ServerResponse} res
+ */
+async function getConfig(res) {
+  let discovered = [];
+  try {
+    discovered = await discoverServers();
+  } catch (err) {
+    log.debug("server discovery failed", { message: err instanceof Error ? err.message : String(err) });
+  }
+  return sendJson(res, 200, {
+    defaultRemote: store.getDefaultRemote(),
+    discoveredServers: discovered,
+  });
+}
+
+/**
+ * POST /api/config — set the default remote server URL.
+ * @param {import("node:http").IncomingMessage} req
+ * @param {import("node:http").ServerResponse} res
+ */
+async function setConfig(req, res) {
+  const body = await readBody(req);
+  const defaultRemote = typeof body.defaultRemote === "string" ? body.defaultRemote.trim() : "";
+  try {
+    store.setDefaultRemote(defaultRemote);
+    log.info("remote server configured", { url: defaultRemote ? "[configured]" : "[cleared]" });
+    return sendJson(res, 200, { ok: true });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return sendJson(res, 400, { error: message });
+  }
+}
+
+/**
+ * GET /api/discover — manually trigger discovery of Lore servers on the local network.
+ * @param {import("node:http").ServerResponse} res
+ */
+async function manualDiscover(res) {
+  try {
+    const discovered = await discoverServers();
+    return sendJson(res, 200, { discoveredServers: discovered });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return sendJson(res, 500, { error: message });
+  }
+}
+
+/**
  * Drive roots present on this machine, used as the picker's top "This PC" level.
  * @returns {string[]} drive-root paths (Windows: C:\ … Z:\; POSIX: "/")
  */
@@ -528,6 +581,10 @@ const server = createServer(async (req, res) => {
 
     if (p === "/api/org" && req.method === "GET") return await getOrg(res, repoPath);
     if (p === "/api/org" && req.method === "POST") return await setOrg(req, res);
+
+    if (p === "/api/config" && req.method === "GET") return await getConfig(res);
+    if (p === "/api/config" && req.method === "POST") return await setConfig(req, res);
+    if (p === "/api/discover" && req.method === "GET") return await manualDiscover(res);
 
     if (p === "/api/history" && req.method === "GET") {
       const length = Number(q.get("length") ?? 50);

--- a/lore-web/server/log.mjs
+++ b/lore-web/server/log.mjs
@@ -1,0 +1,44 @@
+// Structured logger following Lore's level discipline (Trace/Debug/Info/Warn/Error).
+// Info is the default. Levels and ordering mirror lore-base/src/log/mod.rs so that
+// SDK LOG events can pass through with their level preserved.
+
+/** @typedef {"trace"|"debug"|"info"|"warn"|"error"} Level */
+
+const ORDER = { trace: 1, debug: 2, info: 3, warn: 4, error: 5 };
+
+const envLevel = (process.env.LORE_WEB_LOG_LEVEL || "info").toLowerCase();
+const threshold = ORDER[/** @type {Level} */ (envLevel)] ?? ORDER.info;
+
+/**
+ * Emit one structured log line. Fields are rendered as `key=value` pairs after
+ * the message rather than interpolated into it, per the logging standard.
+ * @param {Level} level
+ * @param {string} message
+ * @param {Record<string, unknown>} [fields]
+ */
+function emit(level, message, fields) {
+  if (ORDER[level] < threshold) return;
+  const ts = new Date().toISOString();
+  let line = `${ts} ${level.toUpperCase().padEnd(5)} ${message}`;
+  if (fields) {
+    for (const [k, v] of Object.entries(fields)) {
+      const val = typeof v === "string" ? v : JSON.stringify(v);
+      line += ` ${k}=${val}`;
+    }
+  }
+  const sink = level === "error" || level === "warn" ? process.stderr : process.stdout;
+  sink.write(line + "\n");
+}
+
+export const log = {
+  /** @param {string} m @param {Record<string,unknown>} [f] */
+  trace: (m, f) => emit("trace", m, f),
+  /** @param {string} m @param {Record<string,unknown>} [f] */
+  debug: (m, f) => emit("debug", m, f),
+  /** @param {string} m @param {Record<string,unknown>} [f] */
+  info: (m, f) => emit("info", m, f),
+  /** @param {string} m @param {Record<string,unknown>} [f] */
+  warn: (m, f) => emit("warn", m, f),
+  /** @param {string} m @param {Record<string,unknown>} [f] */
+  error: (m, f) => emit("error", m, f),
+};

--- a/lore-web/server/loreignore.mjs
+++ b/lore-web/server/loreignore.mjs
@@ -7,14 +7,15 @@ import { join } from "node:path";
 
 const LOREIGNORE = ".loreignore";
 const GITIGNORE = ".gitignore";
+const P4IGNORE = ".p4ignore";
 
-// Git's own metadata is meaningless to Lore, so a fresh .loreignore always
-// excludes it. .gitignore is listed too: when Git and Lore coexist it is Git's
-// file, not something Lore should version.
-const LORE_IGNORES = [".git/", ".gitignore"];
+// Other VCS metadata is meaningless to Lore, so a fresh .loreignore always
+// excludes it. The ignore files are listed too: when coexisting with other VCS
+// tools they are their files, not something Lore should version.
+const LORE_IGNORES = [".git/", ".gitignore", ".p4/", ".p4ignore"];
 // Conversely, once Lore manages the working copy its metadata should stay out of
-// Git, so .gitignore gains the Lore counterparts.
-const GIT_IGNORES = [".lore/", ".loreignore"];
+// other VCS tools, so their ignore files gain the Lore counterparts.
+const VCS_IGNORES = [".lore/", ".loreignore"];
 
 const splitLines = (text) => text.split(/\r?\n/);
 
@@ -22,6 +23,21 @@ const splitLines = (text) => text.split(/\r?\n/);
 function sameEntry(a, b) {
   const norm = (s) => s.trim().replace(/\/+$/, "");
   return norm(a) === norm(b);
+}
+
+/**
+ * Convert a Perforce .p4ignore pattern to gitignore format. Perforce uses `...`
+ * to mean "everything recursively"; gitignore interprets trailing `/` as recursive.
+ * Examples: `Intermediate/...` → `Intermediate/`, `*.log` → `*.log` (unchanged).
+ * @param {string} pattern the Perforce pattern
+ * @returns {string} the converted gitignore pattern
+ */
+function convertP4PatternToGitignore(pattern) {
+  // Strip leading/trailing whitespace and skip comments/empty lines.
+  const trimmed = pattern.trim();
+  if (!trimmed || trimmed.startsWith("#")) return trimmed;
+  // Replace Perforce's recursive `...` suffix with gitignore's `/` (or remove it if already has `/`).
+  return trimmed.endsWith("/...") ? trimmed.slice(0, -3) : trimmed.endsWith("...") ? trimmed.slice(0, -3) + "/" : trimmed;
 }
 
 /**
@@ -43,30 +59,84 @@ function appendEntries(filePath, header, entries) {
 }
 
 /**
+ * Append Lore's counterpart entries to an ignore file another VCS tool owns
+ * (.gitignore, .p4ignore), tolerating the read-only files Perforce leaves on
+ * disk until `p4 edit`. A permission failure is reported rather than thrown, so
+ * seeding .loreignore still succeeds when the foreign file cannot be written.
+ * @param {string} filePath the foreign ignore file (must already exist)
+ * @returns {{updated: boolean, blocked: boolean}} updated when entries were
+ *   written; blocked when the file exists but is read-only / not writable
+ */
+function appendForeignIgnore(filePath) {
+  try {
+    return { updated: appendEntries(filePath, "# Lore files", VCS_IGNORES).length > 0, blocked: false };
+  } catch (err) {
+    // Perforce keeps versioned files read-only until `p4 edit`; treat that as a
+    // skip, not a failure that aborts the whole setup.
+    if (err && (err.code === "EPERM" || err.code === "EACCES")) {
+      return { updated: false, blocked: true };
+    }
+    throw err;
+  }
+}
+
+/**
  * Set up .loreignore for a working copy (on init, or on demand for an existing
- * repo). Seeds .loreignore from .gitignore when present, ensures Git's files are
- * ignored by Lore, and — when a .gitignore exists — ensures Lore's files are
- * ignored by Git. Idempotent: safe to call on an already-configured repo.
+ * repo). Seeds .loreignore from .gitignore and .p4ignore when present, ensures
+ * other VCS metadata is ignored by Lore, and ensures Lore's files are ignored by
+ * other VCS tools. The counterpart writes into .gitignore/.p4ignore are
+ * best-effort: a read-only Perforce file is reported via *Blocked flags rather
+ * than aborting the seed. Idempotent: safe to call on an already-configured repo.
  * @param {string} repoPath working-copy root
+ * @returns {{created: boolean, gitignoreUpdated: boolean, gitignoreBlocked: boolean, p4ignoreUpdated: boolean, p4ignoreBlocked: boolean}}
  */
 export function setupLoreignore(repoPath) {
   const lorePath = join(repoPath, LOREIGNORE);
   const gitPath = join(repoPath, GITIGNORE);
+  const p4Path = join(repoPath, P4IGNORE);
   const gitExists = existsSync(gitPath);
+  const p4Exists = existsSync(p4Path);
   const created = !existsSync(lorePath);
 
-  // Seed a brand-new .loreignore from .gitignore — the same paths a user already
-  // declared uninteresting to Git are a sensible starting point for Lore.
-  if (created && gitExists) {
-    writeFileSync(lorePath, readFileSync(gitPath, "utf8"));
+  // Seed a brand-new .loreignore from .gitignore and .p4ignore — the same paths
+  // a user already declared uninteresting to other tools are sensible starting
+  // points for Lore. Convert Perforce patterns (which use `...` for recursion)
+  // to gitignore format (which use `/` or `**`).
+  if (created) {
+    let seedContent = "";
+    if (gitExists) {
+      seedContent += readFileSync(gitPath, "utf8");
+    }
+    if (p4Exists) {
+      const p4Content = readFileSync(p4Path, "utf8");
+      // Avoid duplicating entries if both files exist
+      const existingLines = seedContent.split(/\r?\n/);
+      const p4Lines = p4Content.split(/\r?\n/).map(convertP4PatternToGitignore);
+      const newLines = p4Lines.filter(
+        (line) => !existingLines.some((existingLine) => sameEntry(line, existingLine))
+      );
+      if (newLines.length > 0) {
+        if (seedContent && !seedContent.endsWith("\n")) seedContent += "\n";
+        seedContent += newLines.join("\n");
+      }
+    }
+    if (seedContent) {
+      writeFileSync(lorePath, seedContent);
+    }
   }
-  appendEntries(lorePath, "# Git files (managed by Git, not Lore)", LORE_IGNORES);
 
-  let gitignoreUpdated = false;
-  if (gitExists) {
-    gitignoreUpdated = appendEntries(gitPath, "# Lore files", GIT_IGNORES).length > 0;
-  }
-  return { created, gitignoreUpdated };
+  appendEntries(lorePath, "# Other VCS files (managed by Git/Perforce, not Lore)", LORE_IGNORES);
+
+  const git = gitExists ? appendForeignIgnore(gitPath) : { updated: false, blocked: false };
+  const p4 = p4Exists ? appendForeignIgnore(p4Path) : { updated: false, blocked: false };
+
+  return {
+    created,
+    gitignoreUpdated: git.updated,
+    gitignoreBlocked: git.blocked,
+    p4ignoreUpdated: p4.updated,
+    p4ignoreBlocked: p4.blocked,
+  };
 }
 
 /**
@@ -87,4 +157,9 @@ export function hasLoreignore(repoPath) {
 /** Whether the working copy has a .gitignore file. */
 export function hasGitignore(repoPath) {
   return existsSync(join(repoPath, GITIGNORE));
+}
+
+/** Whether the working copy has a .p4ignore file. */
+export function hasP4ignore(repoPath) {
+  return existsSync(join(repoPath, P4IGNORE));
 }

--- a/lore-web/server/loreignore.mjs
+++ b/lore-web/server/loreignore.mjs
@@ -1,0 +1,90 @@
+// .loreignore management. Lore reads ignore rules from a gitignore-style
+// .loreignore at the working-copy root (see lore-revision repository::load_filter).
+// These helpers seed and extend it from the UI without the user hand-editing files.
+
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const LOREIGNORE = ".loreignore";
+const GITIGNORE = ".gitignore";
+
+// Git's own metadata is meaningless to Lore, so a fresh .loreignore always
+// excludes it. .gitignore is listed too: when Git and Lore coexist it is Git's
+// file, not something Lore should version.
+const LORE_IGNORES = [".git/", ".gitignore"];
+// Conversely, once Lore manages the working copy its metadata should stay out of
+// Git, so .gitignore gains the Lore counterparts.
+const GIT_IGNORES = [".lore/", ".loreignore"];
+
+const splitLines = (text) => text.split(/\r?\n/);
+
+/** Compare ignore entries ignoring trailing slashes and surrounding space. */
+function sameEntry(a, b) {
+  const norm = (s) => s.trim().replace(/\/+$/, "");
+  return norm(a) === norm(b);
+}
+
+/**
+ * Append the entries not already present to an ignore file, creating it if
+ * needed. A header comment is written above the first batch actually added.
+ * @returns {string[]} the entries that were newly written (empty if no change)
+ */
+function appendEntries(filePath, header, entries) {
+  let text = existsSync(filePath) ? readFileSync(filePath, "utf8") : "";
+  const lines = splitLines(text);
+  const missing = entries.filter((e) => !lines.some((l) => sameEntry(l, e)));
+  if (missing.length === 0) return [];
+  let out = text;
+  if (out && !out.endsWith("\n")) out += "\n";
+  if (header) out += `${out ? "\n" : ""}${header}\n`;
+  out += missing.join("\n") + "\n";
+  writeFileSync(filePath, out);
+  return missing;
+}
+
+/**
+ * Set up .loreignore for a working copy (on init, or on demand for an existing
+ * repo). Seeds .loreignore from .gitignore when present, ensures Git's files are
+ * ignored by Lore, and — when a .gitignore exists — ensures Lore's files are
+ * ignored by Git. Idempotent: safe to call on an already-configured repo.
+ * @param {string} repoPath working-copy root
+ */
+export function setupLoreignore(repoPath) {
+  const lorePath = join(repoPath, LOREIGNORE);
+  const gitPath = join(repoPath, GITIGNORE);
+  const gitExists = existsSync(gitPath);
+  const created = !existsSync(lorePath);
+
+  // Seed a brand-new .loreignore from .gitignore — the same paths a user already
+  // declared uninteresting to Git are a sensible starting point for Lore.
+  if (created && gitExists) {
+    writeFileSync(lorePath, readFileSync(gitPath, "utf8"));
+  }
+  appendEntries(lorePath, "# Git files (managed by Git, not Lore)", LORE_IGNORES);
+
+  let gitignoreUpdated = false;
+  if (gitExists) {
+    gitignoreUpdated = appendEntries(gitPath, "# Lore files", GIT_IGNORES).length > 0;
+  }
+  return { created, gitignoreUpdated };
+}
+
+/**
+ * Append a single gitignore-style pattern (a file, folder, or *.ext glob) to
+ * .loreignore, creating the file if it does not exist yet. No-op if already
+ * present.
+ * @returns {boolean} whether the pattern was newly added
+ */
+export function appendIgnorePattern(repoPath, pattern) {
+  return appendEntries(join(repoPath, LOREIGNORE), null, [pattern]).length > 0;
+}
+
+/** Whether the working copy already has a .loreignore file. */
+export function hasLoreignore(repoPath) {
+  return existsSync(join(repoPath, LOREIGNORE));
+}
+
+/** Whether the working copy has a .gitignore file. */
+export function hasGitignore(repoPath) {
+  return existsSync(join(repoPath, GITIGNORE));
+}

--- a/lore-web/server/sdk.mjs
+++ b/lore-web/server/sdk.mjs
@@ -76,7 +76,7 @@ function messageFromErrors(errors, fallback) {
 /**
  * Run a Lore verb to completion and return all of its events. Throws a
  * LoreVerbError if the operation fails.
- * @param {string} verb e.g. "revisionHistory"
+ * @param {string} verb such as "revisionHistory"
  * @param {Record<string, unknown>} globalArgs at minimum `{ repositoryPath }`
  * @param {Record<string, unknown>} [args] verb-specific arguments
  * @returns {Promise<LoreEvt[]>}
@@ -102,7 +102,7 @@ export async function collect(verb, globalArgs, args = {}) {
     }
   } catch (err) {
     // asyncIter throws LoreError on a non-zero return; the COMPLETE detail
-    // captured above is the canonical source, so just mark failure.
+    // captured above is the canonical source, so mark failure and move on.
     if (!(err instanceof LoreError)) throw err;
     status = status || -1;
   }

--- a/lore-web/server/sdk.mjs
+++ b/lore-web/server/sdk.mjs
@@ -1,0 +1,184 @@
+// Thin wrapper over @lore-vcs/sdk (koffi FFI -> lorelib). All Lore work in
+// lore-web flows through here so the FFI lifecycle and the failure contract are
+// handled in exactly one place.
+//
+// Failure contract (per Lore's error-handling standard, errors.md §4): a verb's
+// outcome is canonical on its COMPLETE event — `status` (0 = success, non-zero =
+// FFI code) and an `error` detail (`errorCode`, `message`, `traceLocations`).
+// Older builds instead emit a mid-stream ERROR event (`errorType`, `errorInner`);
+// we read COMPLETE.error first and fall back to ERROR events, then raise a single
+// typed LoreVerbError. Event-detail strings are read inside the iteration (the
+// events are already cloned by the SDK), never retained past it.
+
+import { lore, LoreError } from "@lore-vcs/sdk";
+import { LoreEventTag, LoreLogLevel } from "@lore-vcs/sdk/types/enums";
+import { log } from "./log.mjs";
+
+/** A normalized Lore event: numeric tag resolved to its name plus the payload. */
+/** @typedef {{ tag: string, tagRaw: number, data: any }} LoreEvt */
+
+/** Raised when a Lore verb completes with a non-zero status. */
+export class LoreVerbError extends Error {
+  /** @param {string} message @param {{status?: number, code?: number, verb?: string}} [info] */
+  constructor(message, info = {}) {
+    super(message);
+    this.name = "LoreVerbError";
+    this.status = info.status ?? -1;
+    this.code = info.code ?? info.status ?? -1;
+    this.verb = info.verb;
+  }
+}
+
+const TAG_NAME = /** @type {Record<number, string>} */ (LoreEventTag);
+
+/** Resolve a numeric event tag to its enum name (falls back to the number). */
+function tagName(raw) {
+  return TAG_NAME[raw] ?? String(raw);
+}
+
+/** @param {any} ev */
+function normalize(ev) {
+  return { tag: tagName(ev.tag), tagRaw: ev.tag, data: ev.data };
+}
+
+/** Map SDK LOG severity onto our logger levels. */
+const LOG_LEVEL = {
+  [LoreLogLevel.TRACE]: "trace",
+  [LoreLogLevel.DEBUG]: "debug",
+  [LoreLogLevel.INFO]: "info",
+  [LoreLogLevel.WARN]: "warn",
+  [LoreLogLevel.ERROR]: "error",
+};
+
+/**
+ * Look up a verb function on the SDK, failing loudly for unknown names rather
+ * than letting an undefined call throw an opaque TypeError.
+ * @param {string} verb
+ */
+function resolve(verb) {
+  const fn = /** @type {any} */ (lore)[verb];
+  if (typeof fn !== "function") {
+    throw new LoreVerbError(`Unknown Lore verb: ${verb}`, { verb });
+  }
+  return fn;
+}
+
+/** Pull a readable message out of the ERROR events the SDK collected. */
+function messageFromErrors(errors, fallback) {
+  for (const e of errors ?? []) {
+    const data = e?.data ?? e;
+    const inner = data?.errorInner ?? data?.message;
+    if (inner) return String(inner);
+  }
+  return fallback;
+}
+
+/**
+ * Run a Lore verb to completion and return all of its events. Throws a
+ * LoreVerbError if the operation fails.
+ * @param {string} verb e.g. "revisionHistory"
+ * @param {Record<string, unknown>} globalArgs at minimum `{ repositoryPath }`
+ * @param {Record<string, unknown>} [args] verb-specific arguments
+ * @returns {Promise<LoreEvt[]>}
+ */
+export async function collect(verb, globalArgs, args = {}) {
+  const fn = resolve(verb);
+  const events = [];
+  let status = 0;
+  /** @type {{message?: string, errorCode?: number}|null} */
+  let complete = null;
+  /** @type {string|null} */
+  let errorEvent = null;
+  try {
+    for await (const ev of fn(globalArgs, args).asyncIter()) {
+      const n = normalize(ev);
+      if (n.tag === "COMPLETE") {
+        status = n.data?.status ?? 0;
+        complete = n.data?.error ?? null;
+      } else if (n.tag === "ERROR") {
+        errorEvent = n.data?.errorInner ?? errorEvent;
+      }
+      events.push(n);
+    }
+  } catch (err) {
+    // asyncIter throws LoreError on a non-zero return; the COMPLETE detail
+    // captured above is the canonical source, so just mark failure.
+    if (!(err instanceof LoreError)) throw err;
+    status = status || -1;
+  }
+  if (status !== 0) {
+    const message = complete?.message || errorEvent || `Lore verb '${verb}' failed`;
+    log.debug("lore verb failed", { verb, status, message });
+    throw new LoreVerbError(message, { verb, status, code: complete?.errorCode ?? status });
+  }
+  return events;
+}
+
+/**
+ * Stream a Lore verb's events as they arrive, for live progress over SSE. Yields
+ * normalized events (including LOG, PROGRESS, and any ERROR detail) and a final
+ * `{ tag: "DONE", data: { ok, status } }` marker. Never throws to the caller;
+ * failures arrive as the terminal marker so the SSE channel can close cleanly.
+ * @param {string} verb
+ * @param {Record<string, unknown>} globalArgs
+ * @param {Record<string, unknown>} [args]
+ * @returns {AsyncGenerator<LoreEvt>}
+ */
+export async function* stream(verb, globalArgs, args = {}) {
+  const fn = resolve(verb);
+  let status = 0;
+  /** @type {string|null} */
+  let failure = null;
+  const exec = fn(globalArgs, args);
+  try {
+    for await (const ev of exec.asyncIter()) {
+      const n = normalize(ev);
+      if (n.tag === "COMPLETE") {
+        status = n.data?.status ?? 0;
+        failure = n.data?.error?.message || failure;
+      }
+      if (n.tag === "ERROR") failure = n.data?.errorInner ?? failure;
+      if (n.tag === "LOG") {
+        const lvl = LOG_LEVEL[n.data?.level] ?? "debug";
+        log[/** @type {"debug"} */ (lvl)](`lore: ${n.data?.message ?? ""}`, { verb });
+      }
+      yield n;
+    }
+  } catch (err) {
+    if (err instanceof LoreError) {
+      failure = messageFromErrors(err.loreErrors, failure);
+      status = status || -1;
+    } else {
+      failure = err instanceof Error ? err.message : String(err);
+      status = -1;
+    }
+  }
+  const ok = status === 0 && !failure;
+  yield { tag: "DONE", tagRaw: -1, data: { ok, status, message: failure ?? undefined } };
+}
+
+let configured = false;
+
+/** Configure SDK file logging once. Safe to call repeatedly. */
+export function configureSdk() {
+  if (configured) return;
+  configured = true;
+  try {
+    /** @type {any} */ (lore).logConfigure?.({
+      file: false,
+      level: LoreLogLevel.INFO,
+      categories: 0,
+    });
+  } catch (err) {
+    log.warn("sdk logConfigure failed", { error: err instanceof Error ? err.message : String(err) });
+  }
+}
+
+/** Release the native library. Call on process shutdown. */
+export function shutdownSdk() {
+  try {
+    /** @type {any} */ (lore).shutdown?.();
+  } catch {
+    // The process is exiting; a failure to release the lib is not actionable.
+  }
+}

--- a/lore-web/server/smoke.mjs
+++ b/lore-web/server/smoke.mjs
@@ -1,0 +1,49 @@
+// Spike: prove the vendored @lore-vcs/sdk loads and runs from plain Node (no Electron).
+// Usage: node server/smoke.mjs "<repositoryPath>"
+import { lore, LoreError } from "@lore-vcs/sdk";
+
+const repositoryPath = process.argv[2];
+if (!repositoryPath) {
+  console.error('Usage: node server/smoke.mjs "<repositoryPath>"');
+  process.exit(2);
+}
+
+/** Run a Lore verb and return its collected events, surfacing failures. */
+async function run(label, fn, globalArgs, args) {
+  process.stdout.write(`\n# ${label}\n`);
+  try {
+    const events = await fn(globalArgs, args).collectAsync();
+    for (const e of events) {
+      const data = e.data ? JSON.stringify(e.data) : "";
+      console.log(`  [${e.tag}] ${data.slice(0, 200)}`);
+    }
+    return events;
+  } catch (err) {
+    if (err instanceof LoreError) {
+      console.error(`  LoreError:`, err.loreErrors?.map?.((x) => x?.data ?? x) ?? err);
+    } else {
+      console.error(`  threw:`, err);
+    }
+    return null;
+  }
+}
+
+console.log(`SDK loaded OK. Target repo: ${repositoryPath}`);
+
+await run(
+  "revisionHistory (length 5)",
+  lore.revisionHistory,
+  { repositoryPath },
+  { length: 5 },
+);
+
+await run(
+  "repositoryStatus",
+  lore.repositoryStatus,
+  { repositoryPath },
+  { staged: false },
+);
+
+// The native lib keeps the process alive; release it explicitly.
+if (typeof lore.shutdown === "function") lore.shutdown();
+console.log("\nDone.");

--- a/lore-web/server/start.mjs
+++ b/lore-web/server/start.mjs
@@ -37,7 +37,7 @@ function openBrowser() {
 }
 
 if (await isUp()) {
-  // An instance is already running — just open the browser to it.
+  // An instance is already running — open the browser to it.
   console.log(`lore-web is already running. Opening ${url}`);
   openBrowser();
 } else {

--- a/lore-web/server/start.mjs
+++ b/lore-web/server/start.mjs
@@ -1,0 +1,59 @@
+// Launch the server (if not already running) and open it in the default browser.
+// This is the everyday entry point (`npm start` / start.bat); use `npm run serve`
+// to run headless without opening a browser.
+
+import { spawn } from "node:child_process";
+import { connect } from "node:net";
+
+const host = process.env.LORE_WEB_HOST ?? "127.0.0.1";
+const port = Number(process.env.LORE_WEB_PORT ?? 7420);
+const url = `http://${host}:${port}`;
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+/** Resolve true if something is already listening on the target port. */
+function isUp() {
+  return new Promise((resolve) => {
+    const sock = connect(port, host);
+    sock.on("connect", () => {
+      sock.destroy();
+      resolve(true);
+    });
+    sock.on("error", () => resolve(false));
+  });
+}
+
+/** Open the URL with the platform's default browser opener. */
+function openBrowser() {
+  const [cmd, args] =
+    process.platform === "win32" ? ["cmd", ["/c", "start", "", url]]
+    : process.platform === "darwin" ? ["open", [url]]
+    : ["xdg-open", [url]];
+  try {
+    spawn(cmd, args, { detached: true, stdio: "ignore" }).unref();
+  } catch {
+    // Opening the browser is best-effort; the URL is printed below regardless.
+  }
+}
+
+if (await isUp()) {
+  // An instance is already running — just open the browser to it.
+  console.log(`lore-web is already running. Opening ${url}`);
+  openBrowser();
+} else {
+  // Start the server, then wait for it to accept connections before opening.
+  await import("./index.mjs");
+  let ready = false;
+  for (let i = 0; i < 50 && !ready; i++) {
+    ready = await isUp();
+    if (!ready) await sleep(100);
+  }
+  if (ready) {
+    console.log(`\nlore-web is running. Opening ${url}`);
+    console.log(`If your browser does not open, go to ${url} manually.\n`);
+    openBrowser();
+  } else {
+    console.error(`Server did not become ready on ${url}. Check the log above.`);
+    process.exit(1);
+  }
+}

--- a/lore-web/server/store.mjs
+++ b/lore-web/server/store.mjs
@@ -14,16 +14,21 @@ import { log } from "./log.mjs";
 const STORE_PATH =
   process.env.LORE_WEB_STORE ?? join(homedir(), ".lore-web", "store.json");
 
-/** @type {{ repos: RepoEntry[] }} */
-let state = { repos: [] };
+/** @type {{ repos: RepoEntry[], defaultRemote?: string }} */
+let state = { repos: [], defaultRemote: process.env.LORE_WEB_DEFAULT_REMOTE ?? "" };
 
+/**
+ * Load persisted state from `STORE_PATH` into module state, if the file exists.
+ * A missing file is normal (first run) and leaves the initial empty state in
+ * place. A corrupt file must not take the app down, so it is treated the same
+ * way, with a warning logged for visibility.
+ */
 function loadFromDisk() {
   if (!existsSync(STORE_PATH)) return;
   try {
     const parsed = JSON.parse(readFileSync(STORE_PATH, "utf8"));
     if (parsed && Array.isArray(parsed.repos)) state = parsed;
   } catch (err) {
-    // A corrupt store should not take the app down; start empty and warn.
     log.warn("store unreadable, starting empty", {
       path: STORE_PATH,
       error: err instanceof Error ? err.message : String(err),
@@ -31,6 +36,7 @@ function loadFromDisk() {
   }
 }
 
+/** Write the current module state to `STORE_PATH`, creating its directory if needed. */
 function persist() {
   mkdirSync(dirname(STORE_PATH), { recursive: true });
   writeFileSync(STORE_PATH, JSON.stringify(state, null, 2));
@@ -80,4 +86,26 @@ export function removeRepo(path) {
   const removed = state.repos.length < before;
   if (removed) persist();
   return removed;
+}
+
+/**
+ * Get the configured default remote server URL.
+ * @returns {string} the remote server URL or empty string if not set
+ */
+export function getDefaultRemote() {
+  return state.defaultRemote || "";
+}
+
+/**
+ * Set the default remote server URL for repositories. Validates the URL format.
+ * @param {string} url the remote server URL, for example "lore://127.0.0.1:41337"
+ * @throws {Error} if URL is malformed
+ */
+export function setDefaultRemote(url) {
+  const trimmed = (url || "").trim();
+  if (trimmed && !trimmed.match(/^[a-z][a-z0-9+.-]*:\/\/[^/]+/i)) {
+    throw new Error(`invalid remote URL format: "${trimmed}"`);
+  }
+  state.defaultRemote = trimmed;
+  persist();
 }

--- a/lore-web/server/store.mjs
+++ b/lore-web/server/store.mjs
@@ -1,0 +1,83 @@
+// Persistent record of the repositories the user has added to lore-web. This is
+// the ONLY thing lore-web persists: a set of working-copy paths plus labels.
+// Repository *data* (revisions, status, branches) is never cached here — it is
+// always read live from the SDK so the UI cannot go stale (the core defect of
+// the desktop app this replaces).
+
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { log } from "./log.mjs";
+
+/** @typedef {{ path: string, label: string, addedAt: number }} RepoEntry */
+
+const STORE_PATH =
+  process.env.LORE_WEB_STORE ?? join(homedir(), ".lore-web", "store.json");
+
+/** @type {{ repos: RepoEntry[] }} */
+let state = { repos: [] };
+
+function loadFromDisk() {
+  if (!existsSync(STORE_PATH)) return;
+  try {
+    const parsed = JSON.parse(readFileSync(STORE_PATH, "utf8"));
+    if (parsed && Array.isArray(parsed.repos)) state = parsed;
+  } catch (err) {
+    // A corrupt store should not take the app down; start empty and warn.
+    log.warn("store unreadable, starting empty", {
+      path: STORE_PATH,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+function persist() {
+  mkdirSync(dirname(STORE_PATH), { recursive: true });
+  writeFileSync(STORE_PATH, JSON.stringify(state, null, 2));
+}
+
+loadFromDisk();
+
+/** @returns {RepoEntry[]} a copy of the tracked repositories, newest first */
+export function listRepos() {
+  return [...state.repos].sort((a, b) => b.addedAt - a.addedAt);
+}
+
+/** @param {string} path */
+export function getRepo(path) {
+  return state.repos.find((r) => r.path === path);
+}
+
+/**
+ * Add (or relabel) a tracked repository.
+ * @param {string} path absolute working-copy path
+ * @param {string} label display name
+ * @returns {RepoEntry}
+ */
+export function addRepo(path, label) {
+  const existing = getRepo(path);
+  if (existing) {
+    if (label) existing.label = label;
+    persist();
+    return existing;
+  }
+  const entry = { path, label: label || path, addedAt: Date.now() };
+  state.repos.push(entry);
+  persist();
+  return entry;
+}
+
+/**
+ * Stop tracking a repository. Always succeeds, even for a path whose folder no
+ * longer exists — removing a dangling entry must never be blocked (the desktop
+ * bug this fixes refused to remove a repo once its folder was deleted).
+ * @param {string} path
+ * @returns {boolean} whether an entry was removed
+ */
+export function removeRepo(path) {
+  const before = state.repos.length;
+  state.repos = state.repos.filter((r) => r.path !== path);
+  const removed = state.repos.length < before;
+  if (removed) persist();
+  return removed;
+}

--- a/lore-web/server/transforms.mjs
+++ b/lore-web/server/transforms.mjs
@@ -65,6 +65,26 @@ export function branches(events) {
   return events.filter((e) => e.tag === "BRANCH_LIST_ENTRY").map((e) => e.data);
 }
 
+/**
+ * The files changed in a single revision, from `revisionInfo({ delta: true })`.
+ * @param {LoreEvt[]} events
+ */
+export function revisionFiles(events) {
+  return events
+    .filter((e) => e.tag === "REVISION_INFO_DELTA")
+    // The delta walks the whole tree; keep only entries that actually changed
+    // (content modified, or added/deleted/moved — action other than KEEP=0).
+    // Unchanged directory/context entries (action KEEP, not modified) are noise.
+    .filter((e) => e.data?.flagModify || (e.data?.action ?? 0) !== 0)
+    .map((e) => ({
+      path: e.data?.path,
+      action: e.data?.action,
+      size: e.data?.size,
+      flagModify: e.data?.flagModify,
+      flagMerged: e.data?.flagMerged,
+    }));
+}
+
 /** @param {LoreEvt[]} events */
 export function diff(events) {
   return events

--- a/lore-web/server/transforms.mjs
+++ b/lore-web/server/transforms.mjs
@@ -1,0 +1,87 @@
+// Shape normalized SDK event streams into the compact JSON the SPA consumes.
+// Each function takes the array returned by sdk.collect() and returns plain data.
+
+/** @typedef {{ tag: string, tagRaw: number, data: any }} LoreEvt */
+
+/** Unwrap a Lore metadata value ({ tag, data, tagName }) to its inner value. */
+function metaValue(value) {
+  return value && typeof value === "object" && "data" in value ? value.data : value;
+}
+
+/**
+ * Group revision-history events into revision records. Each REVISION_HISTORY_ENTRY
+ * is followed by METADATA events (message, timestamp, branch) that belong to it.
+ * @param {LoreEvt[]} events
+ */
+export function history(events) {
+  const revisions = [];
+  let current = null;
+  for (const e of events) {
+    if (e.tag === "REVISION_HISTORY_ENTRY") {
+      current = {
+        revision: e.data?.revision,
+        revisionNumber: e.data?.revisionNumber,
+        parent: e.data?.parent,
+        message: undefined,
+        timestamp: undefined,
+        branch: undefined,
+      };
+      revisions.push(current);
+    } else if (e.tag === "METADATA" && current) {
+      const key = e.data?.key;
+      const value = metaValue(e.data?.value);
+      if (key === "message") current.message = value;
+      else if (key === "timestamp") current.timestamp = value;
+      else if (key === "branch") current.branch = value;
+    }
+  }
+  return revisions;
+}
+
+/**
+ * Reduce status events to a branch summary plus the list of changed files.
+ * @param {LoreEvt[]} events
+ */
+export function status(events) {
+  let branch = null;
+  let revision = null;
+  const files = [];
+  let summary = null;
+  for (const e of events) {
+    if (e.tag === "REPOSITORY_STATUS_REVISION") {
+      branch = e.data?.branchName ?? branch;
+      revision = e.data?.revision ?? revision;
+    } else if (e.tag === "REPOSITORY_STATUS_FILE") {
+      files.push(e.data);
+    } else if (e.tag === "REPOSITORY_STATUS_SUMMARY") {
+      summary = e.data;
+    }
+  }
+  return { branch, revision, files, summary };
+}
+
+/** @param {LoreEvt[]} events */
+export function branches(events) {
+  return events.filter((e) => e.tag === "BRANCH_LIST_ENTRY").map((e) => e.data);
+}
+
+/** @param {LoreEvt[]} events */
+export function diff(events) {
+  return events
+    .filter((e) => e.tag === "FILE_DIFF" || e.tag === "REVISION_DIFF_FILE")
+    .map((e) => e.data);
+}
+
+/** Branch/revision summary used to enrich the repo list. @param {LoreEvt[]} events */
+export function repoSummary(events) {
+  for (const e of events) {
+    if (e.tag === "REPOSITORY_STATUS_REVISION") {
+      return {
+        branch: e.data?.branchName,
+        revision: e.data?.revision,
+        repository: e.data?.repository,
+      };
+    }
+  }
+  return {};
+}

--- a/lore-web/server/transforms.mjs
+++ b/lore-web/server/transforms.mjs
@@ -99,6 +99,31 @@ export function remoteRepos(events) {
     .map((e) => ({ id: e.data?.id, name: e.data?.name }));
 }
 
+/** Collect repository metadata key/values from `repositoryMetadataGet`. @param {LoreEvt[]} events */
+export function metadata(events) {
+  /** @type {Record<string, any>} */
+  const out = {};
+  for (const e of events) {
+    if (e.tag === "METADATA" && e.data?.key != null) out[e.data.key] = metaValue(e.data.value);
+  }
+  return out;
+}
+
+/**
+ * Split a repository `name` metadata value into its organization prefix and bare
+ * repository name. Lore encodes the org as an `org/repo` prefix on the name (it
+ * comes from the path of the create/clone URL); everything before the first slash
+ * is the organization, the remainder is the repository name.
+ * @param {string|undefined} name
+ * @returns {{ organization: string, repoName: string, name: string }}
+ */
+export function splitOrg(name) {
+  const full = typeof name === "string" ? name : "";
+  const slash = full.indexOf("/");
+  if (slash === -1) return { organization: "", repoName: full, name: full };
+  return { organization: full.slice(0, slash), repoName: full.slice(slash + 1), name: full };
+}
+
 /** Branch/revision summary used to enrich the repo list. @param {LoreEvt[]} events */
 export function repoSummary(events) {
   for (const e of events) {

--- a/lore-web/server/transforms.mjs
+++ b/lore-web/server/transforms.mjs
@@ -92,6 +92,13 @@ export function diff(events) {
     .map((e) => e.data);
 }
 
+/** Repositories a server hosts, from `repositoryList`. @param {LoreEvt[]} events */
+export function remoteRepos(events) {
+  return events
+    .filter((e) => e.tag === "REPOSITORY_LIST_ENTRY")
+    .map((e) => ({ id: e.data?.id, name: e.data?.name }));
+}
+
 /** Branch/revision summary used to enrich the repo list. @param {LoreEvt[]} events */
 export function repoSummary(events) {
   for (const e of events) {

--- a/lore-web/server/watcher.mjs
+++ b/lore-web/server/watcher.mjs
@@ -1,0 +1,63 @@
+// Per-repo filesystem watcher. When a tracked working copy changes on disk, we
+// notify the browser to refetch — this is what makes lists live instead of
+// stale-until-restart. Built on node:fs.watch (recursive is supported on
+// Windows and macOS); changes are debounced so a burst of writes yields one
+// refresh.
+
+import { watch } from "node:fs";
+import { join } from "node:path";
+import { log } from "./log.mjs";
+
+/** @type {Map<string, { watchers: import("node:fs").FSWatcher[], timer: NodeJS.Timeout|null }>} */
+const active = new Map();
+
+const DEBOUNCE_MS = 400;
+
+/**
+ * Start watching a repo's working tree and its .lore metadata dir. Calling this
+ * again for an already-watched path is a no-op.
+ * @param {string} repoPath
+ * @param {() => void} onChange invoked (debounced) when anything changes
+ */
+export function watchRepo(repoPath, onChange) {
+  if (active.has(repoPath)) return;
+  const entry = { watchers: /** @type {import("node:fs").FSWatcher[]} */ ([]), timer: null };
+
+  const fire = () => {
+    if (entry.timer) clearTimeout(entry.timer);
+    entry.timer = setTimeout(() => {
+      entry.timer = null;
+      onChange();
+    }, DEBOUNCE_MS);
+  };
+
+  // Watch the working tree (recursive) for content changes, and the .lore dir
+  // for new revisions/branch updates committed by the CLI or a remote push.
+  for (const target of [repoPath, join(repoPath, ".lore")]) {
+    try {
+      const w = watch(target, { recursive: true }, fire);
+      w.on("error", (err) => log.debug("watch error", { target, error: err.message }));
+      entry.watchers.push(w);
+    } catch (err) {
+      log.debug("watch failed", { target, error: err instanceof Error ? err.message : String(err) });
+    }
+  }
+
+  active.set(repoPath, entry);
+  log.debug("watching repo", { repoPath, watchers: entry.watchers.length });
+}
+
+/** Stop watching a repo. @param {string} repoPath */
+export function unwatchRepo(repoPath) {
+  const entry = active.get(repoPath);
+  if (!entry) return;
+  if (entry.timer) clearTimeout(entry.timer);
+  for (const w of entry.watchers) {
+    try {
+      w.close();
+    } catch {
+      // Already closed or the path vanished; nothing to do.
+    }
+  }
+  active.delete(repoPath);
+}

--- a/lore-web/setup.bat
+++ b/lore-web/setup.bat
@@ -1,0 +1,63 @@
+@echo off
+REM Set up lore-web: check and install its dependencies, then install the SDK.
+REM Safe to re-run. Works from anywhere (uses the script's own folder).
+REM
+REM Networking (VPN/tunnel/port forwarding to reach a server) is intentionally
+REM out of scope here -- arrange that yourself.
+setlocal
+cd /d "%~dp0"
+
+echo [lore-web] Checking dependencies...
+
+REM --- Node.js (required) ---
+where node >nul 2>nul
+if errorlevel 1 goto :no_node
+goto :have_node
+
+:no_node
+echo [lore-web] Node.js was not found.
+where winget >nul 2>nul
+if errorlevel 1 (
+  echo            Install Node.js 18-24 from https://nodejs.org/ and re-run setup.bat.
+  exit /b 1
+)
+choice /C YN /M "[lore-web] Install Node.js LTS via winget now"
+if errorlevel 2 (
+  echo            Install Node.js 18-24 from https://nodejs.org/ and re-run setup.bat.
+  exit /b 1
+)
+winget install -e --id OpenJS.NodeJS.LTS --accept-source-agreements --accept-package-agreements
+echo.
+echo [lore-web] Node.js installed. Close this window, open a new one, and run
+echo            setup.bat again so the updated PATH takes effect.
+exit /b 0
+
+:have_node
+echo [lore-web] Installing npm dependencies ^(npm install^)...
+call npm install
+if errorlevel 1 (
+  echo [lore-web] npm install failed. Check your internet connection and try again.
+  exit /b 1
+)
+
+REM --- lore CLI (needed to log in to a server) ---
+where lore >nul 2>nul
+if errorlevel 1 goto :no_lore
+goto :done
+
+:no_lore
+echo [lore-web] The 'lore' CLI was not found.
+choice /C YN /M "[lore-web] Install it now via the official Lore installer"
+if errorlevel 2 (
+  echo            Install it later from:
+  echo              https://epicgames.github.io/lore/how-to/install-lore-cli/
+  goto :done
+)
+powershell -NoProfile -ExecutionPolicy Bypass -Command "irm https://raw.githubusercontent.com/EpicGames/lore/main/scripts/install.ps1 | iex"
+echo [lore-web] If 'lore' is still not found, open a new terminal for PATH to update.
+
+:done
+echo.
+echo [lore-web] Setup complete. Run start.bat ^(or: npm start^) to launch.
+echo            Before syncing, make sure this machine can reach your Lore server's host.
+endlocal

--- a/lore-web/start.bat
+++ b/lore-web/start.bat
@@ -10,5 +10,10 @@ if not exist "node_modules\@lore-vcs\sdk" (
   if errorlevel 1 exit /b 1
 )
 
+REM Stop any instance already running so a restart always loads current code.
+if "%LORE_WEB_PORT%"=="" (set "LWPORT=7420") else (set "LWPORT=%LORE_WEB_PORT%")
+echo [lore-web] Stopping any instance on port %LWPORT%...
+powershell -NoProfile -Command "Get-NetTCPConnection -LocalPort %LWPORT% -State Listen -ErrorAction SilentlyContinue | Select-Object -ExpandProperty OwningProcess -Unique | ForEach-Object { Stop-Process -Id $_ -Force -ErrorAction SilentlyContinue }"
+
 npm start
 endlocal

--- a/lore-web/start.bat
+++ b/lore-web/start.bat
@@ -1,0 +1,14 @@
+@echo off
+REM Launch lore-web and open it in the default browser.
+REM Runs setup automatically on first use.
+setlocal
+cd /d "%~dp0"
+
+if not exist "node_modules\@lore-vcs\sdk" (
+  echo [lore-web] First run - installing dependencies...
+  call "%~dp0setup.bat"
+  if errorlevel 1 exit /b 1
+)
+
+npm start
+endlocal

--- a/lore-web/test/loreignore.test.mjs
+++ b/lore-web/test/loreignore.test.mjs
@@ -1,0 +1,92 @@
+// .loreignore management tests. Operate on a throwaway temp directory — no SDK
+// and no repository, just the file shuffling the helpers perform.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, readFileSync, existsSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { setupLoreignore, appendIgnorePattern, hasLoreignore } from "../server/loreignore.mjs";
+
+function freshRepo() {
+  return mkdtempSync(join(tmpdir(), "loreignore-"));
+}
+
+test("setup seeds .loreignore from .gitignore and ignores Git's files", () => {
+  const dir = freshRepo();
+  try {
+    writeFileSync(join(dir, ".gitignore"), "node_modules/\n*.log\n");
+    const result = setupLoreignore(dir);
+    assert.equal(result.created, true);
+    assert.equal(result.gitignoreUpdated, true);
+
+    const lore = readFileSync(join(dir, ".loreignore"), "utf8");
+    assert.match(lore, /node_modules\//);
+    assert.match(lore, /\*\.log/);
+    assert.match(lore, /^\.git\/$/m);
+    assert.match(lore, /^\.gitignore$/m);
+
+    const git = readFileSync(join(dir, ".gitignore"), "utf8");
+    assert.match(git, /^\.lore\/$/m);
+    assert.match(git, /^\.loreignore$/m);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("setup creates .loreignore even without a .gitignore", () => {
+  const dir = freshRepo();
+  try {
+    const result = setupLoreignore(dir);
+    assert.equal(result.created, true);
+    assert.equal(result.gitignoreUpdated, false);
+    assert.ok(hasLoreignore(dir));
+    assert.equal(existsSync(join(dir, ".gitignore")), false);
+    const lore = readFileSync(join(dir, ".loreignore"), "utf8");
+    assert.match(lore, /^\.git\/$/m);
+    assert.match(lore, /^\.gitignore$/m);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("setup is idempotent — no duplicate entries on re-run", () => {
+  const dir = freshRepo();
+  try {
+    writeFileSync(join(dir, ".gitignore"), "dist/\n");
+    setupLoreignore(dir);
+    setupLoreignore(dir);
+    const lore = readFileSync(join(dir, ".loreignore"), "utf8");
+    assert.equal(lore.match(/^\.git\/$/gm).length, 1);
+    const git = readFileSync(join(dir, ".gitignore"), "utf8");
+    assert.equal(git.match(/^\.lore\/$/gm).length, 1);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("setup tolerates trailing-slash variants already present", () => {
+  const dir = freshRepo();
+  try {
+    // .git (no slash) should be recognized as the same entry as .git/.
+    writeFileSync(join(dir, ".loreignore"), ".git\n");
+    setupLoreignore(dir);
+    const lore = readFileSync(join(dir, ".loreignore"), "utf8");
+    assert.equal(lore.match(/^\.git\b/gm).length, 1);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("appendIgnorePattern adds a pattern once and reports duplicates", () => {
+  const dir = freshRepo();
+  try {
+    assert.equal(appendIgnorePattern(dir, "*.tmp"), true);
+    assert.equal(appendIgnorePattern(dir, "*.tmp"), false);
+    const lore = readFileSync(join(dir, ".loreignore"), "utf8");
+    assert.equal(lore.match(/^\*\.tmp$/gm).length, 1);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/lore-web/test/loreignore.test.mjs
+++ b/lore-web/test/loreignore.test.mjs
@@ -3,11 +3,11 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, writeFileSync, readFileSync, existsSync, rmSync } from "node:fs";
+import { mkdtempSync, writeFileSync, readFileSync, existsSync, rmSync, chmodSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
-import { setupLoreignore, appendIgnorePattern, hasLoreignore } from "../server/loreignore.mjs";
+import { setupLoreignore, appendIgnorePattern, hasLoreignore, hasP4ignore } from "../server/loreignore.mjs";
 
 function freshRepo() {
   return mkdtempSync(join(tmpdir(), "loreignore-"));
@@ -86,6 +86,113 @@ test("appendIgnorePattern adds a pattern once and reports duplicates", () => {
     assert.equal(appendIgnorePattern(dir, "*.tmp"), false);
     const lore = readFileSync(join(dir, ".loreignore"), "utf8");
     assert.equal(lore.match(/^\*\.tmp$/gm).length, 1);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("setup seeds .loreignore from .p4ignore and ignores Perforce's files", () => {
+  const dir = freshRepo();
+  try {
+    writeFileSync(join(dir, ".p4ignore"), "*.p4d\nbuild/\n");
+    const result = setupLoreignore(dir);
+    assert.equal(result.created, true);
+    assert.equal(result.p4ignoreUpdated, true);
+
+    const lore = readFileSync(join(dir, ".loreignore"), "utf8");
+    assert.match(lore, /\*\.p4d/);
+    assert.match(lore, /build\//);
+    assert.match(lore, /^\.p4\/$/m);
+    assert.match(lore, /^\.p4ignore$/m);
+
+    const p4 = readFileSync(join(dir, ".p4ignore"), "utf8");
+    assert.match(p4, /^\.lore\/$/m);
+    assert.match(p4, /^\.loreignore$/m);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("setup converts Perforce patterns (with ...) to gitignore format", () => {
+  const dir = freshRepo();
+  try {
+    // Perforce uses `...` for recursive matching; must convert to gitignore `/`.
+    writeFileSync(
+      join(dir, ".p4ignore"),
+      "# Unreal generated folders\n**/Intermediate/...\n**/Saved/...\n.vs/...\n*.log\n",
+    );
+    const result = setupLoreignore(dir);
+    assert.equal(result.created, true);
+
+    const lore = readFileSync(join(dir, ".loreignore"), "utf8");
+    // Perforce `**/Intermediate/...` should be converted to `**/Intermediate/` (gitignore treats `/` as recursive).
+    assert.match(lore, /^\*\*\/Intermediate\/$/m);
+    assert.match(lore, /^\*\*\/Saved\/$/m);
+    assert.match(lore, /^\.vs\/$/m);
+    assert.match(lore, /^\*\.log$/m);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("setup merges patterns from both .gitignore and .p4ignore without duplicates", () => {
+  const dir = freshRepo();
+  try {
+    writeFileSync(join(dir, ".gitignore"), "node_modules/\n*.log\n");
+    writeFileSync(join(dir, ".p4ignore"), "*.log\nbuild/\n");
+    const result = setupLoreignore(dir);
+    assert.equal(result.created, true);
+    assert.equal(result.gitignoreUpdated, true);
+    assert.equal(result.p4ignoreUpdated, true);
+
+    const lore = readFileSync(join(dir, ".loreignore"), "utf8");
+    assert.match(lore, /node_modules\//);
+    assert.match(lore, /build\//);
+    // *.log should appear only once despite being in both source files
+    assert.equal(lore.match(/^\*\.log$/gm)?.length ?? 0, 1);
+    assert.match(lore, /^\.git\/$/m);
+    assert.match(lore, /^\.p4\/$/m);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("setup seeds .loreignore even when .p4ignore is read-only (Perforce)", () => {
+  const dir = freshRepo();
+  const p4 = join(dir, ".p4ignore");
+  try {
+    writeFileSync(p4, "build/\n");
+    // Perforce leaves versioned files read-only until `p4 edit`.
+    chmodSync(p4, 0o444);
+    const result = setupLoreignore(dir);
+    // The important half still succeeds: .loreignore is seeded from .p4ignore.
+    assert.equal(result.created, true);
+    const lore = readFileSync(join(dir, ".loreignore"), "utf8");
+    assert.match(lore, /build\//);
+    assert.match(lore, /^\.p4ignore$/m);
+    // The counterpart write into the read-only .p4ignore is reported, not thrown.
+    assert.equal(result.p4ignoreUpdated, false);
+    assert.equal(result.p4ignoreBlocked, true);
+  } finally {
+    chmodSync(p4, 0o644);
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("setup is idempotent with both .gitignore and .p4ignore", () => {
+  const dir = freshRepo();
+  try {
+    writeFileSync(join(dir, ".gitignore"), "dist/\n");
+    writeFileSync(join(dir, ".p4ignore"), "build/\n");
+    setupLoreignore(dir);
+    setupLoreignore(dir);
+    const lore = readFileSync(join(dir, ".loreignore"), "utf8");
+    assert.equal(lore.match(/^\.git\/$/gm).length, 1);
+    assert.equal(lore.match(/^\.p4\/$/gm).length, 1);
+    const git = readFileSync(join(dir, ".gitignore"), "utf8");
+    assert.equal(git.match(/^\.lore\/$/gm).length, 1);
+    const p4 = readFileSync(join(dir, ".p4ignore"), "utf8");
+    assert.equal(p4.match(/^\.lore\/$/gm).length, 1);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/lore-web/test/store.test.mjs
+++ b/lore-web/test/store.test.mjs
@@ -1,0 +1,41 @@
+// Store unit tests. Each run uses its own throwaway store file (env-injected
+// before import) so tests stay isolated and leave no shared state behind.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { rmSync } from "node:fs";
+
+const storeFile = join(tmpdir(), `lore-web-store-test-${process.pid}.json`);
+process.env.LORE_WEB_STORE = storeFile;
+
+const store = await import("../server/store.mjs");
+
+test.after(() => rmSync(storeFile, { force: true }));
+
+test("add and list a repo", () => {
+  store.addRepo("D:/repo-a", "A");
+  const repos = store.listRepos();
+  assert.equal(repos.length, 1);
+  assert.equal(repos[0].label, "A");
+});
+
+test("relabel an existing repo without duplicating", () => {
+  store.addRepo("D:/repo-a", "A-renamed");
+  const repos = store.listRepos().filter((r) => r.path === "D:/repo-a");
+  assert.equal(repos.length, 1);
+  assert.equal(repos[0].label, "A-renamed");
+});
+
+test("removing a dangling repo always succeeds (issue #4)", () => {
+  // The folder never has to exist — removal must never be blocked.
+  store.addRepo("D:/repo-gone", "ghost");
+  const removed = store.removeRepo("D:/repo-gone");
+  assert.equal(removed, true);
+  assert.ok(!store.listRepos().some((r) => r.path === "D:/repo-gone"));
+});
+
+test("removing an untracked path reports false, does not throw", () => {
+  assert.equal(store.removeRepo("D:/never-added"), false);
+});

--- a/lore-web/test/transforms.test.mjs
+++ b/lore-web/test/transforms.test.mjs
@@ -24,6 +24,43 @@ test("history groups metadata under each revision entry", () => {
   assert.equal(revs[1].timestamp, undefined);
 });
 
+test("metadata collects key/value pairs, unwrapping Lore metadata values", () => {
+  const events = [
+    ev("METADATA", { key: "name", value: { tag: 6, data: "acme/widgets", tagName: "string" } }),
+    ev("METADATA", { key: "description", value: "plain" }),
+    ev("COMPLETE", { status: 0 }),
+  ];
+  const meta = xform.metadata(events);
+  assert.equal(meta.name, "acme/widgets");
+  assert.equal(meta.description, "plain");
+});
+
+test("splitOrg separates the org prefix from the repository name", () => {
+  assert.deepEqual(xform.splitOrg("acme/widgets"), {
+    organization: "acme",
+    repoName: "widgets",
+    name: "acme/widgets",
+  });
+});
+
+test("splitOrg treats a name with no slash as having no organization", () => {
+  assert.deepEqual(xform.splitOrg("lore-web"), {
+    organization: "",
+    repoName: "lore-web",
+    name: "lore-web",
+  });
+});
+
+test("splitOrg keeps only the first slash as the org separator", () => {
+  const out = xform.splitOrg("org/team/repo");
+  assert.equal(out.organization, "org");
+  assert.equal(out.repoName, "team/repo");
+});
+
+test("splitOrg tolerates a missing name", () => {
+  assert.deepEqual(xform.splitOrg(undefined), { organization: "", repoName: "", name: "" });
+});
+
 test("status splits branch summary from changed files", () => {
   const events = [
     ev("REPOSITORY_STATUS_REVISION", { branchName: "main", revision: "r1" }),

--- a/lore-web/test/transforms.test.mjs
+++ b/lore-web/test/transforms.test.mjs
@@ -45,3 +45,16 @@ test("branches keeps only BRANCH_LIST_ENTRY events", () => {
   ];
   assert.deepEqual(xform.branches(events), [{ name: "main" }]);
 });
+
+test("remoteRepos keeps only REPOSITORY_LIST_ENTRY events", () => {
+  const events = [
+    ev("REPOSITORY_LIST_BEGIN", {}),
+    ev("REPOSITORY_LIST_ENTRY", { id: "abc", name: "ui-demo" }),
+    ev("REPOSITORY_LIST_ENTRY", { id: "def", name: "scratch" }),
+    ev("REPOSITORY_LIST_END", {}),
+  ];
+  assert.deepEqual(xform.remoteRepos(events), [
+    { id: "abc", name: "ui-demo" },
+    { id: "def", name: "scratch" },
+  ]);
+});

--- a/lore-web/test/transforms.test.mjs
+++ b/lore-web/test/transforms.test.mjs
@@ -1,0 +1,47 @@
+// Transform unit tests. Pure functions over synthetic event arrays — no SDK, no
+// repository, no filesystem. Event shapes mirror what sdk.collect() yields.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import * as xform from "../server/transforms.mjs";
+
+const ev = (tag, data) => ({ tag, tagRaw: 0, data });
+
+test("history groups metadata under each revision entry", () => {
+  const events = [
+    ev("REVISION_HISTORY_ENTRY", { revision: "abc", revisionNumber: 2, parent: ["x"] }),
+    ev("METADATA", { key: "message", value: { tag: 6, data: "second", tagName: "string" } }),
+    ev("METADATA", { key: "timestamp", value: { tag: 5, data: 1700, tagName: "numeric" } }),
+    ev("REVISION_HISTORY_ENTRY", { revision: "def", revisionNumber: 1, parent: [] }),
+    ev("METADATA", { key: "message", value: { tag: 6, data: "first", tagName: "string" } }),
+    ev("COMPLETE", { status: 0 }),
+  ];
+  const revs = xform.history(events);
+  assert.equal(revs.length, 2);
+  assert.equal(revs[0].message, "second");
+  assert.equal(revs[0].timestamp, 1700);
+  assert.equal(revs[1].message, "first");
+  assert.equal(revs[1].timestamp, undefined);
+});
+
+test("status splits branch summary from changed files", () => {
+  const events = [
+    ev("REPOSITORY_STATUS_REVISION", { branchName: "main", revision: "r1" }),
+    ev("REPOSITORY_STATUS_FILE", { path: "a.txt", flagStaged: true }),
+    ev("REPOSITORY_STATUS_FILE", { path: "b.txt", flagStaged: false }),
+    ev("COMPLETE", { status: 0 }),
+  ];
+  const s = xform.status(events);
+  assert.equal(s.branch, "main");
+  assert.equal(s.revision, "r1");
+  assert.equal(s.files.length, 2);
+});
+
+test("branches keeps only BRANCH_LIST_ENTRY events", () => {
+  const events = [
+    ev("BRANCH_LIST_BEGIN", {}),
+    ev("BRANCH_LIST_ENTRY", { name: "main" }),
+    ev("BRANCH_LIST_END", {}),
+  ];
+  assert.deepEqual(xform.branches(events), [{ name: "main" }]);
+});

--- a/lore-web/web/app.js
+++ b/lore-web/web/app.js
@@ -13,8 +13,6 @@ const state = {
   selectedFile: null,
 };
 
-// ---- API helpers ---------------------------------------------------------
-
 async function apiGet(path) {
   const res = await fetch(path);
   const body = await res.json();
@@ -64,8 +62,6 @@ function toast(msg, isErr) {
   setTimeout(() => (t.hidden = true), isErr ? 5000 : 2500);
 }
 
-// ---- Repo list -----------------------------------------------------------
-
 async function loadRepos() {
   try {
     const { repos } = await apiGet("/api/repos");
@@ -96,18 +92,63 @@ function renderRepos() {
   }
 }
 
+/** Pick a folder, then track it — initializing a new repo if it isn't one yet. */
 async function addRepo() {
-  const input = $("#add-path");
-  const path = input.value.trim();
+  const path = await pickFolder({ title: "Add a repository" });
   if (!path) return;
+  let url;
   try {
-    await apiPost("/api/repos", { path, label: path.split(/[\\/]/).pop() });
-    input.value = "";
+    // Brand-new folders are initialized; let the user review/edit the URL first.
+    const info = await apiGet(`/api/init-url?path=${encodeURIComponent(path)}`);
+    if (!info.isRepo) {
+      url = await confirmInit(path, info.url);
+      if (url === null) return; // cancelled
+    }
+  } catch (err) {
+    return toast(err.message, true);
+  }
+  try {
+    const { initialized } = await apiPost("/api/repos", { path, url });
     await loadRepos();
     selectRepo(path);
+    toast(initialized ? "Repository initialized" : "Repository added");
   } catch (err) {
     toast(err.message, true);
   }
+}
+
+/**
+ * Show the generated repository URL for a soon-to-be-initialized folder in an
+ * editable box. Resolves to the (possibly edited) URL, or null if cancelled.
+ */
+let initResolve = null;
+function confirmInit(path, suggestedUrl) {
+  $("#init-folder").textContent = `${path} is not a Lore repository yet — it will be created with:`;
+  $("#init-url").value = suggestedUrl || "";
+  $("#init-dialog").showModal();
+  return new Promise((resolve) => {
+    initResolve = resolve;
+  });
+}
+
+function initFinish(url) {
+  $("#init-dialog").close();
+  const resolve = initResolve;
+  initResolve = null;
+  resolve?.(url);
+}
+
+function wireInit() {
+  $("#init-cancel").onclick = () => initFinish(null);
+  $("#init-go").onclick = () => {
+    const v = $("#init-url").value.trim();
+    if (!v) return toast("Repository URL required", true);
+    initFinish(v);
+  };
+  $("#init-dialog").addEventListener("cancel", (e) => {
+    e.preventDefault();
+    initFinish(null);
+  });
 }
 
 async function removeRepo(path) {
@@ -123,8 +164,6 @@ async function removeRepo(path) {
     toast(err.message, true);
   }
 }
-
-// ---- Active repo views ---------------------------------------------------
 
 function showEmpty() {
   $("#empty").hidden = false;
@@ -353,8 +392,6 @@ async function loadBranches(pathEnc) {
   }
 }
 
-// ---- Remote operations (streamed) ---------------------------------------
-
 async function runOp(title, path, payload) {
   const overlay = $("#op-overlay");
   const logEl = $("#op-log");
@@ -387,8 +424,6 @@ async function runOp(title, path, payload) {
   await refreshActive();
 }
 
-// ---- Live connection (SSE) ----------------------------------------------
-
 function connectSSE() {
   const es = new EventSource("/events");
   es.onopen = () => $("#conn").classList.add("live");
@@ -408,11 +443,72 @@ function connectSSE() {
   };
 }
 
-// ---- Wiring --------------------------------------------------------------
+// The browser can't hand the server a real filesystem path, so the folder picker
+// drives a server-backed directory browser (/api/browse) instead of typed paths.
+const picker ={ cur: "", parent: null, sep: "\\", resolve: null };
+
+async function pickerNavigate(path) {
+  const data = await apiGet(`/api/browse?path=${encodeURIComponent(path ?? "")}`);
+  picker.cur = data.path;
+  picker.parent = data.parent;
+  picker.sep = data.sep || picker.sep;
+  $("#picker-cur").textContent = data.path || "This PC";
+  $("#picker-up").disabled = data.parent === null;
+  const ul = $("#picker-list");
+  ul.innerHTML = "";
+  if (data.entries.length === 0) {
+    ul.innerHTML = `<li class="muted">— no sub-folders —</li>`;
+  }
+  for (const e of data.entries) {
+    const li = document.createElement("li");
+    li.innerHTML = `<span class="p-name" title="${e.path}">${e.name}</span>${
+      e.isRepo ? `<span class="p-tag">lore</span>` : ""
+    }`;
+    li.onclick = () => pickerNavigate(e.path);
+    ul.appendChild(li);
+  }
+}
+
+/**
+ * Open the folder picker and resolve to a chosen absolute path (or null on
+ * cancel). With { allowNew: true } the user may type a new sub-folder name to
+ * create under the browsed directory (used for a clone destination).
+ */
+function pickFolder({ title, allowNew } = {}) {
+  $("#picker-title").textContent = title || "Select a folder";
+  $("#picker-new").hidden = !allowNew;
+  $("#picker-newname").value = "";
+  pickerNavigate("").catch((err) => toast(err.message, true));
+  $("#picker-dialog").showModal();
+  return new Promise((resolve) => {
+    picker.resolve = resolve;
+  });
+}
+
+function pickerFinish(path) {
+  $("#picker-dialog").close();
+  const resolve = picker.resolve;
+  picker.resolve = null;
+  resolve?.(path);
+}
+
+function wirePicker() {
+  $("#picker-up").onclick = () => picker.parent !== null && pickerNavigate(picker.parent);
+  $("#picker-cancel").onclick = () => pickerFinish(null);
+  $("#picker-choose").onclick = () => {
+    if (!picker.cur) return toast("Open a folder first", true);
+    const name = $("#picker-newname")?.value.trim();
+    const path = !$("#picker-new").hidden && name ? picker.cur + picker.sep + name : picker.cur;
+    pickerFinish(path);
+  };
+  $("#picker-dialog").addEventListener("cancel", (e) => {
+    e.preventDefault();
+    pickerFinish(null);
+  });
+}
 
 function wire() {
   $("#add-btn").onclick = addRepo;
-  $("#add-path").addEventListener("keydown", (e) => e.key === "Enter" && addRepo());
   $("#refresh-btn").onclick = refreshActive;
   $("#commit-btn").onclick = commit;
 
@@ -421,6 +517,10 @@ function wire() {
   $("#op-close").onclick = () => ($("#op-overlay").hidden = true);
 
   $("#clone-btn").onclick = () => $("#clone-dialog").showModal();
+  $("#clone-dest-browse").onclick = async () => {
+    const dest = await pickFolder({ title: "Clone destination", allowNew: true });
+    if (dest) $("#clone-dest").value = dest;
+  };
   $("#clone-go").onclick = (e) => {
     const url = $("#clone-url").value.trim();
     const dest = $("#clone-dest").value.trim();
@@ -433,6 +533,9 @@ function wire() {
       await loadRepos();
     }, 0);
   };
+
+  wirePicker();
+  wireInit();
 
   $$(".tab").forEach((tab) => {
     tab.onclick = () => {
@@ -450,8 +553,6 @@ function wire() {
   // Slow poll catches revisions pushed by the other machine (no local fs event).
   setInterval(() => state.active && loadHistory(encodeURIComponent(state.active)), 10000);
 }
-
-// ---- Boot ----------------------------------------------------------------
 
 wire();
 connectSSE();

--- a/lore-web/web/app.js
+++ b/lore-web/web/app.js
@@ -11,6 +11,8 @@ const state = {
   active: null, // repo path
   tab: "changes",
   selectedFile: null,
+  defaultRemote: "",
+  discoveredServers: [],
 };
 
 async function apiGet(path) {
@@ -736,6 +738,72 @@ async function deleteServerRepo(r) {
   }
 }
 
+/** Load and display the current remote server configuration. */
+async function loadConfig() {
+  try {
+    const data = await apiGet("/api/config");
+    state.defaultRemote = data.defaultRemote || "";
+    state.discoveredServers = data.discoveredServers || [];
+    $("#settings-remote").value = state.defaultRemote;
+    renderDiscoveredServers();
+  } catch (err) {
+    toast(err.message, true);
+  }
+}
+
+/** Display the list of discovered servers in the settings dialog. */
+function renderDiscoveredServers() {
+  const container = $("#discovered-servers");
+  const list = $("#discovered-list");
+  if (state.discoveredServers.length === 0) {
+    container.hidden = true;
+    return;
+  }
+  container.hidden = false;
+  list.innerHTML = "";
+  for (const server of state.discoveredServers) {
+    const li = document.createElement("li");
+    li.textContent = server.url;
+    li.onclick = () => {
+      $("#settings-remote").value = server.url;
+    };
+    list.appendChild(li);
+  }
+}
+
+/** Trigger manual discovery of Lore servers and update the list. */
+async function discoverServers() {
+  const btn = $("#settings-discover");
+  btn.disabled = true;
+  try {
+    const data = await apiGet("/api/discover");
+    state.discoveredServers = data.discoveredServers || [];
+    if (state.discoveredServers.length === 0) {
+      toast("No Lore servers found on the local network");
+    } else {
+      toast(`Found ${state.discoveredServers.length} server${state.discoveredServers.length === 1 ? "" : "s"}`);
+    }
+    renderDiscoveredServers();
+  } catch (err) {
+    toast(err.message, true);
+  } finally {
+    btn.disabled = false;
+  }
+}
+
+/** Save the remote server configuration and refresh repos. */
+async function saveConfig() {
+  const url = $("#settings-remote").value.trim();
+  try {
+    await apiPost("/api/config", { defaultRemote: url });
+    toast(url ? "Remote server configured" : "Remote server cleared");
+    state.defaultRemote = url;
+    await loadRepos();
+  } catch (err) {
+    toast(err.message, true);
+  }
+}
+
 function wire() {
   $("#add-btn").onclick = addRepo;
   $("#refresh-btn").onclick = refreshActive;
@@ -814,6 +882,21 @@ function wire() {
       }
     }, 0);
   };
+
+  // Settings dialog
+  $("#settings-btn").onclick = async () => {
+    await loadConfig();
+    $("#settings-dialog").showModal();
+  };
+  $("#settings-discover").onclick = () => discoverServers();
+  $("#settings-go").onclick = () => {
+    saveConfig();
+    $("#settings-dialog").close();
+  };
+  $("#settings-dialog").addEventListener("cancel", (e) => {
+    e.preventDefault();
+    $("#settings-dialog").close();
+  });
 
   wirePicker();
   wireInit();

--- a/lore-web/web/app.js
+++ b/lore-web/web/app.js
@@ -190,6 +190,13 @@ async function refreshActive() {
 }
 
 function fileBadge(f) {
+  // A directory that is itself a Lore working copy: a live nested repo. Offer to
+  // ignore it (see the changes bar) rather than track a repo-inside-a-repo.
+  if (f.nested) return ["nested", "badge-nested"];
+  // A directory (LoreNodeType.DIRECTORY = 0) reported with action DELETE that is
+  // no longer on disk is a *stale* nested-repo entry — a Lore zombie that no
+  // discard can clear (only "Repair repository" can). Not a real deletion.
+  if (f.type === 0 && f.action === 2) return ["stale", "badge-stale"];
   if (f.action === 1) return ["A", "badge-A"];
   if (f.action === 2) return ["D", "badge-D"];
   if (f.action === 3) return ["R", "badge-M"];
@@ -205,6 +212,7 @@ async function loadStatus(pathEnc) {
     renderFiles($("#staged-files"), staged, "unstage");
     renderFiles($("#unstaged-files"), unstaged, "stage");
     $("#commit-btn").disabled = staged.length === 0;
+    updateChangesBar(data);
   } catch (err) {
     toast(err.message, true);
   }
@@ -223,9 +231,11 @@ function renderFiles(ul, files, action) {
       <span class="f-act ${cls}">${label}</span>
       <span class="f-path" title="${f.path}">${f.path}</span>
       <button class="f-do">${action === "stage" ? "Stage" : "Unstage"}</button>
+      <button class="f-ignore" title="Add to .loreignore">⊘</button>
       ${action === "stage" ? `<button class="f-reset" title="Discard changes">↺</button>` : ""}`;
     li.querySelector(".f-path").onclick = () => showDiff(f.path);
     li.querySelector(".f-do").onclick = () => fileAction(action, f.path);
+    li.querySelector(".f-ignore").onclick = () => openIgnoreMenu(f);
     li.querySelector(".f-reset")?.addEventListener("click", () => fileAction("reset", f.path));
     ul.appendChild(li);
   }
@@ -236,6 +246,143 @@ async function fileAction(action, file) {
     await apiPost(`/api/${action}`, { path: state.active, files: [file] });
     // SSE refresh will follow, but refetch now for immediate feedback.
     await loadStatus(encodeURIComponent(state.active));
+  } catch (err) {
+    toast(err.message, true);
+  }
+}
+
+/**
+ * The ignore patterns offered for a file: the file itself, its parent folder,
+ * and its extension. Patterns are gitignore-style with forward slashes (Lore's
+ * ignore syntax), regardless of the path separator the status used.
+ */
+function ignoreOptionsFor(f) {
+  const path = (f.path || "").replace(/\\/g, "/");
+  const sep = path.lastIndexOf("/");
+  const name = path.slice(sep + 1);
+  const parent = sep >= 0 ? path.slice(0, sep + 1) : "";
+  const opts = [];
+  if (f.type === 0) {
+    // A directory entry (e.g. a stale nested-repo marker): ignore the folder
+    // itself with a trailing slash. This is the way to clear nested-repo
+    // phantoms — Lore's status filter excludes ignored paths.
+    opts.push({ pattern: `${path}/`, label: "This folder" });
+  } else {
+    opts.push({ pattern: path, label: "This file" });
+    const dot = name.lastIndexOf(".");
+    if (dot > 0) opts.push({ pattern: `*${name.slice(dot)}`, label: "All files with this extension" });
+  }
+  if (parent) opts.push({ pattern: parent, label: "Its parent folder" });
+  return opts;
+}
+
+function openIgnoreMenu(f) {
+  const ul = $("#ignore-options");
+  ul.innerHTML = "";
+  for (const o of ignoreOptionsFor(f)) {
+    const li = document.createElement("li");
+    li.innerHTML = `<code>${o.pattern}</code><span class="muted">${o.label}</span>`;
+    li.onclick = () => {
+      $("#ignore-dialog").close();
+      ignorePattern(o.pattern);
+    };
+    ul.appendChild(li);
+  }
+  $("#ignore-dialog").showModal();
+}
+
+async function ignorePattern(pattern) {
+  try {
+    const { added } = await apiPost("/api/ignore", { path: state.active, pattern });
+    toast(added ? `Ignoring ${pattern}` : `${pattern} was already ignored`);
+    await loadStatus(encodeURIComponent(state.active));
+  } catch (err) {
+    toast(err.message, true);
+  }
+}
+
+async function initLoreignore() {
+  try {
+    const { created, gitignoreUpdated } = await apiPost("/api/init-loreignore", { path: state.active });
+    toast(created ? "Created .loreignore" : "Updated .loreignore");
+    if (gitignoreUpdated) toast("Updated .gitignore");
+    await loadStatus(encodeURIComponent(state.active));
+  } catch (err) {
+    toast(err.message, true);
+  }
+}
+
+function barButton(label, onclick, cls) {
+  const b = document.createElement("button");
+  b.className = cls || "ghost";
+  b.textContent = label;
+  b.onclick = onclick;
+  return b;
+}
+
+/**
+ * Populate the toolbar above the file lists with context actions: set up
+ * .loreignore, ignore live nested repos (so they never rot into zombies), and
+ * repair stale nested-repo entries that no discard can clear.
+ */
+function updateChangesBar(data) {
+  const bar = $(".changes-bar");
+  bar.innerHTML = "";
+  const files = data.files || [];
+  const nested = files.filter((f) => f.nested);
+  const stale = files.filter((f) => f.type === 0 && f.action === 2 && !f.nested);
+
+  if (data.hasLoreignore === false) {
+    bar.appendChild(barButton("Initialize .loreignore", initLoreignore));
+  }
+  if (nested.length) {
+    const n = nested.length;
+    const note = document.createElement("span");
+    note.className = "bar-note";
+    note.textContent = `${n} nested ${n === 1 ? "repository" : "repositories"} — ignore so Lore doesn't track a repo-in-a-repo`;
+    bar.appendChild(note);
+    bar.appendChild(barButton(`Ignore nested`, () => ignoreNested(nested)));
+  }
+  if (stale.length) {
+    const n = stale.length;
+    const note = document.createElement("span");
+    note.className = "bar-note warn";
+    note.textContent = `${n} stale nested ${n === 1 ? "entry" : "entries"} can't be discarded`;
+    bar.appendChild(note);
+    bar.appendChild(barButton("Repair repository…", repairRepository));
+  }
+  bar.hidden = bar.childElementCount === 0;
+}
+
+/** Add each live nested repo to .loreignore (as a folder pattern). */
+async function ignoreNested(list) {
+  try {
+    for (const f of list) {
+      const path = (f.path || "").replace(/\\/g, "/");
+      await apiPost("/api/ignore", { path: state.active, pattern: `${path}/` });
+    }
+    toast(`Ignored ${list.length} nested ${list.length === 1 ? "repo" : "repos"}`);
+    await loadStatus(encodeURIComponent(state.active));
+  } catch (err) {
+    toast(err.message, true);
+  }
+}
+
+/**
+ * Rebuild the repo's .lore to purge stale "zombie" entries Lore can't otherwise
+ * remove. Files are untouched; the server refuses if there is committed history.
+ */
+async function repairRepository() {
+  const ok = confirm(
+    "Rebuild this repository's index to clear stale entries?\n\n" +
+      "Your files are not touched, and the repository keeps its identity and remote. " +
+      "You can only do this before anything has been committed.",
+  );
+  if (!ok) return;
+  try {
+    await apiPost("/api/repair", { path: state.active });
+    toast("Repository repaired");
+    await refreshActive();
   } catch (err) {
     toast(err.message, true);
   }
@@ -511,6 +658,7 @@ function wire() {
   $("#add-btn").onclick = addRepo;
   $("#refresh-btn").onclick = refreshActive;
   $("#commit-btn").onclick = commit;
+  $("#ignore-cancel").onclick = () => $("#ignore-dialog").close();
 
   $("#sync-btn").onclick = () => runOp("Syncing…", "/api/sync", { path: state.active });
   $("#push-btn").onclick = () => runOp("Pushing…", "/api/push", { path: state.active });

--- a/lore-web/web/app.js
+++ b/lore-web/web/app.js
@@ -247,21 +247,88 @@ async function commit() {
 async function loadHistory(pathEnc) {
   try {
     const { revisions } = await apiGet(`/api/history?path=${pathEnc}&length=50`);
+    state.revisions = revisions;
+    // Skip the rebuild when nothing changed, so a background refresh (poll, focus,
+    // file-watch) does not collapse a revision the user has expanded.
+    const sig = revisions.map((r) => r.revision).join(",");
+    if (sig === state.historySig) return;
+    state.historySig = sig;
     const ul = $("#history-list");
     ul.innerHTML = "";
     for (const r of revisions) {
       const li = document.createElement("li");
       const when = r.timestamp ? new Date(r.timestamp).toLocaleString() : "";
       li.innerHTML = `
-        <div class="h-msg">${(r.message || "(no message)").split("\n")[0]}</div>
-        <div class="h-meta">
-          <span class="h-rev">#${r.revisionNumber} · ${(r.revision || "").slice(0, 12)}</span>
-          <span>${when}</span>
-        </div>`;
+        <div class="h-row">
+          <div class="h-msg">${(r.message || "(no message)").split("\n")[0]}</div>
+          <div class="h-meta">
+            <span class="h-rev">#${r.revisionNumber} · ${(r.revision || "").slice(0, 12)}</span>
+            <span>${when}</span>
+          </div>
+        </div>
+        <div class="rev-detail" hidden></div>`;
+      li.querySelector(".h-row").onclick = () => toggleRevision(r, li);
+      if (r.revision === state.openRevision) toggleRevision(r, li);
       ul.appendChild(li);
     }
   } catch (err) {
     toast(err.message, true);
+  }
+}
+
+/** Expand a revision to show the files it changed; collapse if already open. */
+async function toggleRevision(r, li) {
+  const detail = li.querySelector(".rev-detail");
+  if (!detail.hidden) {
+    detail.hidden = true;
+    li.classList.remove("open");
+    state.openRevision = null;
+    return;
+  }
+  detail.hidden = false;
+  li.classList.add("open");
+  state.openRevision = r.revision;
+  detail.innerHTML = `<div class="muted">Loading changes…</div>`;
+  const parent = (r.parent && r.parent[0]) || "";
+  try {
+    const { files } = await apiGet(
+      `/api/revision?path=${encodeURIComponent(state.active)}&revision=${r.revision}`,
+    );
+    if (!files.length) {
+      detail.innerHTML = `<div class="muted">No file changes in this revision.</div>`;
+      return;
+    }
+    detail.innerHTML = `<ul class="rev-files"></ul><pre class="rev-diff" hidden></pre>`;
+    const list = detail.querySelector(".rev-files");
+    for (const f of files) {
+      const [label, cls] = fileBadge(f);
+      const item = document.createElement("li");
+      item.innerHTML = `<span class="f-act ${cls}">${label}</span><span class="f-path" title="${f.path}">${f.path}</span>`;
+      item.onclick = () => showRevisionFileDiff(r, parent, f.path, detail);
+      list.appendChild(item);
+    }
+  } catch (err) {
+    detail.innerHTML = `<div class="muted">${err.message}</div>`;
+  }
+}
+
+/** Show one file's diff between a revision and its parent, inside the detail. */
+async function showRevisionFileDiff(r, parent, file, detail) {
+  const pre = detail.querySelector(".rev-diff");
+  detail.querySelectorAll(".rev-files li").forEach((el) =>
+    el.classList.toggle("sel", el.querySelector(".f-path")?.title === file),
+  );
+  pre.hidden = false;
+  pre.textContent = "Loading diff…";
+  try {
+    const url =
+      `/api/diff?path=${encodeURIComponent(state.active)}` +
+      `&file=${encodeURIComponent(file)}&source=${parent}&target=${r.revision}`;
+    const { diff } = await apiGet(url);
+    const patch = diff.map((d) => d.patch || "").join("\n");
+    pre.innerHTML = colorizeDiff(patch || "(no textual diff — binary file or no change)");
+  } catch (err) {
+    pre.textContent = err.message;
   }
 }
 

--- a/lore-web/web/app.js
+++ b/lore-web/web/app.js
@@ -469,12 +469,8 @@ async function commit() {
   if (!msg) return toast("Enter a commit message", true);
   $("#commit-btn").disabled = true;
   try {
-    await apiPost("/api/commit", { path: state.active, message: msg });
+    await runOp("Committing…", "/api/commit", { path: state.active, message: msg });
     $("#commit-msg").value = "";
-    toast("Committed");
-    await refreshActive();
-  } catch (err) {
-    toast(err.message, true);
   } finally {
     $("#commit-btn").disabled = false;
   }
@@ -589,26 +585,80 @@ async function loadBranches(pathEnc) {
   }
 }
 
+/** Format a byte count as a short human-readable string, for example "42.1 MB".
+ * @param {number} n bytes to format
+ * @returns {string} human-readable byte count
+ */
+function fmtBytes(n) {
+  if (!n) return "0 B";
+  const units = ["B", "KB", "MB", "GB", "TB"];
+  let v = n;
+  let i = 0;
+  while (v >= 1024 && i < units.length - 1) {
+    v /= 1024;
+    i++;
+  }
+  return `${v.toFixed(i === 0 ? 0 : 1)} ${units[i]}`;
+}
+
+const PROGRESS_BEGIN_TAGS = new Set(["REPOSITORY_CLONE_BEGIN", "REVISION_COMMIT_BEGIN"]);
+const PROGRESS_TAGS = new Set(["REPOSITORY_CLONE_PROGRESS", "REVISION_COMMIT_PROGRESS"]);
+const PROGRESS_END_TAGS = new Set(["REPOSITORY_CLONE_END", "REVISION_COMMIT_END"]);
+
+/** Render progress data (file and byte counts) onto the operation overlay bar.
+ * @param {HTMLElement} barFillEl progress bar fill element
+ * @param {HTMLElement} textEl progress text element
+ * @param {object} data progress payload with fileComplete, fileTotal, bytesTransferred, bytesTotal, discoveryComplete
+ */
+function renderOpProgress(barFillEl, textEl, data) {
+  const fileDone = data.fileComplete ?? data.fileCount ?? 0;
+  const fileTotal = data.fileTotal ?? data.fileCount ?? 0;
+  const bytesDone = data.bytesTransferred ?? 0;
+  const bytesTotal = data.bytesTotal ?? 0;
+  const pct = data.discoveryComplete && bytesTotal > 0 ? (bytesDone / bytesTotal) * 100 : fileTotal > 0 ? (fileDone / fileTotal) * 100 : 0;
+  barFillEl.style.width = `${Math.min(100, Math.max(0, pct))}%`;
+  textEl.textContent = data.discoveryComplete
+    ? `${fileDone.toLocaleString()} / ${fileTotal.toLocaleString()} files · ${fmtBytes(bytesDone)} / ${fmtBytes(bytesTotal)}`
+    : "Discovering…";
+}
+
 async function runOp(title, path, payload) {
   const overlay = $("#op-overlay");
   const logEl = $("#op-log");
   const statusEl = $("#op-status");
   const closeBtn = $("#op-close");
+  const progressEl = $("#op-progress");
+  const barFillEl = $("#op-bar-fill");
+  const progressTextEl = $("#op-progress-text");
   $("#op-title").textContent = title;
   logEl.textContent = "";
   statusEl.textContent = "";
   statusEl.className = "";
   closeBtn.hidden = true;
+  progressEl.hidden = true;
+  barFillEl.style.width = "0%";
+  progressTextEl.textContent = "";
   overlay.hidden = false;
 
   try {
     await apiStream(path, payload, (ev) => {
       if (ev.tag === "LOG") logEl.textContent += (ev.data?.message || "") + "\n";
       else if (ev.tag === "DONE") {
+        if (ev.data.ok) barFillEl.style.width = "100%";
         statusEl.textContent = ev.data.ok ? "Success" : `Failed: ${ev.data.message || "unknown error"}`;
         statusEl.className = ev.data.ok ? "ok" : "fail";
+      } else if (PROGRESS_BEGIN_TAGS.has(ev.tag)) {
+        progressEl.hidden = false;
+        barFillEl.style.width = "0%";
+        progressTextEl.textContent = "Starting…";
+      } else if (PROGRESS_TAGS.has(ev.tag)) {
+        progressEl.hidden = false;
+        renderOpProgress(barFillEl, progressTextEl, ev.data || {});
+      } else if (PROGRESS_END_TAGS.has(ev.tag)) {
+        progressEl.hidden = false;
+        barFillEl.style.width = "100%";
       } else if (ev.tag !== "END" && ev.tag !== "COMPLETE") {
-        // Surface progress-bearing events compactly.
+        // Surface other progress-bearing events compactly.
         logEl.textContent += `• ${ev.tag}\n`;
       }
       logEl.scrollTop = logEl.scrollHeight;

--- a/lore-web/web/app.js
+++ b/lore-web/web/app.js
@@ -82,8 +82,9 @@ function renderRepos() {
       <span class="r-name" title="${r.path}">${r.label}</span>
       ${r.exists ? `<span class="r-branch">${r.branch || ""}</span>` : `<span class="r-missing">missing</span>`}
       <button class="r-remove" title="Remove">✕</button>`;
-    li.querySelector(".r-name").onclick = () => selectRepo(r.path);
-    li.querySelector(".r-branch, .r-missing")?.addEventListener?.("click", () => selectRepo(r.path));
+    // Select on a click anywhere in the row, not just the label, so the whole
+    // row is one big hit target. The remove button stops propagation below.
+    li.onclick = () => selectRepo(r.path);
     li.querySelector(".r-remove").onclick = (e) => {
       e.stopPropagation();
       removeRepo(r.path);

--- a/lore-web/web/app.js
+++ b/lore-web/web/app.js
@@ -329,9 +329,16 @@ async function ignorePattern(pattern) {
 
 async function initLoreignore() {
   try {
-    const { created, gitignoreUpdated } = await apiPost("/api/init-loreignore", { path: state.active });
+    const { created, gitignoreUpdated, p4ignoreUpdated, p4ignoreBlocked } = await apiPost(
+      "/api/init-loreignore",
+      { path: state.active },
+    );
     toast(created ? "Created .loreignore" : "Updated .loreignore");
     if (gitignoreUpdated) toast("Updated .gitignore");
+    if (p4ignoreUpdated) toast("Updated .p4ignore");
+    // Perforce keeps .p4ignore read-only until it is opened for edit, so Lore
+    // cannot add its entries there on its own.
+    if (p4ignoreBlocked) toast(".p4ignore is read-only — run p4 edit .p4ignore, then retry", true);
     await loadStatus(encodeURIComponent(state.active));
   } catch (err) {
     toast(err.message, true);
@@ -360,6 +367,8 @@ function updateChangesBar(data) {
 
   if (data.hasLoreignore === false) {
     bar.appendChild(barButton("Initialize .loreignore", initLoreignore));
+  } else if (data.hasGitignore || data.hasP4ignore) {
+    bar.appendChild(barButton("Re-sync ignore patterns", initLoreignore, "ghost"));
   }
   if (nested.length) {
     const n = nested.length;

--- a/lore-web/web/app.js
+++ b/lore-web/web/app.js
@@ -80,6 +80,7 @@ function renderRepos() {
     li.className = r.path === state.active ? "active" : "";
     li.innerHTML = `
       <span class="r-name" title="${r.path}">${r.label}</span>
+      ${r.organization ? `<span class="r-org">${r.organization}</span>` : ""}
       ${r.exists ? `<span class="r-branch">${r.branch || ""}</span>` : `<span class="r-missing">missing</span>`}
       <button class="r-remove" title="Remove">✕</button>`;
     // Select on a click anywhere in the row, not only the label, so the whole
@@ -180,7 +181,29 @@ async function selectRepo(path) {
   $("#repo-title").textContent = repo?.label || path;
   $("#repo-path").textContent = path;
   renderRepos();
+  loadOrg(path);
   await refreshActive();
+}
+
+/**
+ * Fetch the active repo's organization and show it as a clickable pill. The org
+ * is the prefix of the repo's `name` metadata; a repo with no org prefix hides
+ * the pill. Best-effort — a read failure leaves the pill hidden rather than
+ * surfacing an error.
+ * @param {string} path the repository path
+ */
+async function loadOrg(path) {
+  const pill = $("#repo-org");
+  pill.hidden = true;
+  try {
+    const { organization, repoName } = await apiGet(`/api/org?path=${encodeURIComponent(path)}`);
+    state.org = { organization, repoName };
+    pill.textContent = organization || "Set organization…";
+    pill.classList.toggle("org-empty", !organization);
+    pill.hidden = false;
+  } catch (err) {
+    state.org = null;
+  }
 }
 
 /** Refetch every view for the active repo. The single source of freshness. */
@@ -761,6 +784,34 @@ function wire() {
     setTimeout(async () => {
       await runOp("Cloning…", "/api/clone", { url, dest });
       await loadRepos();
+    }, 0);
+  };
+
+  $("#repo-org").onclick = () => {
+    if (!state.active) return;
+    $("#org-repo").textContent = state.org?.repoName
+      ? `Repository: ${state.org.repoName}`
+      : "";
+    $("#org-name").value = state.org?.organization || "";
+    $("#org-dialog").showModal();
+    $("#org-name").focus();
+  };
+  $("#org-go").onclick = (e) => {
+    const organization = $("#org-name").value.trim();
+    if (!organization || organization.includes("/")) {
+      e.preventDefault();
+      return toast("Organization is required and cannot contain '/'", true);
+    }
+    const path = state.active;
+    setTimeout(async () => {
+      try {
+        await apiPost("/api/org", { path, organization });
+        toast("Organization changed — repository rebuilt");
+        if (state.active === path) loadOrg(path);
+        await loadRepos();
+      } catch (err) {
+        toast(err.message, true);
+      }
     }, 0);
   };
 

--- a/lore-web/web/app.js
+++ b/lore-web/web/app.js
@@ -82,7 +82,7 @@ function renderRepos() {
       <span class="r-name" title="${r.path}">${r.label}</span>
       ${r.exists ? `<span class="r-branch">${r.branch || ""}</span>` : `<span class="r-missing">missing</span>`}
       <button class="r-remove" title="Remove">✕</button>`;
-    // Select on a click anywhere in the row, not just the label, so the whole
+    // Select on a click anywhere in the row, not only the label, so the whole
     // row is one big hit target. The remove button stops propagation below.
     li.onclick = () => selectRepo(r.path);
     li.querySelector(".r-remove").onclick = (e) => {
@@ -264,7 +264,7 @@ function ignoreOptionsFor(f) {
   const parent = sep >= 0 ? path.slice(0, sep + 1) : "";
   const opts = [];
   if (f.type === 0) {
-    // A directory entry (e.g. a stale nested-repo marker): ignore the folder
+    // A directory entry (for example, a stale nested-repo marker): ignore the folder
     // itself with a trailing slash. This is the way to clear nested-repo
     // phantoms — Lore's status filter excludes ignored paths.
     opts.push({ pattern: `${path}/`, label: "This folder" });
@@ -655,6 +655,64 @@ function wirePicker() {
   });
 }
 
+/** Fetch the server's hosted repositories into the Server repositories dialog
+ * (server URL from the field, or the default when blank). */
+async function loadServerRepos() {
+  const server = $("#server-url").value.trim();
+  const data = await apiGet(`/api/remote-repos${server ? `?url=${encodeURIComponent(server)}` : ""}`);
+  $("#server-url").value = data.base;
+  renderServerRepos(data.repos);
+}
+
+/**
+ * Render the repositories the server hosts. Each row offers Clone (hands the
+ * remote URL to the clone dialog to pick a destination) and ✕ Delete (removes
+ * it from the server by id — see the server's deleteRemoteRepo). Repos already
+ * cloned on this machine are tagged so the real ones stand out from stale ones.
+ */
+function renderServerRepos(repos) {
+  const ul = $("#server-repos");
+  ul.innerHTML = "";
+  ul.hidden = false;
+  if (repos.length === 0) {
+    ul.innerHTML = `<li class="muted">— no repositories on this server —</li>`;
+    return;
+  }
+  for (const r of repos) {
+    const li = document.createElement("li");
+    const tag = r.tracked ? `<span class="p-tag">cloned</span>` : "";
+    li.innerHTML =
+      `<span class="p-name" title="${r.url}">${r.name}</span>${tag}` +
+      `<button type="button" class="p-clone">Clone</button>` +
+      `<button type="button" class="p-del" title="Delete from server">✕</button>`;
+    li.querySelector(".p-clone").onclick = () => cloneServerRepo(r);
+    li.querySelector(".p-del").onclick = () => deleteServerRepo(r);
+    ul.appendChild(li);
+  }
+}
+
+/** Start cloning a server repo: prefill and open the clone-from-URL dialog so
+ * the user only has to choose a destination folder. */
+function cloneServerRepo(r) {
+  $("#server-dialog").close();
+  $("#clone-url").value = r.url;
+  $("#clone-dest").value = "";
+  $("#clone-dialog").showModal();
+}
+
+/** Delete a server-side repository after confirmation, then refresh the list. */
+async function deleteServerRepo(r) {
+  const warn = r.tracked ? "\n\nThis is one of your local working copies — its files on disk are left untouched, but it will no longer exist on the server." : "";
+  if (!confirm(`Delete "${r.name}" from the server? This cannot be undone.${warn}`)) return;
+  try {
+    await apiPost("/api/remote-repos", { _method: "DELETE", id: r.id, base: $("#server-url").value.trim() });
+    toast(`Deleted ${r.name}`);
+    await loadServerRepos();
+  } catch (err) {
+    toast(err.message, true);
+  }
+}
+
 function wire() {
   $("#add-btn").onclick = addRepo;
   $("#refresh-btn").onclick = refreshActive;
@@ -664,6 +722,29 @@ function wire() {
   $("#sync-btn").onclick = () => runOp("Syncing…", "/api/sync", { path: state.active });
   $("#push-btn").onclick = () => runOp("Pushing…", "/api/push", { path: state.active });
   $("#op-close").onclick = () => ($("#op-overlay").hidden = true);
+
+  // Server repositories: open the dialog and list immediately (it falls back to
+  // the default server when the field is blank, so the catalog shows at once).
+  $("#server-btn").onclick = async () => {
+    $("#server-repos").hidden = true;
+    $("#server-dialog").showModal();
+    try {
+      await loadServerRepos();
+    } catch (err) {
+      toast(err.message, true);
+    }
+  };
+  $("#server-refresh").onclick = async () => {
+    const btn = $("#server-refresh");
+    btn.disabled = true;
+    try {
+      await loadServerRepos();
+    } catch (err) {
+      toast(err.message, true);
+    } finally {
+      btn.disabled = false;
+    }
+  };
 
   $("#clone-btn").onclick = () => $("#clone-dialog").showModal();
   $("#clone-dest-browse").onclick = async () => {

--- a/lore-web/web/app.js
+++ b/lore-web/web/app.js
@@ -229,6 +229,7 @@ function fileBadge(f) {
   return ["M", "badge-M"];
 }
 
+/** Fetches repository status and renders the staged/unstaged file lists. */
 async function loadStatus(pathEnc) {
   try {
     const data = await apiGet(`/api/status?path=${pathEnc}`);
@@ -238,6 +239,8 @@ async function loadStatus(pathEnc) {
     renderFiles($("#staged-files"), staged, "unstage");
     renderFiles($("#unstaged-files"), unstaged, "stage");
     $("#commit-btn").disabled = staged.length === 0;
+    $("#stage-all-btn").disabled = unstaged.length === 0;
+    state.unstaged = unstaged;
     updateChangesBar(data);
   } catch (err) {
     toast(err.message, true);
@@ -271,6 +274,18 @@ async function fileAction(action, file) {
   try {
     await apiPost(`/api/${action}`, { path: state.active, files: [file] });
     // SSE refresh will follow, but refetch now for immediate feedback.
+    await loadStatus(encodeURIComponent(state.active));
+  } catch (err) {
+    toast(err.message, true);
+  }
+}
+
+/** Stages every currently unstaged file in the active repository. */
+async function stageAll() {
+  const files = (state.unstaged || []).map((f) => f.path);
+  if (files.length === 0) return;
+  try {
+    await apiPost("/api/stage", { path: state.active, files });
     await loadStatus(encodeURIComponent(state.active));
   } catch (err) {
     toast(err.message, true);
@@ -817,6 +832,7 @@ function wire() {
   $("#add-btn").onclick = addRepo;
   $("#refresh-btn").onclick = refreshActive;
   $("#commit-btn").onclick = commit;
+  $("#stage-all-btn").onclick = stageAll;
   $("#ignore-cancel").onclick = () => $("#ignore-dialog").close();
 
   $("#sync-btn").onclick = () => runOp("Syncing…", "/api/sync", { path: state.active });

--- a/lore-web/web/app.js
+++ b/lore-web/web/app.js
@@ -1,0 +1,391 @@
+// lore-web single-page UI. Vanilla ES modules, no build step. The guiding rule:
+// never trust a cached snapshot — every view refetches live (on select, on a
+// file-watch "refresh" push, on window focus, and on a slow history poll), which
+// is what keeps lists fresh where the desktop app went stale.
+
+const $ = (sel) => document.querySelector(sel);
+const $$ = (sel) => Array.from(document.querySelectorAll(sel));
+
+const state = {
+  repos: [],
+  active: null, // repo path
+  tab: "changes",
+  selectedFile: null,
+};
+
+// ---- API helpers ---------------------------------------------------------
+
+async function apiGet(path) {
+  const res = await fetch(path);
+  const body = await res.json();
+  if (!res.ok) throw new Error(body.error || res.statusText);
+  return body;
+}
+
+async function apiPost(path, payload) {
+  const res = await fetch(path, {
+    method: payload && payload._method === "DELETE" ? "DELETE" : "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  const body = await res.json();
+  if (!res.ok) throw new Error(body.error || res.statusText);
+  return body;
+}
+
+/** POST and consume an NDJSON progress stream, invoking onEvent per line. */
+async function apiStream(path, payload, onEvent) {
+  const res = await fetch(path, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let buf = "";
+  for (;;) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    buf += decoder.decode(value, { stream: true });
+    let nl;
+    while ((nl = buf.indexOf("\n")) >= 0) {
+      const line = buf.slice(0, nl).trim();
+      buf = buf.slice(nl + 1);
+      if (line) onEvent(JSON.parse(line));
+    }
+  }
+}
+
+function toast(msg, isErr) {
+  const t = $("#toast");
+  t.textContent = msg;
+  t.className = "toast" + (isErr ? " err" : "");
+  t.hidden = false;
+  setTimeout(() => (t.hidden = true), isErr ? 5000 : 2500);
+}
+
+// ---- Repo list -----------------------------------------------------------
+
+async function loadRepos() {
+  try {
+    const { repos } = await apiGet("/api/repos");
+    state.repos = repos;
+    renderRepos();
+  } catch (err) {
+    toast(err.message, true);
+  }
+}
+
+function renderRepos() {
+  const ul = $("#repo-list");
+  ul.innerHTML = "";
+  for (const r of state.repos) {
+    const li = document.createElement("li");
+    li.className = r.path === state.active ? "active" : "";
+    li.innerHTML = `
+      <span class="r-name" title="${r.path}">${r.label}</span>
+      ${r.exists ? `<span class="r-branch">${r.branch || ""}</span>` : `<span class="r-missing">missing</span>`}
+      <button class="r-remove" title="Remove">✕</button>`;
+    li.querySelector(".r-name").onclick = () => selectRepo(r.path);
+    li.querySelector(".r-branch, .r-missing")?.addEventListener?.("click", () => selectRepo(r.path));
+    li.querySelector(".r-remove").onclick = (e) => {
+      e.stopPropagation();
+      removeRepo(r.path);
+    };
+    ul.appendChild(li);
+  }
+}
+
+async function addRepo() {
+  const input = $("#add-path");
+  const path = input.value.trim();
+  if (!path) return;
+  try {
+    await apiPost("/api/repos", { path, label: path.split(/[\\/]/).pop() });
+    input.value = "";
+    await loadRepos();
+    selectRepo(path);
+  } catch (err) {
+    toast(err.message, true);
+  }
+}
+
+async function removeRepo(path) {
+  try {
+    await apiPost("/api/repos", { path, _method: "DELETE" });
+    if (state.active === path) {
+      state.active = null;
+      showEmpty();
+    }
+    await loadRepos();
+    toast("Repository removed");
+  } catch (err) {
+    toast(err.message, true);
+  }
+}
+
+// ---- Active repo views ---------------------------------------------------
+
+function showEmpty() {
+  $("#empty").hidden = false;
+  $("#repo-view").hidden = true;
+}
+
+async function selectRepo(path) {
+  state.active = path;
+  state.selectedFile = null;
+  const repo = state.repos.find((r) => r.path === path);
+  $("#empty").hidden = true;
+  $("#repo-view").hidden = false;
+  $("#repo-title").textContent = repo?.label || path;
+  $("#repo-path").textContent = path;
+  renderRepos();
+  await refreshActive();
+}
+
+/** Refetch every view for the active repo. The single source of freshness. */
+async function refreshActive() {
+  if (!state.active) return;
+  const path = encodeURIComponent(state.active);
+  await Promise.all([loadStatus(path), loadHistory(path), loadBranches(path)]);
+}
+
+function fileBadge(f) {
+  if (f.action === 1) return ["A", "badge-A"];
+  if (f.action === 2) return ["D", "badge-D"];
+  if (f.action === 3) return ["R", "badge-M"];
+  return ["M", "badge-M"];
+}
+
+async function loadStatus(pathEnc) {
+  try {
+    const data = await apiGet(`/api/status?path=${pathEnc}`);
+    $("#repo-branch").textContent = data.branch || "";
+    const staged = data.files.filter((f) => f.flagStaged);
+    const unstaged = data.files.filter((f) => !f.flagStaged);
+    renderFiles($("#staged-files"), staged, "unstage");
+    renderFiles($("#unstaged-files"), unstaged, "stage");
+    $("#commit-btn").disabled = staged.length === 0;
+  } catch (err) {
+    toast(err.message, true);
+  }
+}
+
+function renderFiles(ul, files, action) {
+  ul.innerHTML = "";
+  if (files.length === 0) {
+    ul.innerHTML = `<li class="muted">— none —</li>`;
+    return;
+  }
+  for (const f of files) {
+    const [label, cls] = fileBadge(f);
+    const li = document.createElement("li");
+    li.innerHTML = `
+      <span class="f-act ${cls}">${label}</span>
+      <span class="f-path" title="${f.path}">${f.path}</span>
+      <button class="f-do">${action === "stage" ? "Stage" : "Unstage"}</button>
+      ${action === "stage" ? `<button class="f-reset" title="Discard changes">↺</button>` : ""}`;
+    li.querySelector(".f-path").onclick = () => showDiff(f.path);
+    li.querySelector(".f-do").onclick = () => fileAction(action, f.path);
+    li.querySelector(".f-reset")?.addEventListener("click", () => fileAction("reset", f.path));
+    ul.appendChild(li);
+  }
+}
+
+async function fileAction(action, file) {
+  try {
+    await apiPost(`/api/${action}`, { path: state.active, files: [file] });
+    // SSE refresh will follow, but refetch now for immediate feedback.
+    await loadStatus(encodeURIComponent(state.active));
+  } catch (err) {
+    toast(err.message, true);
+  }
+}
+
+async function showDiff(file) {
+  const view = $("#diff-view");
+  state.selectedFile = file;
+  try {
+    const { diff } = await apiGet(`/api/diff?path=${encodeURIComponent(state.active)}&file=${encodeURIComponent(file)}`);
+    const patch = diff.map((d) => d.patch || "").join("\n");
+    view.innerHTML = colorizeDiff(patch || "(no differences)");
+    view.classList.add("show");
+  } catch (err) {
+    toast(err.message, true);
+  }
+}
+
+function colorizeDiff(text) {
+  return text
+    .split("\n")
+    .map((line) => {
+      const esc = line.replace(/&/g, "&amp;").replace(/</g, "&lt;");
+      if (line.startsWith("+")) return `<span class="diff-add">${esc}</span>`;
+      if (line.startsWith("-")) return `<span class="diff-del">${esc}</span>`;
+      if (line.startsWith("@@")) return `<span class="diff-hunk">${esc}</span>`;
+      return esc;
+    })
+    .join("\n");
+}
+
+async function commit() {
+  const msg = $("#commit-msg").value.trim();
+  if (!msg) return toast("Enter a commit message", true);
+  $("#commit-btn").disabled = true;
+  try {
+    await apiPost("/api/commit", { path: state.active, message: msg });
+    $("#commit-msg").value = "";
+    toast("Committed");
+    await refreshActive();
+  } catch (err) {
+    toast(err.message, true);
+  } finally {
+    $("#commit-btn").disabled = false;
+  }
+}
+
+async function loadHistory(pathEnc) {
+  try {
+    const { revisions } = await apiGet(`/api/history?path=${pathEnc}&length=50`);
+    const ul = $("#history-list");
+    ul.innerHTML = "";
+    for (const r of revisions) {
+      const li = document.createElement("li");
+      const when = r.timestamp ? new Date(r.timestamp).toLocaleString() : "";
+      li.innerHTML = `
+        <div class="h-msg">${(r.message || "(no message)").split("\n")[0]}</div>
+        <div class="h-meta">
+          <span class="h-rev">#${r.revisionNumber} · ${(r.revision || "").slice(0, 12)}</span>
+          <span>${when}</span>
+        </div>`;
+      ul.appendChild(li);
+    }
+  } catch (err) {
+    toast(err.message, true);
+  }
+}
+
+async function loadBranches(pathEnc) {
+  try {
+    const { branches } = await apiGet(`/api/branches?path=${pathEnc}`);
+    const ul = $("#branch-list");
+    ul.innerHTML = "";
+    const seen = new Set();
+    for (const b of branches) {
+      if (seen.has(b.name)) continue; // local + remote entries share a name
+      seen.add(b.name);
+      const li = document.createElement("li");
+      li.innerHTML = `
+        <span class="b-current">${b.isCurrent ? "●" : "○"}</span>
+        <span class="b-name">${b.name}</span>
+        <span class="b-loc">${(b.latest || "").slice(0, 12)}</span>`;
+      ul.appendChild(li);
+    }
+  } catch (err) {
+    toast(err.message, true);
+  }
+}
+
+// ---- Remote operations (streamed) ---------------------------------------
+
+async function runOp(title, path, payload) {
+  const overlay = $("#op-overlay");
+  const logEl = $("#op-log");
+  const statusEl = $("#op-status");
+  const closeBtn = $("#op-close");
+  $("#op-title").textContent = title;
+  logEl.textContent = "";
+  statusEl.textContent = "";
+  statusEl.className = "";
+  closeBtn.hidden = true;
+  overlay.hidden = false;
+
+  try {
+    await apiStream(path, payload, (ev) => {
+      if (ev.tag === "LOG") logEl.textContent += (ev.data?.message || "") + "\n";
+      else if (ev.tag === "DONE") {
+        statusEl.textContent = ev.data.ok ? "Success" : `Failed: ${ev.data.message || "unknown error"}`;
+        statusEl.className = ev.data.ok ? "ok" : "fail";
+      } else if (ev.tag !== "END" && ev.tag !== "COMPLETE") {
+        // Surface progress-bearing events compactly.
+        logEl.textContent += `• ${ev.tag}\n`;
+      }
+      logEl.scrollTop = logEl.scrollHeight;
+    });
+  } catch (err) {
+    statusEl.textContent = `Failed: ${err.message}`;
+    statusEl.className = "fail";
+  }
+  closeBtn.hidden = false;
+  await refreshActive();
+}
+
+// ---- Live connection (SSE) ----------------------------------------------
+
+function connectSSE() {
+  const es = new EventSource("/events");
+  es.onopen = () => $("#conn").classList.add("live");
+  es.onerror = () => $("#conn").classList.remove("live");
+  es.onmessage = (e) => {
+    let msg;
+    try {
+      msg = JSON.parse(e.data);
+    } catch {
+      return;
+    }
+    if (msg.type === "refresh") {
+      if (msg.repo === "*") loadRepos();
+      else if (msg.repo === state.active) refreshActive();
+      else loadRepos(); // a non-active repo changed; keep the sidebar fresh
+    }
+  };
+}
+
+// ---- Wiring --------------------------------------------------------------
+
+function wire() {
+  $("#add-btn").onclick = addRepo;
+  $("#add-path").addEventListener("keydown", (e) => e.key === "Enter" && addRepo());
+  $("#refresh-btn").onclick = refreshActive;
+  $("#commit-btn").onclick = commit;
+
+  $("#sync-btn").onclick = () => runOp("Syncing…", "/api/sync", { path: state.active });
+  $("#push-btn").onclick = () => runOp("Pushing…", "/api/push", { path: state.active });
+  $("#op-close").onclick = () => ($("#op-overlay").hidden = true);
+
+  $("#clone-btn").onclick = () => $("#clone-dialog").showModal();
+  $("#clone-go").onclick = (e) => {
+    const url = $("#clone-url").value.trim();
+    const dest = $("#clone-dest").value.trim();
+    if (!url || !dest) {
+      e.preventDefault();
+      return toast("URL and destination required", true);
+    }
+    setTimeout(async () => {
+      await runOp("Cloning…", "/api/clone", { url, dest });
+      await loadRepos();
+    }, 0);
+  };
+
+  $$(".tab").forEach((tab) => {
+    tab.onclick = () => {
+      state.tab = tab.dataset.tab;
+      $$(".tab").forEach((t) => t.classList.toggle("active", t === tab));
+      $$(".panel").forEach((pnl) => pnl.classList.toggle("active", pnl.dataset.panel === state.tab));
+    };
+  });
+
+  // Freshness: refetch when the window regains focus.
+  window.addEventListener("focus", () => {
+    loadRepos();
+    refreshActive();
+  });
+  // Slow poll catches revisions pushed by the other machine (no local fs event).
+  setInterval(() => state.active && loadHistory(encodeURIComponent(state.active)), 10000);
+}
+
+// ---- Boot ----------------------------------------------------------------
+
+wire();
+connectSSE();
+loadRepos();

--- a/lore-web/web/index.html
+++ b/lore-web/web/index.html
@@ -31,6 +31,7 @@
             <div>
               <h1 id="repo-title">—</h1>
               <div class="repo-sub">
+                <button id="repo-org" class="pill org-pill" title="Organization — click to change" hidden></button>
                 <span id="repo-branch" class="pill"></span>
                 <span id="repo-path" class="muted"></span>
               </div>
@@ -141,6 +142,25 @@
         <menu>
           <button type="button" id="init-cancel">Cancel</button>
           <button type="button" id="init-go" class="primary">Initialize</button>
+        </menu>
+      </form>
+    </dialog>
+
+    <!-- Organization editor — recreates the repo identity under a new org -->
+    <dialog id="org-dialog">
+      <form method="dialog" class="clone-form">
+        <h3>Change organization</h3>
+        <p class="muted" id="org-repo"></p>
+        <label>Organization<input id="org-name" type="text" placeholder="organization" /></label>
+        <p class="warn">
+          A repository's organization is part of its read-only identity, set when the
+          repository is created. Changing it rebuilds the local repository, which
+          <strong>discards all local committed revisions</strong>. Only proceed if this
+          repository is fully pushed to its remote — its id and remote are preserved.
+        </p>
+        <menu>
+          <button value="cancel">Cancel</button>
+          <button id="org-go" value="default" class="danger">Change and rebuild</button>
         </menu>
       </form>
     </dialog>

--- a/lore-web/web/index.html
+++ b/lore-web/web/index.html
@@ -51,6 +51,7 @@
             <!-- Changes -->
             <div class="panel active" data-panel="changes">
               <div class="changes-layout">
+                <div class="changes-bar" hidden></div>
                 <div class="file-cols">
                   <div class="file-col">
                     <h3>Staged</h3>
@@ -124,6 +125,17 @@
           <button type="button" id="init-go" class="primary">Initialize</button>
         </menu>
       </form>
+    </dialog>
+
+    <!-- Ignore chooser (ignore this file / its folder / its extension) -->
+    <dialog id="ignore-dialog">
+      <div class="picker">
+        <h3>Add to .loreignore</h3>
+        <ul id="ignore-options" class="ignore-options"></ul>
+        <menu>
+          <button type="button" id="ignore-cancel">Cancel</button>
+        </menu>
+      </div>
     </dialog>
 
     <!-- Folder picker dialog -->

--- a/lore-web/web/index.html
+++ b/lore-web/web/index.html
@@ -16,7 +16,8 @@
         <ul id="repo-list" class="repo-list"></ul>
         <footer class="side-foot">
           <button id="add-btn" class="primary">Add a repository…</button>
-          <button id="clone-btn" class="ghost">Clone a repository…</button>
+          <button id="server-btn" class="ghost">Server repositories…</button>
+          <button id="clone-btn" class="ghost">Clone from URL…</button>
         </footer>
       </aside>
 
@@ -96,10 +97,27 @@
       </div>
     </div>
 
-    <!-- Clone dialog -->
+    <!-- Server repositories: browse what the server hosts, then clone or delete -->
+    <dialog id="server-dialog">
+      <form method="dialog" class="clone-form">
+        <h3>Server repositories</h3>
+        <label>Server URL
+          <div class="field-row">
+            <input id="server-url" type="text" placeholder="lore://host:41337" />
+            <button type="button" id="server-refresh" class="ghost">List</button>
+          </div>
+        </label>
+        <ul id="server-repos" class="picker-list" hidden></ul>
+        <menu>
+          <button value="cancel">Close</button>
+        </menu>
+      </form>
+    </dialog>
+
+    <!-- Clone dialog (clone directly from a known remote URL) -->
     <dialog id="clone-dialog">
       <form method="dialog" class="clone-form">
-        <h3>Clone a repository</h3>
+        <h3>Clone from URL</h3>
         <label>Remote URL<input id="clone-url" type="text" placeholder="lore://host:41337/org/repo" /></label>
         <label>Destination folder
           <div class="field-row">

--- a/lore-web/web/index.html
+++ b/lore-web/web/index.html
@@ -61,7 +61,7 @@
                     <ul id="staged-files" class="files"></ul>
                   </div>
                   <div class="file-col">
-                    <h3>Unstaged</h3>
+                    <h3>Unstaged <button id="stage-all-btn" class="link-btn">Stage all</button></h3>
                     <ul id="unstaged-files" class="files"></ul>
                   </div>
                 </div>

--- a/lore-web/web/index.html
+++ b/lore-web/web/index.html
@@ -12,6 +12,7 @@
         <header class="brand">
           <span class="logo">lore</span><span class="logo-web">web</span>
           <span id="conn" class="conn" title="live connection">●</span>
+          <button id="settings-btn" class="icon-btn" title="Settings">⚙</button>
         </header>
         <ul id="repo-list" class="repo-list"></ul>
         <footer class="side-foot">
@@ -194,6 +195,31 @@
           <button type="button" id="picker-choose" class="primary">Select this folder</button>
         </menu>
       </div>
+    </dialog>
+
+    <!-- Settings dialog — configure remote server -->
+    <dialog id="settings-dialog">
+      <form method="dialog" class="clone-form">
+        <h3>Settings</h3>
+        <label>Remote server
+          <div class="settings-field">
+            <input id="settings-remote" type="text" placeholder="lore://host:41337" />
+            <button type="button" id="settings-discover" class="ghost" title="Search for local servers">⟲</button>
+          </div>
+        </label>
+        <div id="discovered-servers" class="discovered-servers" hidden>
+          <p class="muted">Discovered servers:</p>
+          <ul id="discovered-list" class="discovered-list"></ul>
+        </div>
+        <p class="muted">
+          Format: <code>lore://IP-or-hostname:port</code><br>
+          Leave empty to disable remote operations.
+        </p>
+        <menu>
+          <button value="cancel">Cancel</button>
+          <button id="settings-go" value="default" class="primary">Save</button>
+        </menu>
+      </form>
     </dialog>
 
     <div id="toast" class="toast" hidden></div>

--- a/lore-web/web/index.html
+++ b/lore-web/web/index.html
@@ -13,12 +13,9 @@
           <span class="logo">lore</span><span class="logo-web">web</span>
           <span id="conn" class="conn" title="live connection">●</span>
         </header>
-        <div class="add-repo">
-          <input id="add-path" type="text" placeholder="Path to a Lore working copy…" />
-          <button id="add-btn">Add</button>
-        </div>
         <ul id="repo-list" class="repo-list"></ul>
         <footer class="side-foot">
+          <button id="add-btn" class="primary">Add a repository…</button>
           <button id="clone-btn" class="ghost">Clone a repository…</button>
         </footer>
       </aside>
@@ -103,12 +100,50 @@
       <form method="dialog" class="clone-form">
         <h3>Clone a repository</h3>
         <label>Remote URL<input id="clone-url" type="text" placeholder="lore://host:41337/org/repo" /></label>
-        <label>Destination folder<input id="clone-dest" type="text" placeholder="D:\path\to\clone" /></label>
+        <label>Destination folder
+          <div class="field-row">
+            <input id="clone-dest" type="text" placeholder="D:\path\to\clone" />
+            <button type="button" id="clone-dest-browse" class="ghost">Browse…</button>
+          </div>
+        </label>
         <menu>
           <button value="cancel">Cancel</button>
           <button id="clone-go" value="default" class="primary">Clone</button>
         </menu>
       </form>
+    </dialog>
+
+    <!-- Initialize-repository confirmation (new repo: review the generated URL) -->
+    <dialog id="init-dialog">
+      <form method="dialog" class="clone-form">
+        <h3>Initialize repository</h3>
+        <p class="muted" id="init-folder"></p>
+        <label>Repository URL<input id="init-url" type="text" /></label>
+        <menu>
+          <button type="button" id="init-cancel">Cancel</button>
+          <button type="button" id="init-go" class="primary">Initialize</button>
+        </menu>
+      </form>
+    </dialog>
+
+    <!-- Folder picker dialog -->
+    <dialog id="picker-dialog">
+      <div class="picker">
+        <h3 id="picker-title">Select a folder</h3>
+        <div class="picker-bar">
+          <button type="button" id="picker-up" title="Up one level">↑</button>
+          <span id="picker-cur" class="picker-cur"></span>
+        </div>
+        <ul id="picker-list" class="picker-list"></ul>
+        <label id="picker-new" class="picker-new" hidden>
+          New folder (optional)
+          <input id="picker-newname" type="text" placeholder="leave empty to use the folder above" />
+        </label>
+        <menu>
+          <button type="button" id="picker-cancel">Cancel</button>
+          <button type="button" id="picker-choose" class="primary">Select this folder</button>
+        </menu>
+      </div>
     </dialog>
 
     <div id="toast" class="toast" hidden></div>

--- a/lore-web/web/index.html
+++ b/lore-web/web/index.html
@@ -91,6 +91,10 @@
     <div id="op-overlay" class="overlay" hidden>
       <div class="op-modal">
         <h3 id="op-title">Working…</h3>
+        <div id="op-progress" class="op-progress" hidden>
+          <div class="op-bar"><div id="op-bar-fill"></div></div>
+          <span id="op-progress-text"></span>
+        </div>
         <pre id="op-log" class="op-log"></pre>
         <div class="op-foot">
           <span id="op-status"></span>

--- a/lore-web/web/index.html
+++ b/lore-web/web/index.html
@@ -1,0 +1,117 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>lore-web</title>
+    <link rel="stylesheet" href="/style.css" />
+  </head>
+  <body>
+    <div id="app">
+      <aside id="sidebar">
+        <header class="brand">
+          <span class="logo">lore</span><span class="logo-web">web</span>
+          <span id="conn" class="conn" title="live connection">●</span>
+        </header>
+        <div class="add-repo">
+          <input id="add-path" type="text" placeholder="Path to a Lore working copy…" />
+          <button id="add-btn">Add</button>
+        </div>
+        <ul id="repo-list" class="repo-list"></ul>
+        <footer class="side-foot">
+          <button id="clone-btn" class="ghost">Clone a repository…</button>
+        </footer>
+      </aside>
+
+      <main id="main">
+        <div id="empty" class="empty">
+          <p>Select or add a repository to begin.</p>
+        </div>
+
+        <section id="repo-view" hidden>
+          <header class="repo-head">
+            <div>
+              <h1 id="repo-title">—</h1>
+              <div class="repo-sub">
+                <span id="repo-branch" class="pill"></span>
+                <span id="repo-path" class="muted"></span>
+              </div>
+            </div>
+            <div class="repo-actions">
+              <button id="sync-btn">Sync</button>
+              <button id="push-btn" class="primary">Push</button>
+              <button id="refresh-btn" class="ghost" title="Refresh">⟳</button>
+            </div>
+          </header>
+
+          <nav class="tabs">
+            <button class="tab active" data-tab="changes">Changes</button>
+            <button class="tab" data-tab="history">History</button>
+            <button class="tab" data-tab="branches">Branches</button>
+          </nav>
+
+          <div class="tab-panels">
+            <!-- Changes -->
+            <div class="panel active" data-panel="changes">
+              <div class="changes-layout">
+                <div class="file-cols">
+                  <div class="file-col">
+                    <h3>Staged</h3>
+                    <ul id="staged-files" class="files"></ul>
+                  </div>
+                  <div class="file-col">
+                    <h3>Unstaged</h3>
+                    <ul id="unstaged-files" class="files"></ul>
+                  </div>
+                </div>
+                <div class="commit-box">
+                  <textarea id="commit-msg" placeholder="Commit message…"></textarea>
+                  <button id="commit-btn" class="primary">Commit staged</button>
+                </div>
+                <div id="diff-view" class="diff-view"></div>
+              </div>
+            </div>
+
+            <!-- History -->
+            <div class="panel" data-panel="history">
+              <ul id="history-list" class="history"></ul>
+            </div>
+
+            <!-- Branches -->
+            <div class="panel" data-panel="branches">
+              <ul id="branch-list" class="branches"></ul>
+            </div>
+          </div>
+        </section>
+      </main>
+    </div>
+
+    <!-- Operation progress overlay (sync / push / clone) -->
+    <div id="op-overlay" class="overlay" hidden>
+      <div class="op-modal">
+        <h3 id="op-title">Working…</h3>
+        <pre id="op-log" class="op-log"></pre>
+        <div class="op-foot">
+          <span id="op-status"></span>
+          <button id="op-close" hidden>Close</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Clone dialog -->
+    <dialog id="clone-dialog">
+      <form method="dialog" class="clone-form">
+        <h3>Clone a repository</h3>
+        <label>Remote URL<input id="clone-url" type="text" placeholder="lore://host:41337/org/repo" /></label>
+        <label>Destination folder<input id="clone-dest" type="text" placeholder="D:\path\to\clone" /></label>
+        <menu>
+          <button value="cancel">Cancel</button>
+          <button id="clone-go" value="default" class="primary">Clone</button>
+        </menu>
+      </form>
+    </dialog>
+
+    <div id="toast" class="toast" hidden></div>
+    <script type="module" src="/app.js"></script>
+  </body>
+</html>

--- a/lore-web/web/style.css
+++ b/lore-web/web/style.css
@@ -72,7 +72,7 @@ input:focus, textarea:focus { outline: none; border-color: var(--accent); }
 .repo-list .r-missing { color: var(--red); font-size: 11px; }
 .repo-list .r-remove { margin-left: 6px; color: var(--muted); border: none; background: none; padding: 2px 6px; }
 .repo-list .r-remove:hover { color: var(--red); }
-.side-foot { padding: 12px; border-top: 1px solid var(--border); }
+.side-foot { padding: 12px; border-top: 1px solid var(--border); display: flex; flex-direction: column; gap: 8px; }
 .side-foot button { width: 100%; }
 
 /* Main */
@@ -153,6 +153,22 @@ dialog::backdrop { background: rgba(0,0,0,0.6); }
 .clone-form h3 { margin: 0; }
 .clone-form label { display: flex; flex-direction: column; gap: 4px; font-size: 13px; color: var(--muted); }
 .clone-form menu { display: flex; gap: 8px; justify-content: flex-end; margin: 0; padding: 0; }
+.field-row { display: flex; gap: 6px; }
+.field-row input { flex: 1; min-width: 0; }
+
+/* Folder picker dialog */
+.picker { padding: 18px; display: flex; flex-direction: column; gap: 12px; width: min(520px, 92vw); }
+.picker h3 { margin: 0; }
+.picker-bar { display: flex; align-items: center; gap: 8px; }
+.picker-cur { font-size: 13px; color: var(--muted); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.picker-list { list-style: none; margin: 0; padding: 4px; height: 320px; overflow-y: auto; border: 1px solid var(--border); border-radius: var(--radius); background: var(--panel-2); }
+.picker-list li { display: flex; align-items: center; gap: 8px; padding: 7px 10px; border-radius: var(--radius); cursor: pointer; }
+.picker-list li:hover { background: var(--panel); }
+.picker-list li.muted { cursor: default; color: var(--muted); }
+.picker-list .p-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.picker-list .p-tag { margin-left: auto; font-size: 10px; text-transform: uppercase; letter-spacing: .04em; color: var(--accent); border: 1px solid var(--accent); border-radius: 4px; padding: 0 5px; }
+.picker-new { display: flex; flex-direction: column; gap: 4px; font-size: 13px; color: var(--muted); }
+.picker menu { display: flex; gap: 8px; justify-content: flex-end; margin: 0; padding: 0; }
 
 /* Toast */
 .toast { position: fixed; bottom: 20px; left: 50%; transform: translateX(-50%); background: var(--panel-2); border: 1px solid var(--border); border-radius: var(--radius); padding: 10px 16px; z-index: 60; }

--- a/lore-web/web/style.css
+++ b/lore-web/web/style.css
@@ -61,6 +61,8 @@ input:focus, textarea:focus { outline: none; border-color: var(--accent); }
 .brand .logo-web { color: var(--accent); }
 .brand .conn { margin-left: auto; font-size: 12px; color: var(--red); }
 .brand .conn.live { color: var(--green); }
+.icon-btn { margin-left: 10px; padding: 2px 6px; font-size: 14px; line-height: 1; background: transparent; border: 1px solid var(--border); }
+.icon-btn:hover { border-color: var(--accent); color: var(--accent); }
 .add-repo { display: flex; gap: 6px; padding: 0 12px 12px; }
 .add-repo input { flex: 1; min-width: 0; }
 .repo-list { list-style: none; margin: 0; padding: 0 8px; overflow-y: auto; flex: 1; }
@@ -203,6 +205,14 @@ dialog::backdrop { background: rgba(0,0,0,0.6); }
 /* Per-file ignore button */
 .files .f-ignore { color: var(--muted); border: none; background: none; padding: 2px 6px; }
 .files .f-ignore:hover { color: var(--accent); }
+
+/* Settings dialog */
+.settings-field { display: flex; gap: 6px; }
+.settings-field input { flex: 1; min-width: 0; }
+.discovered-servers { margin-top: 8px; padding: 10px; background: var(--panel-2); border-radius: var(--radius); }
+.discovered-list { list-style: none; margin: 8px 0 0; padding: 0; }
+.discovered-list li { padding: 6px 8px; background: var(--panel); border: 1px solid var(--border); border-radius: 6px; margin-bottom: 4px; cursor: pointer; font-family: ui-monospace, monospace; font-size: 12px; }
+.discovered-list li:hover { border-color: var(--accent); background: var(--panel); }
 
 /* Toast */
 .toast { position: fixed; bottom: 20px; left: 50%; transform: translateX(-50%); background: var(--panel-2); border: 1px solid var(--border); border-radius: var(--radius); padding: 10px 16px; z-index: 60; }

--- a/lore-web/web/style.css
+++ b/lore-web/web/style.css
@@ -115,10 +115,20 @@ input:focus, textarea:focus { outline: none; border-color: var(--accent); }
 
 /* History */
 .history { list-style: none; margin: 0; padding: 0; }
-.history li { padding: 12px 14px; border: 1px solid var(--border); border-radius: var(--radius); margin-bottom: 8px; background: var(--panel); }
+.history li { border: 1px solid var(--border); border-radius: var(--radius); margin-bottom: 8px; background: var(--panel); overflow: hidden; }
+.history li.open { outline: 1px solid var(--accent); }
+.history .h-row { padding: 12px 14px; cursor: pointer; }
+.history .h-row:hover { background: var(--panel-2); }
 .history .h-msg { font-weight: 600; margin-bottom: 4px; white-space: pre-wrap; }
 .history .h-meta { color: var(--muted); font-size: 12px; display: flex; gap: 12px; }
 .history .h-rev { font-family: ui-monospace, monospace; }
+.rev-detail { border-top: 1px solid var(--border); padding: 10px 14px; background: var(--bg); }
+.rev-files { list-style: none; margin: 0 0 8px; padding: 0; }
+.rev-files li { display: flex; align-items: center; gap: 8px; padding: 5px 8px; border-radius: 6px; cursor: pointer; }
+.rev-files li:hover { background: var(--panel-2); }
+.rev-files li.sel { background: var(--panel-2); outline: 1px solid var(--accent); }
+.rev-files .f-path { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.rev-diff { font-family: ui-monospace, "Cascadia Code", Consolas, monospace; font-size: 12.5px; white-space: pre; overflow-x: auto; background: var(--panel); border: 1px solid var(--border); border-radius: var(--radius); padding: 12px; margin: 0; max-height: 45vh; }
 
 /* Branches */
 .branches { list-style: none; margin: 0; padding: 0; }

--- a/lore-web/web/style.css
+++ b/lore-web/web/style.css
@@ -108,7 +108,10 @@ input:focus, textarea:focus { outline: none; border-color: var(--accent); }
 .changes-bar .bar-note { margin-right: auto; font-size: 12px; color: var(--muted); }
 .changes-bar .bar-note.warn { color: var(--yellow); }
 .file-cols { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
-.file-col h3 { margin: 0 0 8px; font-size: 13px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.5px; }
+.file-col h3 { margin: 0 0 8px; font-size: 13px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.5px; display: flex; align-items: center; justify-content: space-between; }
+.file-col h3 .link-btn { font-size: 11px; text-transform: none; letter-spacing: normal; color: var(--accent); border: none; background: none; padding: 0; cursor: pointer; }
+.file-col h3 .link-btn:hover { text-decoration: underline; }
+.file-col h3 .link-btn:disabled { color: var(--muted); cursor: default; text-decoration: none; }
 .files { list-style: none; margin: 0; padding: 0; }
 .files li { display: flex; align-items: center; gap: 8px; padding: 6px 8px; border-radius: 6px; }
 .files li:hover { background: var(--panel-2); }

--- a/lore-web/web/style.css
+++ b/lore-web/web/style.css
@@ -17,7 +17,7 @@
 
 * { box-sizing: border-box; }
 /* The `hidden` attribute must win over component `display` rules below
-   (e.g. .overlay { display: grid }), otherwise hidden panels stay visible. */
+   (for example, .overlay { display: grid }), otherwise hidden panels stay visible. */
 [hidden] { display: none !important; }
 html, body { margin: 0; height: 100%; }
 body {
@@ -173,6 +173,17 @@ dialog::backdrop { background: rgba(0,0,0,0.6); }
 .picker-list li.muted { cursor: default; color: var(--muted); }
 .picker-list .p-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .picker-list .p-tag { margin-left: auto; font-size: 10px; text-transform: uppercase; letter-spacing: .04em; color: var(--accent); border: 1px solid var(--accent); border-radius: 4px; padding: 0 5px; }
+/* The Server repositories list is short and inline, not a full picker. Rows are
+   not selectable — each carries its own Clone and Delete actions instead. */
+#server-repos { height: auto; max-height: 280px; }
+#server-repos li { cursor: default; }
+#server-repos .p-name { margin-right: auto; }
+#server-repos .p-tag { margin-left: 0; }
+#server-repos .p-clone { margin-left: 8px; border: 1px solid var(--border); background: var(--panel-2); color: var(--fg, inherit); cursor: pointer; font-size: 11px; padding: 2px 8px; border-radius: 4px; opacity: 0; }
+#server-repos .p-del { margin-left: 6px; border: none; background: transparent; color: var(--muted); cursor: pointer; font-size: 13px; line-height: 1; padding: 2px 6px; border-radius: 4px; opacity: 0; }
+#server-repos li:hover .p-clone, #server-repos li:hover .p-del { opacity: 1; }
+#server-repos .p-clone:hover { border-color: var(--accent); color: var(--accent); }
+#server-repos .p-del:hover { background: var(--danger, #c0392b); color: #fff; }
 .picker-new { display: flex; flex-direction: column; gap: 4px; font-size: 13px; color: var(--muted); }
 .picker menu { display: flex; gap: 8px; justify-content: flex-end; margin: 0; padding: 0; }
 

--- a/lore-web/web/style.css
+++ b/lore-web/web/style.css
@@ -160,6 +160,10 @@ input:focus, textarea:focus { outline: none; border-color: var(--accent); }
 .op-modal { background: var(--panel); border: 1px solid var(--border); border-radius: 12px; width: min(720px, 92vw); max-height: 80vh; display: flex; flex-direction: column; }
 .op-modal h3 { margin: 0; padding: 16px 18px; border-bottom: 1px solid var(--border); }
 .op-log { flex: 1; overflow: auto; margin: 0; padding: 14px 18px; font-family: ui-monospace, monospace; font-size: 12px; color: var(--muted); white-space: pre-wrap; max-height: 50vh; }
+.op-progress { padding: 0 18px 14px; display: flex; flex-direction: column; gap: 6px; }
+.op-bar { height: 6px; border-radius: 3px; background: var(--border); overflow: hidden; }
+#op-bar-fill { height: 100%; width: 0%; background: var(--accent); transition: width .15s ease-out; }
+#op-progress-text { font-size: 12px; color: var(--muted); }
 .op-foot { display: flex; align-items: center; justify-content: space-between; padding: 12px 18px; border-top: 1px solid var(--border); }
 #op-status.ok { color: var(--green); }
 #op-status.fail { color: var(--red); }

--- a/lore-web/web/style.css
+++ b/lore-web/web/style.css
@@ -37,6 +37,9 @@ button {
 button:hover { border-color: var(--accent); }
 button.primary { background: var(--accent); color: #0b0d12; border-color: var(--accent); font-weight: 600; }
 button.primary:hover { background: var(--accent-press); }
+button.danger { background: var(--red); color: #0b0d12; border-color: var(--red); font-weight: 600; }
+button.danger:hover { background: var(--red); filter: brightness(1.1); }
+.warn { color: var(--red); font-size: 12px; line-height: 1.4; margin: 4px 0 0; }
 button.ghost { background: transparent; }
 button:disabled { opacity: 0.5; cursor: not-allowed; }
 input, textarea {
@@ -68,6 +71,7 @@ input:focus, textarea:focus { outline: none; border-color: var(--accent); }
 .repo-list li:hover { background: var(--panel-2); }
 .repo-list li.active { background: var(--panel-2); outline: 1px solid var(--accent); }
 .repo-list .r-name { font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.repo-list .r-org { color: var(--accent); font-size: 11px; background: var(--panel-2); border: 1px solid var(--border); border-radius: 10px; padding: 0 6px; }
 .repo-list .r-branch { color: var(--muted); font-size: 12px; margin-left: auto; }
 .repo-list .r-missing { color: var(--red); font-size: 11px; }
 .repo-list .r-remove { margin-left: 6px; color: var(--muted); border: none; background: none; padding: 2px 6px; }
@@ -83,6 +87,9 @@ input:focus, textarea:focus { outline: none; border-color: var(--accent); }
 .repo-head h1 { margin: 0 0 6px; font-size: 18px; }
 .repo-sub { display: flex; align-items: center; gap: 10px; }
 .pill { background: var(--panel-2); border: 1px solid var(--border); border-radius: 20px; padding: 2px 10px; font-size: 12px; color: var(--accent); }
+.org-pill { cursor: pointer; font: inherit; font-size: 12px; }
+.org-pill:hover { border-color: var(--accent); }
+.org-pill.org-empty { color: var(--muted); font-style: italic; }
 .muted { color: var(--muted); font-size: 12px; }
 .repo-actions { display: flex; gap: 8px; }
 

--- a/lore-web/web/style.css
+++ b/lore-web/web/style.css
@@ -1,0 +1,149 @@
+/* lore-web UI — minimal dark theme, no framework. */
+:root {
+  --bg: #0f1115;
+  --panel: #171a21;
+  --panel-2: #1d212b;
+  --border: #2a2f3a;
+  --text: #e6e9ef;
+  --muted: #8b93a7;
+  --accent: #6ea8fe;
+  --accent-press: #4f8cf0;
+  --green: #5fd07a;
+  --red: #e5707a;
+  --yellow: #e6c06a;
+  --radius: 8px;
+  font-size: 14px;
+}
+
+* { box-sizing: border-box; }
+/* The `hidden` attribute must win over component `display` rules below
+   (e.g. .overlay { display: grid }), otherwise hidden panels stay visible. */
+[hidden] { display: none !important; }
+html, body { margin: 0; height: 100%; }
+body {
+  background: var(--bg);
+  color: var(--text);
+  font-family: "Segoe UI", system-ui, -apple-system, sans-serif;
+}
+button {
+  font: inherit;
+  color: var(--text);
+  background: var(--panel-2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 6px 12px;
+  cursor: pointer;
+}
+button:hover { border-color: var(--accent); }
+button.primary { background: var(--accent); color: #0b0d12; border-color: var(--accent); font-weight: 600; }
+button.primary:hover { background: var(--accent-press); }
+button.ghost { background: transparent; }
+button:disabled { opacity: 0.5; cursor: not-allowed; }
+input, textarea {
+  font: inherit;
+  color: var(--text);
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 6px 9px;
+}
+input:focus, textarea:focus { outline: none; border-color: var(--accent); }
+
+#app { display: grid; grid-template-columns: 280px 1fr; height: 100vh; }
+
+/* Sidebar */
+#sidebar { background: var(--panel); border-right: 1px solid var(--border); display: flex; flex-direction: column; }
+.brand { display: flex; align-items: center; gap: 2px; padding: 16px; font-size: 20px; font-weight: 700; }
+.brand .logo { color: var(--text); }
+.brand .logo-web { color: var(--accent); }
+.brand .conn { margin-left: auto; font-size: 12px; color: var(--red); }
+.brand .conn.live { color: var(--green); }
+.add-repo { display: flex; gap: 6px; padding: 0 12px 12px; }
+.add-repo input { flex: 1; min-width: 0; }
+.repo-list { list-style: none; margin: 0; padding: 0 8px; overflow-y: auto; flex: 1; }
+.repo-list li {
+  padding: 9px 10px; border-radius: var(--radius); cursor: pointer;
+  display: flex; align-items: center; gap: 8px; margin-bottom: 2px;
+}
+.repo-list li:hover { background: var(--panel-2); }
+.repo-list li.active { background: var(--panel-2); outline: 1px solid var(--accent); }
+.repo-list .r-name { font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.repo-list .r-branch { color: var(--muted); font-size: 12px; margin-left: auto; }
+.repo-list .r-missing { color: var(--red); font-size: 11px; }
+.repo-list .r-remove { margin-left: 6px; color: var(--muted); border: none; background: none; padding: 2px 6px; }
+.repo-list .r-remove:hover { color: var(--red); }
+.side-foot { padding: 12px; border-top: 1px solid var(--border); }
+.side-foot button { width: 100%; }
+
+/* Main */
+#main { overflow: hidden; display: flex; flex-direction: column; }
+.empty { display: grid; place-items: center; height: 100%; color: var(--muted); }
+#repo-view { display: flex; flex-direction: column; height: 100%; }
+.repo-head { display: flex; align-items: flex-start; justify-content: space-between; padding: 16px 20px; border-bottom: 1px solid var(--border); }
+.repo-head h1 { margin: 0 0 6px; font-size: 18px; }
+.repo-sub { display: flex; align-items: center; gap: 10px; }
+.pill { background: var(--panel-2); border: 1px solid var(--border); border-radius: 20px; padding: 2px 10px; font-size: 12px; color: var(--accent); }
+.muted { color: var(--muted); font-size: 12px; }
+.repo-actions { display: flex; gap: 8px; }
+
+.tabs { display: flex; gap: 4px; padding: 8px 20px 0; border-bottom: 1px solid var(--border); }
+.tab { background: none; border: none; border-bottom: 2px solid transparent; border-radius: 0; padding: 8px 12px; color: var(--muted); }
+.tab.active { color: var(--text); border-bottom-color: var(--accent); }
+.tab-panels { flex: 1; overflow: auto; }
+.panel { display: none; padding: 16px 20px; }
+.panel.active { display: block; }
+
+/* Changes */
+.file-cols { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+.file-col h3 { margin: 0 0 8px; font-size: 13px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.5px; }
+.files { list-style: none; margin: 0; padding: 0; }
+.files li { display: flex; align-items: center; gap: 8px; padding: 6px 8px; border-radius: 6px; }
+.files li:hover { background: var(--panel-2); }
+.files .f-path { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; cursor: pointer; }
+.files .f-act { font-size: 11px; color: var(--muted); padding: 1px 6px; border-radius: 4px; border: 1px solid var(--border); }
+.files .badge-A { color: var(--green); }
+.files .badge-M { color: var(--yellow); }
+.files .badge-D { color: var(--red); }
+.commit-box { margin-top: 18px; display: flex; flex-direction: column; gap: 8px; }
+.commit-box textarea { min-height: 64px; resize: vertical; }
+.commit-box button { align-self: flex-start; }
+.diff-view { margin-top: 16px; font-family: ui-monospace, "Cascadia Code", Consolas, monospace; font-size: 12.5px; white-space: pre; overflow-x: auto; background: var(--panel); border: 1px solid var(--border); border-radius: var(--radius); padding: 12px; display: none; }
+.diff-view.show { display: block; }
+.diff-add { color: var(--green); }
+.diff-del { color: var(--red); }
+.diff-hunk { color: var(--accent); }
+
+/* History */
+.history { list-style: none; margin: 0; padding: 0; }
+.history li { padding: 12px 14px; border: 1px solid var(--border); border-radius: var(--radius); margin-bottom: 8px; background: var(--panel); }
+.history .h-msg { font-weight: 600; margin-bottom: 4px; white-space: pre-wrap; }
+.history .h-meta { color: var(--muted); font-size: 12px; display: flex; gap: 12px; }
+.history .h-rev { font-family: ui-monospace, monospace; }
+
+/* Branches */
+.branches { list-style: none; margin: 0; padding: 0; }
+.branches li { display: flex; align-items: center; gap: 10px; padding: 10px 12px; border-bottom: 1px solid var(--border); }
+.branches .b-current { color: var(--green); }
+.branches .b-name { font-weight: 600; }
+.branches .b-loc { color: var(--muted); font-size: 12px; }
+
+/* Operation overlay */
+.overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.6); display: grid; place-items: center; z-index: 50; }
+.op-modal { background: var(--panel); border: 1px solid var(--border); border-radius: 12px; width: min(720px, 92vw); max-height: 80vh; display: flex; flex-direction: column; }
+.op-modal h3 { margin: 0; padding: 16px 18px; border-bottom: 1px solid var(--border); }
+.op-log { flex: 1; overflow: auto; margin: 0; padding: 14px 18px; font-family: ui-monospace, monospace; font-size: 12px; color: var(--muted); white-space: pre-wrap; max-height: 50vh; }
+.op-foot { display: flex; align-items: center; justify-content: space-between; padding: 12px 18px; border-top: 1px solid var(--border); }
+#op-status.ok { color: var(--green); }
+#op-status.fail { color: var(--red); }
+
+/* Clone dialog */
+dialog { background: var(--panel); color: var(--text); border: 1px solid var(--border); border-radius: 12px; padding: 0; }
+dialog::backdrop { background: rgba(0,0,0,0.6); }
+.clone-form { padding: 18px; display: flex; flex-direction: column; gap: 12px; width: min(460px, 90vw); }
+.clone-form h3 { margin: 0; }
+.clone-form label { display: flex; flex-direction: column; gap: 4px; font-size: 13px; color: var(--muted); }
+.clone-form menu { display: flex; gap: 8px; justify-content: flex-end; margin: 0; padding: 0; }
+
+/* Toast */
+.toast { position: fixed; bottom: 20px; left: 50%; transform: translateX(-50%); background: var(--panel-2); border: 1px solid var(--border); border-radius: var(--radius); padding: 10px 16px; z-index: 60; }
+.toast.err { border-color: var(--red); color: var(--red); }

--- a/lore-web/web/style.css
+++ b/lore-web/web/style.css
@@ -94,6 +94,10 @@ input:focus, textarea:focus { outline: none; border-color: var(--accent); }
 .panel.active { display: block; }
 
 /* Changes */
+.changes-bar { display: flex; align-items: center; justify-content: flex-end; gap: 8px; margin-bottom: 12px; }
+.changes-bar:empty { display: none; }
+.changes-bar .bar-note { margin-right: auto; font-size: 12px; color: var(--muted); }
+.changes-bar .bar-note.warn { color: var(--yellow); }
 .file-cols { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
 .file-col h3 { margin: 0 0 8px; font-size: 13px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.5px; }
 .files { list-style: none; margin: 0; padding: 0; }
@@ -104,6 +108,8 @@ input:focus, textarea:focus { outline: none; border-color: var(--accent); }
 .files .badge-A { color: var(--green); }
 .files .badge-M { color: var(--yellow); }
 .files .badge-D { color: var(--red); }
+.files .badge-nested { color: var(--accent); }
+.files .badge-stale { color: var(--yellow); }
 .commit-box { margin-top: 18px; display: flex; flex-direction: column; gap: 8px; }
 .commit-box textarea { min-height: 64px; resize: vertical; }
 .commit-box button { align-self: flex-start; }
@@ -169,6 +175,16 @@ dialog::backdrop { background: rgba(0,0,0,0.6); }
 .picker-list .p-tag { margin-left: auto; font-size: 10px; text-transform: uppercase; letter-spacing: .04em; color: var(--accent); border: 1px solid var(--accent); border-radius: 4px; padding: 0 5px; }
 .picker-new { display: flex; flex-direction: column; gap: 4px; font-size: 13px; color: var(--muted); }
 .picker menu { display: flex; gap: 8px; justify-content: flex-end; margin: 0; padding: 0; }
+
+/* Ignore chooser */
+.ignore-options { list-style: none; margin: 0; padding: 4px; border: 1px solid var(--border); border-radius: var(--radius); background: var(--panel-2); }
+.ignore-options li { display: flex; align-items: baseline; gap: 10px; padding: 9px 10px; border-radius: var(--radius); cursor: pointer; }
+.ignore-options li:hover { background: var(--panel); }
+.ignore-options code { font-family: ui-monospace, "Cascadia Code", Consolas, monospace; color: var(--accent); }
+
+/* Per-file ignore button */
+.files .f-ignore { color: var(--muted); border: none; background: none; padding: 2px 6px; }
+.files .f-ignore:hover { color: var(--accent); }
 
 /* Toast */
 .toast { position: fixed; bottom: 20px; left: 50%; transform: translateX(-50%); background: var(--panel-2); border: 1px solid var(--border); border-radius: var(--radius); padding: 10px 16px; z-index: 60; }


### PR DESCRIPTION
A small Node + browser app that drives Lore through @lore-vcs/sdk with refresh logic it controls, replacing daily use of the desktop client.

- Server uses Node stdlib only (http, fs.watch, JSON store) plus the SDK; no web framework, no database, no build step.
- Persists no view state: repository and revision lists are read live and refresh on file-watch events, window focus, and a slow poll. Fixes the desktop's stale-until-restart lists.
- Removing a repository whose folder is gone always succeeds.
- Streams sync/push/clone progress; surfaces failures via the SDK COMPLETE-event error contract.
- Vanilla-JS SPA; Diátaxis docs; unit tests; Windows setup/start scripts.