### PR TITLE
ci: Add PR validation workflow

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -103,9 +103,12 @@ rustflags = [
     "-C", "force-unwind-tables=yes",
     "-C", "force-frame-pointers=yes",
     "-C", "target-cpu=neoverse-512tvb",
-    # Leave debug symbols in the binary for now, we want these in place for the server binary, but still split them via
-    # package-cli.sh for CLI binaries.
-    "-C", "split-debuginfo=off",
+    # Split debug info into a companion .dwp instead of embedding it. Embedding
+    # (split-debuginfo=off) makes the linker hold every binary's full DWARF in
+    # memory, which OOMs the 16 GB hosted arm64 runner on the full-workspace
+    # `cargo test` build. Packed keeps symbols available (in the .dwp) alongside
+    # the binary while cutting peak linker memory.
+    "-C", "split-debuginfo=packed",
     # allows uuid IntoBytes/FromBytes unstable feature
     "--cfg", "uuid_unstable"
 ]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -103,12 +103,9 @@ rustflags = [
     "-C", "force-unwind-tables=yes",
     "-C", "force-frame-pointers=yes",
     "-C", "target-cpu=neoverse-512tvb",
-    # Split debug info into a companion .dwp instead of embedding it. Embedding
-    # (split-debuginfo=off) makes the linker hold every binary's full DWARF in
-    # memory, which OOMs the 16 GB hosted arm64 runner on the full-workspace
-    # `cargo test` build. Packed keeps symbols available (in the .dwp) alongside
-    # the binary while cutting peak linker memory.
-    "-C", "split-debuginfo=packed",
+    # Leave debug symbols in the binary for now, we want these in place for the server binary, but still split them via
+    # package-cli.sh for CLI binaries.
+    "-C", "split-debuginfo=off",
     # allows uuid IntoBytes/FromBytes unstable feature
     "--cfg", "uuid_unstable"
 ]

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,8 @@
+# actionlint's bundled list of GitHub-hosted runner labels does not yet include
+# the arm64 Linux runner image `ubuntu-24.04-arm`. It is a real GitHub-hosted
+# runner (not self-hosted), but declaring it here is actionlint's supported way
+# to teach it a label it doesn't know, which stops the [runner-label] check from
+# failing the lint hook. Remove once actionlint ships knowledge of this label.
+self-hosted-runner:
+  labels:
+    - ubuntu-24.04-arm

--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -1,6 +1,10 @@
 # SPDX-FileCopyrightText: 2026 Epic Games, Inc.
 # SPDX-License-Identifier: MIT
 
+# Validates a pull request by fanning out the full test suite across every
+# supported platform. Everything here runs on public GitHub-hosted runners with
+# no secrets: the source is checked out from git and all backing services for
+# the integration tests come from public container images.
 name: PR Validate
 
 on:
@@ -13,17 +17,171 @@ concurrency:
   group: pr-validate-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: "1"
+
 jobs:
-  validate:
-    name: validate
-    runs-on: ubuntu-latest
+  # Unit tests: plain `cargo test` across all platforms. The integration-test
+  # suite is feature-gated, so it does not run here.
+  unit:
+    name: unit (${{ matrix.name }})
+    runs-on: ${{ matrix.os }}
     permissions:
-      contents: read # Check out the PR head to validate it
+      contents: read # Check out the PR head to test it
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { name: linux-x86_64, os: ubuntu-latest }
+          - { name: linux-aarch64, os: ubuntu-24.04-arm }
+          - { name: macos-aarch64, os: macos-latest }
+          - { name: windows-x86_64, os: windows-latest }
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
 
