### PR TITLE
fix: add transport connect timeouts so local reads don't stall on unreachable remotes

### DIFF
--- a/lore-revision/src/repository/status.rs
+++ b/lore-revision/src/repository/status.rs
@@ -806,52 +806,45 @@ async fn count_subtrees(roots: Vec<CountWork>) -> Result<(u64, u64), StatusError
     Ok((directories, files))
 }
 
-const REMOTE_RESOLVE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3);
-
-/// Time-boxed remote branch resolution that degrades gracefully on timeout.
+/// Remote branch resolution that degrades gracefully on unavailability.
 ///
 /// Resolves the latest revision and authorization status of a branch on the
-/// configured remote, timing out after the given deadline. On timeout or remote
-/// unavailability, degrades to (None, false, false) — same shape as `NoRemote` —
-/// ensuring an unreachable remote never stalls a local status read.
+/// configured remote. On remote unavailability, degrades to (None, false, false) —
+/// same shape as `NoRemote` — ensuring an unreachable remote never stalls a local
+/// status read. Transport-level connect timeouts in lore-transport bound the wait;
+/// status is a local read that reports remote state opportunistically.
 ///
 /// # Arguments
 ///
 /// * `repository` — repository context with the configured remote.
 /// * `branch_id` — the branch to query on the remote.
-/// * `deadline` — maximum time to wait for remote resolution.
 ///
 /// # Returns
 ///
 /// A 3-tuple `(latest, authorized, available)` where:
 /// - `latest` is the remote branch's latest revision hash, or None if unresolved.
 /// - `authorized` is true iff the remote query returned an authoritative answer.
