### PR TITLE
lore-revision: Fix conflict markers glued to hunks lacking a trailing newline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,7 +101,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -112,7 +112,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1414,11 +1414,11 @@ checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "diffy"
-version = "0.4.2"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b545b8c50194bdd008283985ab0b31dba153cfd5b3066a92770634fbc0d7d291"
+checksum = "3e3dc2f773b6aaa63b1a7684b8589f670a8a0146a510b74d23a401c882364b49"
 dependencies = [
- "nu-ansi-term",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -1460,7 +1460,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1558,7 +1558,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1913,6 +1913,9 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "heck"
@@ -3125,7 +3128,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3992,7 +3995,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4406,7 +4409,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4539,7 +4542,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5452,7 +5455,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ config = { version = "0.15.15", features = ["toml"], default-features = false }
 ctor = "0.2"
 crossbeam = "0.8.4"
 dashmap = "6.1.0"
-diffy = "0.4.2"
+diffy = "0.5.2"
 directories = "6.0.0"
 enum_dispatch = "0.3.13"
 tracing-appender = "0.2.3"

--- a/lore-revision/src/merge.rs
+++ b/lore-revision/src/merge.rs
@@ -32,7 +32,11 @@ pub fn merge3_text(
     mine_marker: Option<&str>,
     theirs_marker: Option<&str>,
 ) -> Result<String, String> {
-    let merge_result = diffy::merge(base, mine, theirs);
+    // `Git`, not diffy's `Diff3` default: `Diff3` glues the next marker onto a
+    // final line that lacks a newline, which is unparsable.
+    let merge_result = diffy::MergeOptions::new()
+        .set_incomplete_hunk_style(diffy::IncompleteHunkStyle::Git)
+        .merge(base, mine, theirs);
     let merge_conflicts = merge_result.is_err();
     let mut merge_output = match merge_result {
         Ok(str) | Err(str) => str,

--- a/lore-revision/tests/merge.rs
+++ b/lore-revision/tests/merge.rs
@@ -35,6 +35,36 @@ mod tests {
         assert_eq!(result_string, expected_string);
     }
 
+    /// Fails without `IncompleteHunkStyle::Git`: the default glues the next
+    /// marker onto the last line when it has no trailing newline.
+    #[test]
+    fn test_conflict_without_trailing_newlines() {
+        let base_string = "This is line 1.
+This is line 2.";
+        let mine_string = "This is line 1.
+This is line 2 as I wrote it.";
+        let theirs_string = "This is line 1.
+This is line 2 as they wrote it.";
+
+        let result_string =
+            match merge3_text(base_string, mine_string, theirs_string, None, None, None) {
+                Err(str) | Ok(str) => str,
+            };
+
+        for marker in [
+            "<<<<<<< ours",
+            "||||||| original",
+            "=======",
+            ">>>>>>> theirs",
+        ] {
+            assert!(
+                result_string.lines().any(|line| line == marker),
+                "`{marker}` must occupy a line of its own, got:
+{result_string}"
+            );
+        }
+    }
+
     #[test]
     fn test_markers() {
         let base_string = "This is line 1.\nThis is line 2.\n";

--- a/scripts/test/test_merge_resolve.py
+++ b/scripts/test/test_merge_resolve.py
@@ -584,3 +584,72 @@ def test_merge_resolve_mine_no_paths(new_lore_repo):
         )
 
     repo.commit("Resolved all with mine (no paths)", offline=True)
+# ---------------------------------------------------------------------------
+# Test: a final line without a newline survives resolve unchanged
+# ---------------------------------------------------------------------------
+
+# `IncompleteHunkStyle::Git` inserts a newline after an incomplete final line so
+# the following conflict marker starts at column 0. These pin that the newline
+# belongs to the marker rendering only: resolving restores the side byte for
+# byte, exactly as it was committed.
+
+BASE_NO_EOL = b"line 1\nline 2"
+MINE_NO_EOL = b"line 1\nline 2 mine"
+THEIRS_NO_EOL = b"line 1\nline 2 theirs"
+
+
+@pytest.mark.smoke
+def test_merge_conflict_markers_own_line_without_trailing_newline(new_lore_repo):
+    """Every marker starts a line even when the conflicting hunk has no EOL."""
+    repo: Lore = new_lore_repo()
+    setup_merge_conflict(
+        repo, {"a.txt": (BASE_NO_EOL, MINE_NO_EOL, THEIRS_NO_EOL)}
+    )
+
+    with repo.open_file("a.txt", "rb") as f:
+        conflicted = f.read().decode()
+
+    for marker in ["<<<<<<< ours", "||||||| original", "=======", ">>>>>>> theirs"]:
+        assert any(line == marker for line in conflicted.split("\n")), (
+            f"{marker!r} must occupy a whole line, got {conflicted!r}"
+        )
+
+    repo.branch_merge_abort(offline=True)
+
+
+@pytest.mark.smoke
+def test_merge_resolve_mine_restores_missing_trailing_newline(new_lore_repo):
+    """resolve mine gives back the committed bytes, without the marker newline."""
+    repo: Lore = new_lore_repo()
+    setup_merge_conflict(
+        repo, {"a.txt": (BASE_NO_EOL, MINE_NO_EOL, THEIRS_NO_EOL)}
+    )
+
+    repo.branch_merge_resolve_mine(["a.txt"], offline=True, json=True)
+
+    with repo.open_file("a.txt", "rb") as f:
+        content = f.read()
+    assert content == MINE_NO_EOL, (
+        f"resolve mine must restore the exact bytes, got {content!r}"
+    )
+
+    repo.branch_merge_abort(offline=True)
+
+
+@pytest.mark.smoke
+def test_merge_resolve_theirs_restores_missing_trailing_newline(new_lore_repo):
+    """resolve theirs gives back the committed bytes, without the marker newline."""
+    repo: Lore = new_lore_repo()
+    setup_merge_conflict(
+        repo, {"a.txt": (BASE_NO_EOL, MINE_NO_EOL, THEIRS_NO_EOL)}
+    )
+
+    repo.branch_merge_resolve_theirs(["a.txt"], offline=True, json=True)
+
+    with repo.open_file("a.txt", "rb") as f:
+        content = f.read()
+    assert content == THEIRS_NO_EOL, (
+        f"resolve theirs must restore the exact bytes, got {content!r}"
+    )
+
+    repo.branch_merge_abort(offline=True)


### PR DESCRIPTION
When both sides of a conflict end the file without a trailing newline, the merge glues
the conflict markers onto the content lines and the file becomes unparseable — markers
are only recognizable at the start of a line:

```
<<<<<<< ours
This is line 2 changed.||||||| original
This is line 2.=======
This is line 2 also changed.>>>>>>> theirs
```

git merge-file --diff3 puts every marker on its own line for the same inputs.

Repro is easy: commit a file written with no trailing newline on two branches
from a common base, then `branch merge start`. With trailing newlines the markers come
out fine.

The bug was in the diffy crate. It is fixed there now (bmwill/diffy#85), and 0.5.2 makes
the behaviour selectable (bmwill/diffy#88).

## Updated per review

**No vendoring.** This is now a plain dependency bump to `diffy = "0.5.2"` plus
`MergeOptions::set_incomplete_hunk_style(IncompleteHunkStyle::Git)` in `merge3_text`.
The bump alone is not enough: 0.5.2 defaults to `IncompleteHunkStyle::Diff3`, which is
the old glued behaviour, so the setting is what does the work.

**Tests that resolve restores the content unchanged.** `scripts/test/test_merge_resolve.py`
gains three cases on a file whose last line has no trailing newline:

- every conflict marker occupies a whole line;
- `merge resolve mine` restores the committed bytes exactly;
- `merge resolve theirs` restores the committed bytes exactly.

They compare bytes rather than strings, so an added newline fails the assertion instead of
passing unnoticed. The inserted newline belongs to the marker rendering only — resolving
through the Lore API reads the `~mine` / `~theirs` sidecars and returns the side as it was
committed.

`lore-revision/tests/merge.rs` keeps a unit-level regression test for the marker shape.

## Testing

- `cargo test -p lore-revision` — 4 merge tests, 364 lib tests
- `pytest test_merge_resolve.py test_merge.py test_conflict.py` — 25 passed
- `pytest test_diff.py test_diff_git_baseline.py` — 64 passed (`PatchFormatter` is the
  other diffy consumer, so the diff output is covered too)

---

Disclosure: I used Claude to investigate the root cause of this bug and to
implement the fix. I reviewed and tested the changes myself.