-      # TODO: add validation steps.
-      - name: Validate
-        run: echo "pr-validate stub — no checks yet"
+      # Rust ships preinstalled on the hosted runners; this just pins the stable
+      # channel. Actions below are pinned to SHAs for first-party ones (matching
+      # lint.yml); third-party actions use release tags — pin these to SHAs too
+      # if the repo adopts a stricter supply-chain policy.
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: unit-${{ matrix.name }}
+
+      - name: cargo test
+        run: cargo test --workspace --verbose
+
+  # Integration tests: exercise the AWS store, gRPC, and Consul suites against
+  # local approximations (MinIO, DynamoDB Local, Consul) started via Docker
+  # Compose. Docker is only available on the Linux runners, so this is
+  # Linux-x86_64 only. The tests hard-code 127.0.0.1:9000/9090/8500, which the
+  # compose file maps.
+  integration:
+    name: integration (linux-x86_64)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # Check out the PR head to test it
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: integration
+
+      - name: Start backing services (MinIO, DynamoDB Local, Consul)
+        run: docker compose --file lore-integration-tests/compose.yaml up --detach
+
+      - name: Wait for services to be ready
+        run: |
+          for i in $(seq 1 30); do
+            if curl -sf http://127.0.0.1:9000/minio/health/ready \
+               && curl -sf http://127.0.0.1:8500/v1/status/leader \
+               && curl -s -o /dev/null http://127.0.0.1:9090; then
+              echo "services ready"
+              exit 0
+            fi
+            echo "waiting for services (attempt $i)..."
+            sleep 2
+          done
+          echo "services did not become ready in time"
+          exit 1
+
+      - name: cargo test (integration)
+        env:
+          AWS_ACCESS_KEY_ID: lorelocal
+          AWS_SECRET_ACCESS_KEY: lorelocal
+          AWS_REGION: us-east-1
+        run: >
+          cargo test --package lore-integration-tests
+          --features integration_tests --verbose
+
+      - name: Dump service logs on failure
+        if: failure()
+        run: docker compose --file lore-integration-tests/compose.yaml logs
+
+      - name: Stop services
+        if: always()
+        run: docker compose --file lore-integration-tests/compose.yaml down --volumes
+
+  # Smoke tests: the pytest suite under scripts/test (marked `smoke`), run via uv
+  # against locally built release binaries. Runs on every platform. The server is
+  # built with `failure_generator` so fault-injection tests execute rather than
+  # skip.
+  smoke:
+    name: smoke (${{ matrix.name }})
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read # Check out the PR head to test it
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { name: linux-x86_64, os: ubuntu-latest }
+          - { name: linux-aarch64, os: ubuntu-24.04-arm }
+          - { name: macos-aarch64, os: macos-latest }
+          # Windows needs explicit loopback ports for the local remote server.
+          - name: windows-x86_64
+            os: windows-latest
+            extra-args: >-
+              --lore-remote-http-port 41339
+              --lore-remote-quic-port 41338
+              --lore-remote-grpc-port 41338
+              --lore-remote-internal-port 41340
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: smoke-${{ matrix.name }}
+
+      - uses: astral-sh/setup-uv@v5
+
+      - name: Build lore and loreserver (release)
+        run: >
+          cargo build --release
+          --package lore-client --package lore-server
+          --features lore-server/failure_generator
+          --bin lore --bin loreserver
+
+      # conftest resolves the `release` keyword to target/release/{lore,loreserver}
+      # (adding .exe on Windows). `uv run` provisions Python and installs the test
+      # dependencies from uv.lock automatically.
+      - name: Smoke tests
+        run: >
+          uv run pytest scripts/test -m smoke -n 4
+          --lore-client-binary release
+          --lore-server-binary release
+          ${{ matrix.extra-args }}
+
+  # Single required status check: branch protection can require just this job,
+  # which passes only when every validation job above succeeded.
+  pr-validate:
+    name: PR Validate
+    if: ${{ always() }}
+    needs: [unit, integration, smoke]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify all validation jobs passed
+        run: |
+          echo "unit=${{ needs.unit.result }}"
+          echo "integration=${{ needs.integration.result }}"
+          echo "smoke=${{ needs.smoke.result }}"
+          if [ "${{ needs.unit.result }}" != "success" ] \
+             || [ "${{ needs.integration.result }}" != "success" ] \
+             || [ "${{ needs.smoke.result }}" != "success" ]; then
+            echo "One or more validation jobs failed."
+            exit 1
+          fi
+          echo "All validation jobs passed."