-/// - `available` is true iff the remote connected and responded within the deadline
+/// - `available` is true iff the remote connected and responded successfully
 ///   (even if with a non-branch-not-found error; a reachable server that errors is not unavailable).
 async fn resolve_remote_latest(
     repository: &Arc<RepositoryContext>,
     branch_id: BranchId,
-    deadline: std::time::Duration,
 ) -> (Option<Hash>, bool, bool) {
-    async fn inner(
-        repository: &Arc<RepositoryContext>,
-        branch_id: BranchId,
-    ) -> (Option<Hash>, bool, bool) {
-        let remote = match repository.remote().await {
-            Ok(r) => r,
-            Err(_) => return (None, false, false),
-        };
-
-        match branch::load_remote(remote, repository.id, branch_id).await {
-            Ok(status) => (Some(status.latest), true, true),
-            Err(err) if err.is_branch_not_found() => (None, true, true),
-            Err(_) => (None, false, true),
+    let remote = match repository.remote().await {
+        Ok(r) => r,
+        Err(err) => {
+            lore_debug!("Remote unavailable for status: {err}");
+            return (None, false, false);
         }
-    }
+    };
 
-    match tokio::time::timeout(deadline, inner(repository, branch_id)).await {
-        Ok((latest, authorized, available)) => (latest, authorized, available),
-        Err(_) => (None, false, false),
+    match branch::load_remote(remote, repository.id, branch_id).await {
+        Ok(status) => (Some(status.latest), true, true),
+        Err(err) if err.is_branch_not_found() => (None, true, true),
+        Err(err) => {
+            lore_debug!("Remote branch query failed: {err}");
+            (None, false, true)
+        }
     }
 }
 
@@ -957,7 +950,7 @@ pub async fn status(
     // Authorized only on an authoritative answer — a latest revision
     // or branch not found; proving the identity is authorized and has access
     let (remote_latest, remote_authorized, remote_available) =
-        resolve_remote_latest(&repository, branch.id, REMOTE_RESOLVE_TIMEOUT).await;
+        resolve_remote_latest(&repository, branch.id).await;
 
     let remote_state = if let Some(remote_latest) = remote_latest {
         state::State::deserialize(repository.clone(), remote_latest)
@@ -1504,16 +1497,19 @@ pub async fn status(
 
 #[cfg(test)]
 mod remote_resolve_tests {
-    use std::future::pending;
-
-    use futures::FutureExt;
+    use lore_transport::ProtocolError;
 
     use super::*;
+    use crate::errors::Disconnected;
     use crate::lore::BranchId;
     use crate::repository::RemoteState;
     use crate::repository::RepositoryContext;
     use crate::repository::RepositoryFormat;
     use crate::repository::create_client_memory_stores;
+
+    fn disconnected() -> ProtocolError {
+        ProtocolError::from(Disconnected)
+    }
 
     async fn context_with_state(state: RemoteState) -> Arc<RepositoryContext> {
         let (immutable, mutable) = create_client_memory_stores()
@@ -1532,37 +1528,28 @@ mod remote_resolve_tests {
     }
 
     #[tokio::test]
-    async fn hung_remote_resolution_times_out_and_degrades() {
-        let never: futures::future::BoxFuture<'static, _> = pending().boxed();
-        let shared = never.shared();
-        let ctx = context_with_state(RemoteState::Pending(shared)).await;
-
-        let result = resolve_remote_latest(
-            &ctx,
-            BranchId::default(),
-            std::time::Duration::from_millis(10),
-        )
-        .await;
-
-        assert_eq!(
-            result,
-            (None, false, false),
-            "timeout should degrade to unavailable"
-        );
-    }
-
-    #[tokio::test]
     async fn offline_remote_resolves_to_unavailable() {
         let ctx = context_with_state(RemoteState::Offline).await;
 
-        let result =
-            resolve_remote_latest(&ctx, BranchId::default(), std::time::Duration::from_secs(3))
-                .await;
+        let result = resolve_remote_latest(&ctx, BranchId::default()).await;
 
         assert_eq!(
             result,
             (None, false, false),
             "offline should degrade to unavailable"
+        );
+    }
+
+    #[tokio::test]
+    async fn failed_remote_resolves_to_unavailable() {
+        let ctx = context_with_state(RemoteState::Failed(disconnected())).await;
+
+        let result = resolve_remote_latest(&ctx, BranchId::default()).await;
+
+        assert_eq!(
+            result,
+            (None, false, false),
+            "failed remote should degrade to unavailable"
         );
     }
 }

--- a/lore-revision/src/repository/status.rs
+++ b/lore-revision/src/repository/status.rs
@@ -806,26 +806,12 @@ async fn count_subtrees(roots: Vec<CountWork>) -> Result<(u64, u64), StatusError
     Ok((directories, files))
 }
 
-/// Remote branch resolution that degrades gracefully on unavailability.
+/// Resolve the remote's latest revision for a branch, degrading to the existing
+/// `NoRemote` state when the remote is unavailable so an unreachable remote never
+/// stalls a local status read; transport connect timeouts bound the wait.
 ///
-/// Resolves the latest revision and authorization status of a branch on the
-/// configured remote. On remote unavailability, degrades to (None, false, false) —
-/// same shape as `NoRemote` — ensuring an unreachable remote never stalls a local
-/// status read. Transport-level connect timeouts in lore-transport bound the wait;
-/// status is a local read that reports remote state opportunistically.
-///
-/// # Arguments
-///
-/// * `repository` — repository context with the configured remote.
-/// * `branch_id` — the branch to query on the remote.
-///
-/// # Returns
-///
-/// A 3-tuple `(latest, authorized, available)` where:
-/// - `latest` is the remote branch's latest revision hash, or None if unresolved.
-/// - `authorized` is true iff the remote query returned an authoritative answer.
-/// - `available` is true iff the remote connected and responded successfully
-///   (even if with a non-branch-not-found error; a reachable server that errors is not unavailable).
+/// Returns `(latest, authorized, available)`, where `available` reflects
+/// connectivity, not query success — a reachable remote that errors is still available.
 async fn resolve_remote_latest(
     repository: &Arc<RepositoryContext>,
     branch_id: BranchId,

--- a/lore-revision/src/repository/status.rs
+++ b/lore-revision/src/repository/status.rs
@@ -806,6 +806,55 @@ async fn count_subtrees(roots: Vec<CountWork>) -> Result<(u64, u64), StatusError
     Ok((directories, files))
 }
 
+const REMOTE_RESOLVE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3);
+
+/// Time-boxed remote branch resolution that degrades gracefully on timeout.
+///
+/// Resolves the latest revision and authorization status of a branch on the
+/// configured remote, timing out after the given deadline. On timeout or remote
+/// unavailability, degrades to (None, false, false) — same shape as NoRemote —
+/// ensuring an unreachable remote never stalls a local status read.
+///
+/// # Arguments
+///
+/// * `repository` — repository context with the configured remote.
+/// * `branch_id` — the branch to query on the remote.
+/// * `deadline` — maximum time to wait for remote resolution.
+///
+/// # Returns
+///
+/// A 3-tuple `(latest, authorized, available)` where:
+/// - `latest` is the remote branch's latest revision hash, or None if unresolved.
+/// - `authorized` is true iff the remote query returned an authoritative answer.
+/// - `available` is true iff the remote connected and responded within the deadline
+///   (even if with a non-branch-not-found error; a reachable server that errors is not unavailable).
+async fn resolve_remote_latest(
+    repository: &Arc<RepositoryContext>,
+    branch_id: BranchId,
+    deadline: std::time::Duration,
+) -> (Option<Hash>, bool, bool) {
+    async fn inner(
+        repository: &Arc<RepositoryContext>,
+        branch_id: BranchId,
+    ) -> (Option<Hash>, bool, bool) {
+        let remote = match repository.remote().await {
+            Ok(r) => r,
+            Err(_) => return (None, false, false),
+        };
+
+        match branch::load_remote(remote, repository.id, branch_id).await {
+            Ok(status) => (Some(status.latest), true, true),
+            Err(err) if err.is_branch_not_found() => (None, true, true),
+            Err(_) => (None, false, true),
+        }
+    }
+
+    match tokio::time::timeout(deadline, inner(repository, branch_id)).await {
+        Ok((latest, authorized, available)) => (latest, authorized, available),
+        Err(_) => (None, false, false),
+    }
+}
+
 pub async fn status(
     repository: Arc<RepositoryContext>,
     paths: Option<Vec<RelativePath>>,
@@ -907,14 +956,8 @@ pub async fn status(
 
     // Authorized only on an authoritative answer — a latest revision
     // or branch not found; proving the identity is authorized and has access
-    let (remote_latest, remote_authorized) = match repository.remote().await {
-        Ok(remote) => match branch::load_remote(remote, repository.id, branch.id).await {
-            Ok(status) => (Some(status.latest), true),
-            Err(err) if err.is_branch_not_found() => (None, true),
-            Err(_) => (None, false),
-        },
-        Err(_) => (None, false),
-    };
+    let (remote_latest, remote_authorized, remote_available) =
+        resolve_remote_latest(&repository, branch.id, REMOTE_RESOLVE_TIMEOUT).await;
 
     let remote_state = if let Some(remote_latest) = remote_latest {
         state::State::deserialize(repository.clone(), remote_latest)
@@ -1080,7 +1123,7 @@ pub async fn status(
             },
             local_ahead,
             remote_ahead,
-            repository.remote().await.is_ok(),
+            remote_available,
             remote_authorized,
             remote_latest.is_some(),
         );
@@ -1457,4 +1500,69 @@ pub async fn status(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod remote_resolve_tests {
+    use std::future::pending;
+
+    use futures::FutureExt;
+
+    use super::*;
+    use crate::lore::BranchId;
+    use crate::repository::RemoteState;
+    use crate::repository::RepositoryContext;
+    use crate::repository::RepositoryFormat;
+    use crate::repository::create_client_memory_stores;
+
+    async fn context_with_state(state: RemoteState) -> Arc<RepositoryContext> {
+        let (immutable, mutable) = create_client_memory_stores()
+            .await
+            .expect("in-memory stores should be creatable");
+        Arc::new(RepositoryContext::new_with_state(
+            None,
+            immutable,
+            mutable,
+            crate::lore::RepositoryId::default(),
+            crate::instance::InstanceId::default(),
+            state,
+            Arc::default(),
+            RepositoryFormat::Lore,
+        ))
+    }
+
+    #[tokio::test]
+    async fn hung_remote_resolution_times_out_and_degrades() {
+        let never: futures::future::BoxFuture<'static, _> = pending().boxed();
+        let shared = never.shared();
+        let ctx = context_with_state(RemoteState::Pending(shared)).await;
+
+        let result = resolve_remote_latest(
+            &ctx,
+            BranchId::default(),
+            std::time::Duration::from_millis(10),
+        )
+        .await;
+
+        assert_eq!(
+            result,
+            (None, false, false),
+            "timeout should degrade to unavailable"
+        );
+    }
+
+    #[tokio::test]
+    async fn offline_remote_resolves_to_unavailable() {
+        let ctx = context_with_state(RemoteState::Offline).await;
+
+        let result =
+            resolve_remote_latest(&ctx, BranchId::default(), std::time::Duration::from_secs(3))
+                .await;
+
+        assert_eq!(
+            result,
+            (None, false, false),
+            "offline should degrade to unavailable"
+        );
+    }
 }

--- a/lore-revision/src/repository/status.rs
+++ b/lore-revision/src/repository/status.rs
@@ -812,7 +812,7 @@ const REMOTE_RESOLVE_TIMEOUT: std::time::Duration = std::time::Duration::from_se
 ///
 /// Resolves the latest revision and authorization status of a branch on the
 /// configured remote, timing out after the given deadline. On timeout or remote
-/// unavailability, degrades to (None, false, false) — same shape as NoRemote —
+/// unavailability, degrades to (None, false, false) — same shape as `NoRemote` —
 /// ensuring an unreachable remote never stalls a local status read.
 ///
 /// # Arguments

--- a/lore-transport/src/grpc/mod.rs
+++ b/lore-transport/src/grpc/mod.rs
@@ -69,6 +69,7 @@ pub const REVISION_LIST_STRATEGY_HEADER: &str = "x-lore-revision-list-strategy";
 const RETRY_START_BACKOFF_MS: u64 = 50;
 const RETRY_MAX_BACKOFF_MS: u64 = 10_000;
 const RETRY_MAX_ATTEMPTS: usize = 60;
+const GRPC_CONNECT_TIMEOUT_SECS: u64 = 5;
 
 fn grpc_retry() -> crate::util::Retry {
     crate::util::retry(
@@ -574,6 +575,8 @@ async fn connect_to_endpoint(remote: &str) -> Result<Channel, ProtocolError> {
         .internal_with(|| format!("setting user agent for {remote}"))?;
 
     lore_trace!("Set user agent to {user_agent}");
+
+    endpoint = endpoint.connect_timeout(Duration::from_secs(GRPC_CONNECT_TIMEOUT_SECS));
 
     // Silent propagation of connection errors
     let channel = endpoint

--- a/lore-transport/src/quic/client.rs
+++ b/lore-transport/src/quic/client.rs
@@ -70,6 +70,7 @@ pub struct EndpointConfig {
 
 const IDLE_TIMEOUT_MS: u32 = 30000;
 const KEEP_ALIVE_MS: u64 = 500;
+const HANDSHAKE_TIMEOUT_SECS: u64 = 5;
 pub const DEFAULT_EXPECTED_RTT_MS: u64 = 100;
 
 #[derive(Clone, Debug)]
@@ -772,13 +773,21 @@ pub async fn connect(
             Ok(mut endpoint) => {
                 endpoint.set_default_client_config(client_config.clone());
                 match endpoint.connect(remote_addr, server_name) {
-                    Ok(connecting) => match connecting.await {
-                        Ok(connection) => {
+                    Ok(connecting) => match tokio::time::timeout(
+                        Duration::from_secs(HANDSHAKE_TIMEOUT_SECS),
+                        connecting,
+                    )
+                    .await
+                    {
+                        Ok(Ok(connection)) => {
                             lore_debug!("Success QUIC connecting to {remote_addr}");
                             return Ok(connection);
                         }
-                        Err(err) => {
+                        Ok(Err(err)) => {
                             lore_debug!("Failed QUIC connecting to {remote_addr}: {err}");
+                        }
+                        Err(_) => {
+                            lore_debug!("QUIC handshake timeout to {remote_addr}");
                         }
                     },
                     Err(err) => {


### PR DESCRIPTION
### Problem
When the configured remote is unreachable, local read verbs (e.g. repositoryStatus) stalled for ~10–30s per call. Root cause: a down remote over QUIC gives no connection-refused (UDP), so the handshake spins until the 30s idle timeout. The status read path resolves the remote even for local reads, so every call paid this cost.

### Change
Bound the wait at the transport connect layer, where the hang actually is:
- gRPC: 5s connect_timeout on the endpoint.
- QUIC: 5s handshake timeout around connect.

In lore-revision, status's remote lookup (resolve_remote_latest) now degrades gracefully when the remote is unavailable, same NoRemote state the code already handled, instead of blocking the whole status result. It resolves the remote once (previously twice), distinguishes "unreachable" from "reachable but query errored" in the reported flags, and logs the underlying error at debug instead of discarding it silently.

An earlier revision of this PR added a 3s timeout inside the status path itself; that was removed after review, it conflated slow-lookup handling with unreachable-remote bounding and duplicated the transport-level timeouts. Transport connect timeouts are now the single timeout layer.

### Validation
cargo build -p lore-client --release -> succeeds. (cargo build -p lore alone only builds the library crate, the CLI bin target lives in lore-client.)
cargo test -p lore-revision -> passes, including remote_resolve_tests.
cargo clippy --all-targets -- -D warnings --no-deps -> clean; cargo +nightly fmt --all --check -> clean.
End-to-end: pointed a repo at an unreachable remote (RFC 5737 test-net address, packets silently dropped, not refused, to reproduce the real hang) and timed lore status:
- Before this fix: 42.2s
- After this fix: 10.5s (two bounded 5s connect attempts instead of unbounded hangs)

### AI assistance disclosure
I used an LLM (Claude Code) to help with implementation, code comments, and documentation on this change, and to help word things clearly as a non-native English speaker. I reviewed and tested all the code myself for its correctness, security, and license compliance.