### PR TITLE
Fix generic aarch64 Linux builds

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -97,12 +97,14 @@ rustflags = [
 #  The rust flags for this would be ["-C", "linker-flavor=lld-link"]
 
 [target.aarch64-unknown-linux-gnu]
-# Target Graviton3+
+# Keep the default aarch64 Linux build portable. Release jobs that produce a
+# Neoverse 512-bit vector/SVE artifact can opt in by setting a full
+# CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_RUSTFLAGS replacement that includes
+# target-cpu=neoverse-512tvb, plus LORE_AARCH64_NEOVERSE_512TVB=1 for C sources.
 rustflags = [
     "--cfg", "tokio_unstable",
     "-C", "force-unwind-tables=yes",
     "-C", "force-frame-pointers=yes",
-    "-C", "target-cpu=neoverse-512tvb",
     # Leave debug symbols in the binary for now, we want these in place for the server binary, but still split them via
     # package-cli.sh for CLI binaries.
     "-C", "split-debuginfo=off",

--- a/docs/how-to/deploy-local-lore-server.md
+++ b/docs/how-to/deploy-local-lore-server.md
@@ -15,7 +15,7 @@ In this guide, you'll deploy local Lore Servers — with durable storage and a c
 The binary and Docker paths are mutually exclusive, and each is complete on its own — follow one top to bottom.
 
 - **[Run from the binary](#run-from-the-binary):** Fewer moving parts and native performance. Pick this to run `loreserver` directly on the host.
-- **[Run with Docker](#run-with-docker):** An isolated container. Pick this if you'd rather not put a binary on the host — but note the `linux/amd64` emulation caveat on Apple Silicon in the build step.
+- **[Run with Docker](#run-with-docker):** An isolated container. Pick this if you'd rather not put a binary on the host.
 
 ## Run from the binary
 
@@ -196,11 +196,8 @@ The binary and Docker paths are mutually exclusive, and each is complete on its 
     This needs Docker (and WSL2 on Windows) and the Lore repository cloned locally. Building the image compiles the server, so it needs several GB of free RAM. From the repository root:
 
     ```bash
-    docker build --platform linux/amd64 -f lore-server/Dockerfile -t lore-server .
+    docker build -f lore-server/Dockerfile -t lore-server .
     ```
-
-    > [!NOTE]
-    > On Apple Silicon or Windows (both arm64 and amd64), build and run with `--platform linux/amd64` as shown. The `linux/arm64` server image targets AWS Graviton3 (SVE), an instruction set those CPUs lack.
 
 2. **Run it with default settings.**
 

--- a/lore-base/build.rs
+++ b/lore-base/build.rs
@@ -5,6 +5,8 @@ use std::path::Path;
 
 include!("../build-helper.rs");
 
+const AARCH64_NEOVERSE_512TVB_ENV: &str = "LORE_AARCH64_NEOVERSE_512TVB";
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Populate environment with build details
     vergen::Emitter::default()
@@ -25,7 +27,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .opt_level(3)
         .includes(Some(native_dir.join("thirdparty")));
 
-    if platform == "linux" && arch == "aarch64" {
+    println!("cargo:rerun-if-env-changed={}", AARCH64_NEOVERSE_512TVB_ENV);
+
+    if platform == "linux" && arch == "aarch64" && env_flag_enabled(AARCH64_NEOVERSE_512TVB_ENV) {
         cc_builder.flag("-mcpu=neoverse-512tvb");
     }
 
@@ -47,4 +51,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     cc_builder.clone().file(rpmalloc_source).compile("rpmalloc");
 
     Ok(())
+}
+
+fn env_flag_enabled(name: &str) -> bool {
+    env::var(name)
+        .map(|value| value == "1" || value.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
 }

--- a/lore-base/build.rs
+++ b/lore-base/build.rs
@@ -27,7 +27,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .opt_level(3)
         .includes(Some(native_dir.join("thirdparty")));
 
-    println!("cargo:rerun-if-env-changed={}", AARCH64_NEOVERSE_512TVB_ENV);
+    println!("cargo:rerun-if-env-changed={AARCH64_NEOVERSE_512TVB_ENV}");
 
     if platform == "linux" && arch == "aarch64" && env_flag_enabled(AARCH64_NEOVERSE_512TVB_ENV) {
         cc_builder.flag("-mcpu=neoverse-512tvb");
@@ -54,7 +54,5 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 fn env_flag_enabled(name: &str) -> bool {
-    env::var(name)
-        .map(|value| value == "1" || value.eq_ignore_ascii_case("true"))
-        .unwrap_or(false)
+    env::var(name).is_ok_and(|value| value == "1" || value.eq_ignore_ascii_case("true"))
 }

--- a/lore-server/DOCKER.md
+++ b/lore-server/DOCKER.md
@@ -6,15 +6,13 @@ telemetry integration, or replication is configured.
 ## Prerequisites
 
 - Docker with BuildKit support
-- On Apple Silicon (M-series Macs), builds must target `linux/amd64` due to Graviton-specific
-  compiler flags in `.cargo/config.toml` for `aarch64-unknown-linux-gnu`
 
 ## Building
 
 From the repository root:
 
 ```sh
-docker build --platform linux/amd64 -f lore-server/Dockerfile -t loreserver .
+docker build -f lore-server/Dockerfile -t loreserver .
 ```
 
 The build compiles the `loreserver` binary and generates self-signed TLS certificates for QUIC


### PR DESCRIPTION
### Summary

This PR makes the default `aarch64-unknown-linux-gnu` build portable again by
removing the hardcoded Graviton3/Neoverse 512-bit vector tuning from the generic
aarch64 path.

Previously, two default build paths forced `neoverse-512tvb` for all Linux
aarch64 builds:

- `.cargo/config.toml` passed `-C target-cpu=neoverse-512tvb` through Cargo
  rustflags.
- `lore-base/build.rs` passed `-mcpu=neoverse-512tvb` to the C compiler for
  rpmalloc.

That target assumes CPU features that are not present on many valid aarch64
Linux hosts. On this Cortex-A55 arm64 host, the Rust flag caused a build-script
SIGILL, and the C flag produced binaries that built successfully but failed at
runtime with an illegal instruction in rpmalloc.

The default aarch64 Linux build now uses the portable baseline. Release jobs
that intentionally build a Neoverse/Graviton tuned artifact can still opt in
without a custom target JSON:

- Set a full `CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_RUSTFLAGS` replacement
  including `-C target-cpu=neoverse-512tvb`.
- Set `LORE_AARCH64_NEOVERSE_512TVB=1` so the rpmalloc C build receives
  `-mcpu=neoverse-512tvb`.

This also removes stale Docker docs that required arm64 users to force
`linux/amd64` builds because of the previous hardcoded Graviton flags.

### Testing

Tested on a native aarch64 Linux host that lacks SVE:

- `cargo fmt --all --check`
- `git diff --check`
- `env -u LORE_AARCH64_NEOVERSE_512TVB cargo build`
- `target/debug/lore --version`
- `target/debug/loreserver --version`
- `target/debug/lore_chaos_client --version`
- `env -u LORE_AARCH64_NEOVERSE_512TVB cargo build --release`
- `target/release/lore --version`
- `target/release/loreserver --version`
- `target/release/lore_chaos_client --version`
- Release binary smoke test:
  start `loreserver`, create a repository, stage/commit/push text and binary
  files, create a shared store, clone a second worktree, branch, commit, merge,
  push, sync the clone, and confirm both worktrees are in sync.
- Isolated opt-in check:
  `CC_ENABLE_DEBUG_OUTPUT=1 LORE_AARCH64_NEOVERSE_512TVB=1 cargo build -p lore-base -vv`
  with a temporary `CARGO_TARGET_DIR`, verifying the C compiler command contains
  `-mcpu=neoverse-512tvb`.

Stable `rustfmt` prints existing warnings that the repo's unstable rustfmt
options require nightly, but the formatting check completed successfully.