--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -34,7 +34,15 @@ jobs:
       matrix:
         include:
           - { name: linux-x86_64, os: ubuntu-latest }
-          - { name: linux-aarch64, os: ubuntu-24.04-arm }
+          # TODO: re-enable once the aarch64-linux debug-info method is changed.
+          # `cargo test --workspace` links every test binary with full embedded
+          # DWARF (split-debuginfo=off for aarch64-unknown-linux-gnu in
+          # .cargo/config.toml), so the linker exhausts the 16 GB hosted arm64
+          # runner and it is killed (SIGTERM/143) mid-compile, before any test
+          # runs. Switching that target to split-debuginfo=packed/unpacked (or a
+          # line-tables-only test profile) cuts peak linker memory and lets this
+          # come back. Smoke still covers linux-aarch64 below.
+          # - { name: linux-aarch64, os: ubuntu-24.04-arm }
           - { name: macos-aarch64, os: macos-latest }
           - { name: windows-x86_64, os: windows-latest }
     steps:
@@ -124,8 +132,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { name: linux-x86_64, os: ubuntu-latest }
-          - { name: linux-aarch64, os: ubuntu-24.04-arm }
+          # basetemp-arg points pytest's working data at the tmpfs mounted below
+          # (Linux only; see the "Grow /dev/shm" step). Empty on macOS/Windows.
+          - { name: linux-x86_64, os: ubuntu-latest, basetemp-arg: "--basetemp=/dev/shm/lore-smoke" }
+          - { name: linux-aarch64, os: ubuntu-24.04-arm, basetemp-arg: "--basetemp=/dev/shm/lore-smoke" }
           - { name: macos-aarch64, os: macos-latest }
           # Windows needs explicit loopback ports for the local remote server.
           - name: windows-x86_64
@@ -155,6 +165,20 @@ jobs:
           --features lore-server/failure_generator
           --bin lore --bin loreserver
 
+      # Smoke working data (server stores + per-test repos) is disk-I/O heavy and
+      # pytest never cleans it up mid-session, so the full -n 4 suite writes ~10 GB
+      # (dominated by a handful of large-file tests: test_push, test_manyfiles,
+      # test_commit, test_rest, test_branch_switch_reconnect). Hosting it on tmpfs
+      # (RAM) rather than the runner disk speeds up the I/O-bound tests. The hosted
+      # Linux runners have 16 GB RAM; /dev/shm defaults to ~half that (8 GB), which
+      # the suite overflows, so grow it to 12 GB — above the observed footprint,
+      # still leaving headroom for the OS and test processes. tmpfs only consumes
+      # RAM as data is written, so the 12 GB cap is a safety valve, not a reserve.
+      # Linux only: macOS and Windows have no tmpfs (see basetemp-arg above).
+      - name: Grow /dev/shm for smoke test data (tmpfs)
+        if: runner.os == 'Linux'
+        run: sudo mount -o remount,size=12G /dev/shm
+
       # conftest resolves the `release` keyword to target/release/{lore,loreserver}
       # (adding .exe on Windows). `uv run` provisions Python and installs the test
       # dependencies from uv.lock automatically.
@@ -163,6 +187,7 @@ jobs:
           uv run pytest scripts/test -m smoke -n 4
           --lore-client-binary release
           --lore-server-binary release
+          ${{ matrix.basetemp-arg }}
           ${{ matrix.extra-args }}
 
   # Single required status check: branch protection can require just this job,

--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -43,8 +43,11 @@ jobs:
           # line-tables-only test profile) cuts peak linker memory and lets this
           # come back. Smoke still covers linux-aarch64 below.
           # - { name: linux-aarch64, os: ubuntu-24.04-arm }
-          - { name: macos-aarch64, os: macos-latest }
-          - { name: windows-x86_64, os: windows-latest }
+          # TODO: re-enable the remaining platforms. Temporarily narrowed to
+          # linux-x86_64 to iterate on the workflow itself without paying for
+          # (or triaging) the full cross-platform fan-out on every push.
+          # - { name: macos-aarch64, os: macos-latest }
+          # - { name: windows-x86_64, os: windows-latest }
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -135,16 +138,19 @@ jobs:
           # basetemp-arg points pytest's working data at the tmpfs mounted below
           # (Linux only; see the "Grow /dev/shm" step). Empty on macOS/Windows.
           - { name: linux-x86_64, os: ubuntu-latest, basetemp-arg: "--basetemp=/dev/shm/lore-smoke" }
-          - { name: linux-aarch64, os: ubuntu-24.04-arm, basetemp-arg: "--basetemp=/dev/shm/lore-smoke" }
-          - { name: macos-aarch64, os: macos-latest }
+          # TODO: re-enable the remaining platforms. Temporarily narrowed to
+          # linux-x86_64 to iterate on the workflow itself without paying for
+          # (or triaging) the full cross-platform fan-out on every push.
+          # - { name: linux-aarch64, os: ubuntu-24.04-arm, basetemp-arg: "--basetemp=/dev/shm/lore-smoke" }
+          # - { name: macos-aarch64, os: macos-latest }
           # Windows needs explicit loopback ports for the local remote server.
-          - name: windows-x86_64
-            os: windows-latest
-            extra-args: >-
-              --lore-remote-http-port 41339
-              --lore-remote-quic-port 41338
-              --lore-remote-grpc-port 41338
-              --lore-remote-internal-port 41340
+          # - name: windows-x86_64
+          #   os: windows-latest
+          #   extra-args: >-
+          #     --lore-remote-http-port 41339
+          #     --lore-remote-quic-port 41338
+          #     --lore-remote-grpc-port 41338
+          #     --lore-remote-internal-port 41340
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -188,7 +194,6 @@ jobs:
           --lore-client-binary release
           --lore-server-binary release
           ${{ matrix.basetemp-arg }}
-          ${{ matrix.extra-args }}
 
   # Single required status check: branch protection can require just this job,
   # which passes only when every validation job above succeeded.

--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -1,10 +1,9 @@
 # SPDX-FileCopyrightText: 2026 Epic Games, Inc.
 # SPDX-License-Identifier: MIT
 
-# Validates a pull request by fanning out the full test suite across every
-# supported platform. Everything here runs on public GitHub-hosted runners with
-# no secrets: the source is checked out from git and all backing services for
-# the integration tests come from public container images.
+# Runs the test suite on GitHub-hosted runners. This workflow needs no secrets:
+# it checks the source out from git and starts the integration test services
+# from public container images.
 name: PR Validate
 
 on:
@@ -22,8 +21,8 @@ env:
   RUST_BACKTRACE: "1"
 
 jobs:
-  # Unit tests: plain `cargo test` across all platforms. The integration-test
-  # suite is feature-gated, so it does not run here.
+  # Runs `cargo test` for the workspace. A cargo feature gates the integration
+  # tests, so they do not run here.
   unit:
     name: unit (${{ matrix.name }})
     runs-on: ${{ matrix.os }}
@@ -34,18 +33,15 @@ jobs:
       matrix:
         include:
           - { name: linux-x86_64, os: ubuntu-latest }
-          # TODO: re-enable once the aarch64-linux debug-info method is changed.
-          # `cargo test --workspace` links every test binary with full embedded
-          # DWARF (split-debuginfo=off for aarch64-unknown-linux-gnu in
-          # .cargo/config.toml), so the linker exhausts the 16 GB hosted arm64
-          # runner and it is killed (SIGTERM/143) mid-compile, before any test
-          # runs. Switching that target to split-debuginfo=packed/unpacked (or a
-          # line-tables-only test profile) cuts peak linker memory and lets this
-          # come back. Smoke still covers linux-aarch64 below.
+          # TODO: re-enable. `cargo test --workspace` links every test binary
+          # with embedded DWARF, because .cargo/config.toml sets
+          # split-debuginfo=off for aarch64-unknown-linux-gnu. The linker
+          # exhausts the 16 GB arm64 runner, which kills the job before any test
+          # runs. Setting split-debuginfo=packed for that target, or building the
+          # tests with line tables only, lowers the linker's peak memory.
           # - { name: linux-aarch64, os: ubuntu-24.04-arm }
-          # TODO: re-enable the remaining platforms. Temporarily narrowed to
-          # linux-x86_64 to iterate on the workflow itself without paying for
-          # (or triaging) the full cross-platform fan-out on every push.
+          # TODO: re-enable. Only linux-x86_64 runs while this workflow is still
+          # being changed.
           # - { name: macos-aarch64, os: macos-latest }
           # - { name: windows-x86_64, os: windows-latest }
     steps:
@@ -53,19 +49,13 @@ jobs:
         with:
           persist-credentials: false
 
-      # Rust ships preinstalled on the hosted runners; this just pins the stable
-      # channel. Actions below are pinned to SHAs for first-party ones (matching
-      # lint.yml); third-party actions use release tags — pin these to SHAs too
-      # if the repo adopts a stricter supply-chain policy.
       - uses: dtolnay/rust-toolchain@stable
 
-      # `cargo test --workspace` builds a debug test binary per crate with
-      # embedded DWARF, which overflows the hosted runner's small root
-      # filesystem ("No space left on device"). The runners carry a second,
-      # much larger ephemeral volume at /mnt, so build there instead. Set
-      # before rust-cache so the cache acts on this target dir rather than the
-      # now-unused ./target. Linux only: the macOS and Windows runners have no
-      # /mnt volume, and there the in-workspace target dir is used as before.
+      # `cargo test --workspace` builds a debug test binary for every crate with
+      # embedded DWARF, which does not fit on the runner's root filesystem. The
+      # Linux runners carry a larger volume at /mnt, so build there. This step
+      # runs before rust-cache so the cache uses this target directory. The
+      # macOS and Windows runners have no /mnt and build in the workspace.
       - name: Build on the larger /mnt volume
         if: runner.os == 'Linux'
         run: |
@@ -81,10 +71,9 @@ jobs:
       - name: cargo test
         run: cargo test --workspace --verbose
 
-  # Integration tests: exercise the AWS store, gRPC, and Consul suites against
-  # local approximations (MinIO, DynamoDB Local, Consul) started via Docker
-  # Compose. Docker is only available on the Linux runners, so this is
-  # Linux-x86_64 only. The tests hard-code 127.0.0.1:9000/9090/8500, which the
+  # Runs the integration tests against the MinIO, DynamoDB Local, and Consul
+  # services that Docker Compose starts. Only the Linux runners provide Docker.
+  # The tests connect to 127.0.0.1 on ports 9000, 9090, and 8500, which the
   # compose file maps.
   integration:
     name: integration (linux-x86_64)
@@ -98,7 +87,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
 
-      # Build on the larger ephemeral volume — see the note in the unit job.
+      # Build on /mnt. See the unit job for the reason.
       - name: Build on the larger /mnt volume
         run: |
           sudo mkdir -p /mnt/cargo-target
@@ -145,10 +134,9 @@ jobs:
         if: always()
         run: docker compose --file lore-integration-tests/compose.yaml down --volumes
 
-  # Smoke tests: the pytest suite under scripts/test (marked `smoke`), run via uv
-  # against locally built release binaries. Runs on every platform. The server is
-  # built with `failure_generator` so fault-injection tests execute rather than
-  # skip.
+  # Runs the tests in scripts/test that carry the `smoke` marker, through uv,
+  # against release binaries built here. The server build enables
+  # failure_generator so the fault injection tests run instead of skipping.
   smoke:
     name: smoke (${{ matrix.name }})
     runs-on: ${{ matrix.os }}
@@ -158,12 +146,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # basetemp-arg points pytest's working data at the tmpfs mounted below
-          # (Linux only; see the "Grow /dev/shm" step). Empty on macOS/Windows.
+          # basetemp-arg puts the pytest working data on the tmpfs that the
+          # "Grow /dev/shm" step below resizes.
           - { name: linux-x86_64, os: ubuntu-latest, basetemp-arg: "--basetemp=/dev/shm/lore-smoke" }
-          # TODO: re-enable the remaining platforms. Temporarily narrowed to
-          # linux-x86_64 to iterate on the workflow itself without paying for
-          # (or triaging) the full cross-platform fan-out on every push.
+          # TODO: re-enable. Only linux-x86_64 runs while this workflow is still
+          # being changed.
           # - { name: linux-aarch64, os: ubuntu-24.04-arm, basetemp-arg: "--basetemp=/dev/shm/lore-smoke" }
           # - { name: macos-aarch64, os: macos-latest }
           # Windows needs explicit loopback ports for the local remote server.
@@ -181,12 +168,11 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
 
-      # Build on the larger ephemeral volume — see the note in the unit job.
-      # conftest's `release` binary keyword resolves to <cwd>/target/release,
-      # which moving CARGO_TARGET_DIR would leave empty, so point the suite at
-      # the relocated binaries explicitly; LORE_*_EXECUTABLE_PATH takes
-      # precedence over the --lore-*-binary flags below. Skipped on macOS and
-      # Windows, where `release` still resolves in-workspace.
+      # Build on /mnt. See the unit job for the reason. conftest resolves the
+      # `release` binary keyword to <cwd>/target/release, which stays empty when
+      # CARGO_TARGET_DIR points elsewhere, so name the binaries directly.
+      # LORE_EXECUTABLE_PATH and LORE_SERVER_EXECUTABLE_PATH take precedence
+      # over the --lore-*-binary flags below.
       - name: Build on the larger /mnt volume
         if: runner.os == 'Linux'
         run: |
@@ -212,23 +198,16 @@ jobs:
           --features lore-server/failure_generator
           --bin lore --bin loreserver
 
-      # Smoke working data (server stores + per-test repos) is disk-I/O heavy and
-      # pytest never cleans it up mid-session, so the full -n 4 suite writes ~10 GB
-      # (dominated by a handful of large-file tests: test_push, test_manyfiles,
-      # test_commit, test_rest, test_branch_switch_reconnect). Hosting it on tmpfs
-      # (RAM) rather than the runner disk speeds up the I/O-bound tests. The hosted
-      # Linux runners have 16 GB RAM; /dev/shm defaults to ~half that (8 GB), which
-      # the suite overflows, so grow it to 12 GB — above the observed footprint,
-      # still leaving headroom for the OS and test processes. tmpfs only consumes
-      # RAM as data is written, so the 12 GB cap is a safety valve, not a reserve.
-      # Linux only: macOS and Windows have no tmpfs (see basetemp-arg above).
+      # The suite writes about 10 GB of server stores and per-test repositories,
+      # and pytest keeps all of it for the session. Holding that on tmpfs instead
+      # of the runner disk speeds up these I/O-bound tests. /dev/shm defaults to
+      # 8 GB, which the suite exceeds, so raise it to 12 GB. The runners have
+      # 16 GB of RAM, and tmpfs only uses RAM for the data written to it.
       - name: Grow /dev/shm for smoke test data (tmpfs)
         if: runner.os == 'Linux'
         run: sudo mount -o remount,size=12G /dev/shm
 
-      # conftest resolves the `release` keyword to target/release/{lore,loreserver}
-      # (adding .exe on Windows). `uv run` provisions Python and installs the test
-      # dependencies from uv.lock automatically.
+      # `uv run` installs the test dependencies from uv.lock.
       - name: Smoke tests
         run: >
           uv run pytest scripts/test -m smoke -n 4
@@ -236,8 +215,8 @@ jobs:
           --lore-server-binary release
           ${{ matrix.basetemp-arg }}
 
-  # Single required status check: branch protection can require just this job,
-  # which passes only when every validation job above succeeded.
+  # Reports one result for the jobs above so branch protection can require a
+  # single check.
   pr-validate:
     name: PR Validate
     if: ${{ always() }}

--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -59,6 +59,21 @@ jobs:
       # if the repo adopts a stricter supply-chain policy.
       - uses: dtolnay/rust-toolchain@stable
 
+      # `cargo test --workspace` builds a debug test binary per crate with
+      # embedded DWARF, which overflows the hosted runner's small root
+      # filesystem ("No space left on device"). The runners carry a second,
+      # much larger ephemeral volume at /mnt, so build there instead. Set
+      # before rust-cache so the cache acts on this target dir rather than the
+      # now-unused ./target. Linux only: the macOS and Windows runners have no
+      # /mnt volume, and there the in-workspace target dir is used as before.
+      - name: Build on the larger /mnt volume
+        if: runner.os == 'Linux'
+        run: |
+          sudo mkdir -p /mnt/cargo-target
+          sudo chown -R "$(id -u):$(id -g)" /mnt/cargo-target
+          echo "CARGO_TARGET_DIR=/mnt/cargo-target" >> "$GITHUB_ENV"
+          df -h / /mnt
+
       - uses: Swatinem/rust-cache@v2
         with:
           key: unit-${{ matrix.name }}
@@ -82,6 +97,14 @@ jobs:
           persist-credentials: false
 
       - uses: dtolnay/rust-toolchain@stable
+
+      # Build on the larger ephemeral volume — see the note in the unit job.
+      - name: Build on the larger /mnt volume
+        run: |
+          sudo mkdir -p /mnt/cargo-target
+          sudo chown -R "$(id -u):$(id -g)" /mnt/cargo-target
+          echo "CARGO_TARGET_DIR=/mnt/cargo-target" >> "$GITHUB_ENV"
+          df -h / /mnt
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -157,6 +180,24 @@ jobs:
           persist-credentials: false
 
       - uses: dtolnay/rust-toolchain@stable
+
+      # Build on the larger ephemeral volume — see the note in the unit job.
+      # conftest's `release` binary keyword resolves to <cwd>/target/release,
+      # which moving CARGO_TARGET_DIR would leave empty, so point the suite at
+      # the relocated binaries explicitly; LORE_*_EXECUTABLE_PATH takes
+      # precedence over the --lore-*-binary flags below. Skipped on macOS and
+      # Windows, where `release` still resolves in-workspace.
+      - name: Build on the larger /mnt volume
+        if: runner.os == 'Linux'
+        run: |
+          sudo mkdir -p /mnt/cargo-target
+          sudo chown -R "$(id -u):$(id -g)" /mnt/cargo-target
+          {
+            echo "CARGO_TARGET_DIR=/mnt/cargo-target"
+            echo "LORE_EXECUTABLE_PATH=/mnt/cargo-target/release/lore"
+            echo "LORE_SERVER_EXECUTABLE_PATH=/mnt/cargo-target/release/loreserver"
+          } >> "$GITHUB_ENV"
+          df -h / /mnt
 
       - uses: Swatinem/rust-cache@v2
         with:


### PR DESCRIPTION
Adds `.github/workflows/pr-validate.yml`. It runs on pull requests using
GitHub-hosted runners and needs no secrets: it checks the source out from git
and starts the integration test services from public container images.

## Jobs

| Job | Runs |
|-----|------|
| `unit` | `cargo test --workspace` |
| `integration` | MinIO, DynamoDB Local, and Consul from `lore-integration-tests/compose.yaml`, then `cargo test -p lore-integration-tests --features integration_tests` |
| `smoke` | builds `lore` and `loreserver`, then `uv run pytest scripts/test -m smoke -n 4` |
| `PR Validate` | reports one result for the three jobs above, for branch protection to require |

All three jobs currently run on linux-x86_64 only. The macOS and Windows legs
are commented out while the workflow is still being changed, and the
linux-aarch64 unit leg is commented out because the linker exhausts the arm64
runner's memory. Integration only ever runs on Linux, which is where the
runners provide Docker.

## Notes

- The Linux jobs build in `/mnt`, because a workspace debug build does not fit
  on the runner's root filesystem.
- The smoke job holds its test data on tmpfs, grown to 12 GB, which speeds up
  the I/O-bound tests.
- The server build enables `failure_generator` so the fault injection tests run
  instead of skipping.
- Third-party actions use release tags rather than commit SHAs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)