### PR TITLE
lore: Use correct caller working directory for absolute path resolution in the service process

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,4 +1,5 @@
 disallowed-methods = [
+    { path = "std::env::current_dir", reason = "The library must not depend on the process working directory: a call executed by the Lore service runs in a process whose directory is unrelated to the caller's. Use lore_revision::util::path::make_absolute, which resolves against the working directory the call carries." },
     { path = "dashmap::DashMap::entry", reason = "This function internally takes a write lock and returns it in the entry handle. This can potentially block worker threads and cause deadlocks if used incorrectly. If you're sure it's ok add #[allow(clippy::disallowed_methods)] with a comment explaining why its safe" },
     { path = "tokio::spawn", reason = "Use lore_base::lore_spawn! so LORE_CONTEXT is propagated to the spawned task." },
     { path = "tokio::task::spawn", reason = "Use lore_base::lore_spawn! so LORE_CONTEXT is propagated to the spawned task." },

--- a/lore-capi/lore.h
+++ b/lore-capi/lore.h
@@ -3530,6 +3530,12 @@ typedef struct lore_event_t {
 typedef struct lore_global_args_t {
   // Repository path
   struct lore_string_t repository_path;
+  // Directory that relative paths in this call are resolved against. Set it
+  // when a call may be executed by another process, such as the Lore
+  // service, whose own working directory is unrelated to the caller's. When
+  // empty, relative paths resolve against the working directory of the
+  // process performing the call.
+  struct lore_string_t working_directory;
   // Correlation ID
   struct lore_string_t correlation_id;
   // Identity to use

--- a/lore-client/src/cli/cli.rs
+++ b/lore-client/src/cli/cli.rs
@@ -349,6 +349,10 @@ pub enum LoreCliError {
 pub fn lore_globals_from_args(cli: &LoreCli) -> LoreGlobalArgs {
     let mut args = LoreGlobalArgs {
         repository_path: get_repository_path(cli.repository.clone()),
+        working_directory: std::env::current_dir()
+            .map(|path| path.display().to_string())
+            .unwrap_or_default()
+            .into(),
 
         force: cli.force.into(),
         dry_run: cli.dry_run.into(),

--- a/lore-client/src/cli/cli.rs
+++ b/lore-client/src/cli/cli.rs
@@ -349,10 +349,6 @@ pub enum LoreCliError {
 pub fn lore_globals_from_args(cli: &LoreCli) -> LoreGlobalArgs {
     let mut args = LoreGlobalArgs {
         repository_path: get_repository_path(cli.repository.clone()),
-        working_directory: std::env::current_dir()
-            .map(|path| path.display().to_string())
-            .unwrap_or_default()
-            .into(),
 
         force: cli.force.into(),
         dry_run: cli.dry_run.into(),

--- a/lore-client/src/cli/commands/service/run.rs
+++ b/lore-client/src/cli/commands/service/run.rs
@@ -35,11 +35,38 @@ pub enum ServiceMainError {}
 /// left behind is a stale socket, which the next start detects and removes.
 const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
 
+/// Where the service parks its working directory. It inherits one from whoever
+/// started it, which is unrelated to the directories its callers run in, and
+/// holding that directory would also keep the filesystem under it busy. Callers
+/// send the directory their relative paths belong to, so the service never
+/// needs one of its own.
+fn detached_working_directory() -> std::path::PathBuf {
+    #[cfg(target_family = "unix")]
+    {
+        std::path::PathBuf::from("/")
+    }
+    #[cfg(target_os = "windows")]
+    {
+        std::env::var_os("SystemRoot").map_or_else(
+            || std::path::PathBuf::from("C:\\"),
+            std::path::PathBuf::from,
+        )
+    }
+}
+
 pub async fn service_main(
     listening_signal: Option<tokio::sync::oneshot::Sender<()>>,
 ) -> Result<(), ServiceMainError> {
     if !uds_supported() {
         return Err(ServiceMainError::internal("IPC not supported on this OS"));
+    }
+
+    let detached = detached_working_directory();
+    if let Err(error) = std::env::set_current_dir(&detached) {
+        eprintln!(
+            "Failed to set working directory to {}: {error}",
+            detached.display()
+        );
     }
 
     let listener: UdsListener = UdsListener::new().internal("Failed to start listener socket")?;

--- a/lore-revision/src/file/write.rs
+++ b/lore-revision/src/file/write.rs
@@ -167,14 +167,14 @@ pub async fn write_file(
     let destination = {
         let mut absolute_path = Path::new(&output).to_path_buf();
         if !absolute_path.is_absolute() {
-            let Ok(current_path) = std::env::current_dir() else {
+            let Ok(resolved) = crate::util::path::make_absolute(&output) else {
                 return Err(InvalidPath {
                     path: output.clone(),
                 }
                 .into());
             };
 
-            absolute_path = current_path.join(output);
+            absolute_path = resolved;
         }
         absolute_path
     };
@@ -295,14 +295,14 @@ pub async fn write_address(
     let destination = {
         let mut absolute_path = Path::new(&output).to_path_buf();
         if !absolute_path.is_absolute() {
-            let Ok(current_path) = std::env::current_dir() else {
+            let Ok(resolved) = crate::util::path::make_absolute(&output) else {
                 return Err(InvalidPath {
                     path: output.clone(),
                 }
                 .into());
             };
 
-            absolute_path = current_path.join(output);
+            absolute_path = resolved;
         }
         absolute_path
     };

--- a/lore-revision/src/interface.rs
+++ b/lore-revision/src/interface.rs
@@ -527,6 +527,12 @@ pub enum LoreLoadConfig {
 pub struct LoreGlobalArgs {
     /// Repository path
     pub repository_path: LoreString,
+    /// Directory that relative paths in this call are resolved against. Set it
+    /// when a call may be executed by another process, such as the Lore
+    /// service, whose own working directory is unrelated to the caller's. When
+    /// empty, relative paths resolve against the working directory of the
+    /// process performing the call.
+    pub working_directory: LoreString,
     /// Correlation ID
     pub correlation_id: LoreString,
     /// Identity to use
@@ -577,6 +583,10 @@ pub struct LoreGlobalArgs {
 impl LoreGlobalArgs {
     pub fn repository_path(&self) -> &str {
         self.repository_path.as_str()
+    }
+
+    pub fn working_directory(&self) -> Option<&str> {
+        (&self.working_directory).into()
     }
 
     pub fn identity(&self) -> Option<&str> {

--- a/lore-revision/src/util/path.rs
+++ b/lore-revision/src/util/path.rs
@@ -16,19 +16,18 @@ pub enum PathError {
     InvalidPath,
 }
 
-/// The directory the call in progress resolves relative paths against, when it
-/// named one. A call arriving over IPC carries the directory of the process
-/// that made it, because the service's own is unrelated to the caller's.
-fn call_working_directory() -> Option<PathBuf> {
-    let context = crate::runtime::try_execution_context()?;
-    let directory = context.globals().working_directory()?;
-    Some(PathBuf::from(directory))
-}
-
 /// Resolves `path` against the working directory of the call in progress, or
 /// against this process's own when the call did not name one.
+///
+/// A call arriving over IPC carries the directory of the process that made it,
+/// because the service's own is unrelated to the caller's.
 pub fn make_absolute(path: impl AsRef<str>) -> Result<PathBuf, PathError> {
-    make_absolute_from(path, call_working_directory())
+    let context = crate::runtime::try_execution_context();
+    let base = context
+        .as_ref()
+        .and_then(|context| context.globals().working_directory())
+        .map(Path::new);
+    make_absolute_from(path, base)
 }
 
 /// [`make_absolute`] with the base directory supplied by the caller, for the
@@ -36,7 +35,7 @@ pub fn make_absolute(path: impl AsRef<str>) -> Result<PathBuf, PathError> {
 /// cannot look it up.
 pub fn make_absolute_from(
     path: impl AsRef<str>,
-    base: Option<PathBuf>,
+    base: Option<&Path>,
 ) -> Result<PathBuf, PathError> {
     let path = path.as_ref();
     let cleanpath = clean(path.to_owned());
@@ -46,13 +45,14 @@ pub fn make_absolute_from(
     if pathbuf.is_absolute() {
         return Ok(pathbuf);
     }
-    let base = match base {
-        Some(base) => base,
-        None => std::env::current_dir().emit_map_err(PathError::internal(
-            "failed to get current working directory",
-        ))?,
-    };
-    Ok(base.join(pathbuf))
+    match base {
+        Some(base) => Ok(base.join(pathbuf)),
+        None => Ok(std::env::current_dir()
+            .emit_map_err(PathError::internal(
+                "failed to get current working directory",
+            ))?
+            .join(pathbuf)),
+    }
 }
 
 /// Returns `true` when `candidate` resolves to a location inside

--- a/lore-revision/src/util/path.rs
+++ b/lore-revision/src/util/path.rs
@@ -16,21 +16,43 @@ pub enum PathError {
     InvalidPath,
 }
 
+/// The directory the call in progress resolves relative paths against, when it
+/// named one. A call arriving over IPC carries the directory of the process
+/// that made it, because the service's own is unrelated to the caller's.
+fn call_working_directory() -> Option<PathBuf> {
+    let context = crate::runtime::try_execution_context()?;
+    let directory = context.globals().working_directory()?;
+    Some(PathBuf::from(directory))
+}
+
+/// Resolves `path` against the working directory of the call in progress, or
+/// against this process's own when the call did not name one.
 pub fn make_absolute(path: impl AsRef<str>) -> Result<PathBuf, PathError> {
+    make_absolute_from(path, call_working_directory())
+}
+
+/// [`make_absolute`] with the base directory supplied by the caller, for the
+/// call wrappers that resolve paths before the execution context exists and so
+/// cannot look it up.
+pub fn make_absolute_from(
+    path: impl AsRef<str>,
+    base: Option<PathBuf>,
+) -> Result<PathBuf, PathError> {
     let path = path.as_ref();
     let cleanpath = clean(path.to_owned());
     let pathbuf = PathBuf::from_str(cleanpath.as_str()).emit_map_err(InvalidPath {
         path: path.to_string(),
     })?;
-    if !pathbuf.is_absolute() {
-        Ok(std::env::current_dir()
-            .emit_map_err(PathError::internal(
-                "failed to get current working directory",
-            ))?
-            .join(pathbuf))
-    } else {
-        Ok(pathbuf)
+    if pathbuf.is_absolute() {
+        return Ok(pathbuf);
     }
+    let base = match base {
+        Some(base) => base,
+        None => std::env::current_dir().emit_map_err(PathError::internal(
+            "failed to get current working directory",
+        ))?,
+    };
+    Ok(base.join(pathbuf))
 }
 
 /// Returns `true` when `candidate` resolves to a location inside

--- a/lore-revision/src/util/path.rs
+++ b/lore-revision/src/util/path.rs
@@ -673,15 +673,13 @@ impl RelativePathBuf {
 
         let mut absolute_path = Path::new(user_path).to_path_buf();
         if !absolute_path.is_absolute() {
-            absolute_path = std::path::absolute(absolute_path)
-                .emit_map_err(PathError::internal("failed to resolve absolute path"))?;
+            absolute_path = make_absolute(absolute_path.to_string_lossy())?;
         }
         let absolute_path = clean(absolute_path.display().to_string());
 
         let mut repository_path = Path::new(repository_path).to_path_buf();
         if !repository_path.is_absolute() {
-            repository_path = std::path::absolute(repository_path)
-                .emit_map_err(PathError::internal("failed to resolve absolute path"))?;
+            repository_path = make_absolute(repository_path.to_string_lossy())?;
         }
         let repository_path = clean(repository_path.display().to_string()).to_lowercase();
 

--- a/lore/src/call.rs
+++ b/lore/src/call.rs
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: 2026 Epic Games, Inc.
 // SPDX-License-Identifier: MIT
+use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Instant;
@@ -221,10 +222,10 @@ async fn prepare_repository_call(
     mut globals: LoreGlobalArgs,
     callback: LoreEventCallback,
 ) -> Result<(PathBuf, Arc<ExecutionContext>), i32> {
-    let working_directory = globals.working_directory().map(PathBuf::from);
-    let repository_path = if let Ok(path) =
-        util::path::make_absolute_from(globals.repository_path.as_str(), working_directory)
-    {
+    let repository_path = if let Ok(path) = util::path::make_absolute_from(
+        globals.repository_path.as_str(),
+        globals.working_directory().map(Path::new),
+    ) {
         globals.repository_path = path.display().to_string().into();
         path
     } else {

--- a/lore/src/call.rs
+++ b/lore/src/call.rs
@@ -221,13 +221,15 @@ async fn prepare_repository_call(
     mut globals: LoreGlobalArgs,
     callback: LoreEventCallback,
 ) -> Result<(PathBuf, Arc<ExecutionContext>), i32> {
-    let repository_path =
-        if let Ok(path) = util::path::make_absolute(globals.repository_path.as_str()) {
-            globals.repository_path = path.display().to_string().into();
-            path
-        } else {
-            PathBuf::from(globals.repository_path.as_str())
-        };
+    let working_directory = globals.working_directory().map(PathBuf::from);
+    let repository_path = if let Ok(path) =
+        util::path::make_absolute_from(globals.repository_path.as_str(), working_directory)
+    {
+        globals.repository_path = path.display().to_string().into();
+        path
+    } else {
+        PathBuf::from(globals.repository_path.as_str())
+    };
 
     let execution = setup_execution(globals, callback);
 

--- a/lore/src/remote/call.rs
+++ b/lore/src/remote/call.rs
@@ -34,11 +34,28 @@ impl EventError for ServiceCallError {
     }
 }
 
+/// Records the directory the service resolves this call's relative paths
+/// against, when the caller left it unset. The service runs in a directory
+/// unrelated to the caller's, so without this a relative path would resolve
+/// there rather than where the caller ran. A caller that set the field, such as
+/// an installed tool that runs from a fixed directory but wants relative paths
+/// resolved elsewhere, keeps its value.
+#[allow(clippy::disallowed_methods)]
+fn fill_working_directory(globals: &mut LoreGlobalArgs) {
+    if globals.working_directory().is_some() {
+        return;
+    }
+    if let Ok(directory) = std::env::current_dir() {
+        globals.working_directory = directory.display().to_string().into();
+    }
+}
+
 pub async fn service_call<ArgsType: LoreArgs + Clone + Send + 'static>(
-    globals: LoreGlobalArgs,
+    mut globals: LoreGlobalArgs,
     args: ArgsType,
     callback: LoreEventCallback,
 ) -> i32 {
+    fill_working_directory(&mut globals);
     let mut event_dispatcher = EventDispatcher::new(callback);
 
     service_call_impl(&mut event_dispatcher, globals, args)

--- a/scripts/test/conftest.py
+++ b/scripts/test/conftest.py
@@ -205,6 +205,31 @@ def _wait_for_service_ready(lore_executable_path, service_process, attempts=30):
 
 
 @pytest.fixture(scope="function")
+def lore_service_in_directory(lore_executable_path):
+    """Starts the service in a chosen directory, for tests that need the
+    service's own working directory to differ from the caller's."""
+    processes = []
+
+    def start(directory):
+        service_process = subprocess.Popen(
+            [lore_executable_path, "service", "run"], cwd=str(directory)
+        )
+        processes.append(service_process)
+        _wait_for_service_ready(lore_executable_path, service_process)
+        return service_process
+
+    yield start
+
+    for service_process in processes:
+        service_process.terminate()
+        try:
+            service_process.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            logger.warning("Lore service did not exit on terminate, killing it")
+            service_process.kill()
+
+
+@pytest.fixture(scope="function")
 def background_lore_service(lore_executable_path):
     command_args = [lore_executable_path, "service", "run"]
     logger.info("Executing Lore service command: %s", command_args)

--- a/scripts/test/conftest.py
+++ b/scripts/test/conftest.py
@@ -205,14 +205,18 @@ def _wait_for_service_ready(lore_executable_path, service_process, attempts=30):
 
 
 @pytest.fixture(scope="function")
-def lore_service_in_directory(lore_executable_path):
+def lore_service_in_directory(lore_executable_path, global_dir_name):
     """Starts the service in a chosen directory, for tests that need the
-    service's own working directory to differ from the caller's."""
+    service's own working directory to differ from the caller's. The service
+    shares the test's isolated global config so shared stores it creates land
+    where the client looks for them."""
     processes = []
 
     def start(directory):
+        env = os.environ.copy()
+        env["LORE_GLOBAL_PATH"] = global_dir_name
         service_process = subprocess.Popen(
-            [lore_executable_path, "service", "run"], cwd=str(directory)
+            [lore_executable_path, "service", "run"], cwd=str(directory), env=env
         )
         processes.append(service_process)
         _wait_for_service_ready(lore_executable_path, service_process)

--- a/scripts/test/test_service.py
+++ b/scripts/test/test_service.py
@@ -3,6 +3,7 @@
 import logging
 import os
 import platform
+import subprocess
 
 import pytest
 
@@ -19,6 +20,7 @@ def service_supported():
 
 
 @pytest.mark.smoke
+@pytest.mark.xdist_group("lore_service")
 @pytest.mark.skip(reason="Unknown issue specifically running in CI for OSS")
 @pytest.mark.skipif(
     not service_supported(), reason="Service not supported on " + platform.system()
@@ -29,6 +31,7 @@ def test_service_down(new_lore_repo):
 
 
 @pytest.mark.smoke
+@pytest.mark.xdist_group("lore_service")
 @pytest.mark.skipif(
     not service_supported(), reason="Service not supported on " + platform.system()
 )
@@ -48,3 +51,71 @@ def test_service_call(new_lore_repo, background_lore_service):
     assert "A " + file_name in map(
         lambda line: line.strip(" "), status_output.splitlines()
     )
+
+
+@pytest.mark.smoke
+@pytest.mark.xdist_group("lore_service")
+@pytest.mark.skipif(
+    not service_supported(), reason="Service not supported on " + platform.system()
+)
+def test_service_resolves_relative_paths_against_caller(
+    new_lore_repo, lore_executable_path, lore_service_in_directory, tmp_path
+):
+    """Relative paths belong to the directory the command was run in.
+
+    The service resolves them, and its own working directory is unrelated to
+    the caller's, so a service started elsewhere must not pull them towards
+    itself. Every other service test passes an absolute repository path, which
+    cannot catch this.
+    """
+    repo: Lore = new_lore_repo()
+    with repo.open_file("seed.txt", "w+") as seed_file:
+        seed_file.write("seed\n")
+    repo.stage(scan=True, offline=True)
+    repo.commit("Seed", offline=True)
+    repo.push()
+
+    service_directory = tmp_path / "service_elsewhere"
+    caller_directory = tmp_path / "caller"
+    service_directory.mkdir()
+    caller_directory.mkdir()
+    lore_service_in_directory(service_directory)
+
+    environment = os.environ.copy()
+    environment.update(LORE_SERVICE_ENVIRONMENT)
+
+    def run_in(directory, args):
+        result = subprocess.run(
+            [lore_executable_path, *args],
+            capture_output=True,
+            text=True,
+            cwd=str(directory),
+            env=environment,
+        )
+        assert result.returncode == 0, (
+            f"{args} failed in {directory}: {result.stdout}{result.stderr}"
+        )
+        return result.stdout + result.stderr
+
+    clone_name = "relative_clone"
+    run_in(caller_directory, ["clone", repo.remote_path, clone_name])
+
+    clone_path = caller_directory / clone_name
+    assert (clone_path / ".lore").is_dir(), (
+        f"Clone must land under the caller's directory, not the service's. "
+        f"{caller_directory} contains {list(caller_directory.iterdir())}"
+    )
+    assert not (service_directory / clone_name).exists(), (
+        f"Clone must not land under the service's directory. "
+        f"{service_directory} contains {list(service_directory.iterdir())}"
+    )
+
+    file_name = "added.uasset"
+    (clone_path / file_name).write_bytes(os.urandom(30))
+
+    run_in(clone_path, ["stage", file_name])
+
+    status_output = run_in(clone_path, ["status"])
+    assert "A " + file_name in map(
+        lambda line: line.strip(" "), status_output.splitlines()
+    ), f"Staged file should show as added: {status_output}"

--- a/scripts/test/test_service.py
+++ b/scripts/test/test_service.py
@@ -3,7 +3,6 @@
 import logging
 import os
 import platform
-import subprocess
 
 import pytest
 
@@ -59,7 +58,7 @@ def test_service_call(new_lore_repo, background_lore_service):
     not service_supported(), reason="Service not supported on " + platform.system()
 )
 def test_service_resolves_relative_paths_against_caller(
-    new_lore_repo, lore_executable_path, lore_service_in_directory, tmp_path
+    new_lore_repo, lore_service_in_directory, tmp_path
 ):
     """Relative paths belong to the directory the command was run in.
 
@@ -68,37 +67,32 @@ def test_service_resolves_relative_paths_against_caller(
     itself. Every other service test passes an absolute repository path, which
     cannot catch this.
     """
-    repo: Lore = new_lore_repo()
-    with repo.open_file("seed.txt", "w+") as seed_file:
-        seed_file.write("seed\n")
-    repo.stage(scan=True, offline=True)
-    repo.commit("Seed", offline=True)
-    repo.push()
-
+    # Start the service in a directory unrelated to where the commands run, so
+    # that a relative path resolved there rather than at the caller would show.
     service_directory = tmp_path / "service_elsewhere"
     caller_directory = tmp_path / "caller"
     service_directory.mkdir()
     caller_directory.mkdir()
     lore_service_in_directory(service_directory)
 
-    environment = os.environ.copy()
-    environment.update(LORE_SERVICE_ENVIRONMENT)
+    # Seed a remote to clone from. Routed through the service like the rest,
+    # but against the repository's own absolute path, so unaffected by the
+    # service's directory.
+    source: Lore = new_lore_repo(environment_vars=LORE_SERVICE_ENVIRONMENT.copy())
+    with source.open_file("seed.txt", "w+") as seed_file:
+        seed_file.write("seed\n")
+    source.stage(scan=True, offline=True)
+    source.commit("Seed", offline=True)
+    source.push()
 
-    def run_in(directory, args):
-        result = subprocess.run(
-            [lore_executable_path, *args],
-            capture_output=True,
-            text=True,
-            cwd=str(directory),
-            env=environment,
-        )
-        assert result.returncode == 0, (
-            f"{args} failed in {directory}: {result.stdout}{result.stderr}"
-        )
-        return result.stdout + result.stderr
-
+    # Clone to a relative path from the caller's directory. It must land there,
+    # not under the service's directory.
     clone_name = "relative_clone"
-    run_in(caller_directory, ["clone", repo.remote_path, clone_name])
+    source.run(
+        ["repository", "clone", source.remote_path, clone_name],
+        cwd=str(caller_directory),
+        use_os_dir=True,
+    )
 
     clone_path = caller_directory / clone_name
     assert (clone_path / ".lore").is_dir(), (
@@ -110,12 +104,22 @@ def test_service_resolves_relative_paths_against_caller(
         f"{service_directory} contains {list(service_directory.iterdir())}"
     )
 
+    # Stage a relative path from inside the clone.
+    clone = Lore(
+        lore_executable_path=source.lore_executable_path,
+        path=str(clone_path),
+        name=clone_name,
+        global_dir=source.global_dir,
+        environment_vars=LORE_SERVICE_ENVIRONMENT.copy(),
+        remote_url=source.remote,
+        remote_path=source.remote_path,
+        create_repo=False,
+    )
     file_name = "added.uasset"
     (clone_path / file_name).write_bytes(os.urandom(30))
+    clone.stage(file_name, relative_paths=True)
 
-    run_in(clone_path, ["stage", file_name])
-
-    status_output = run_in(clone_path, ["status"])
+    status_output = clone.status()
     assert "A " + file_name in map(
         lambda line: line.strip(" "), status_output.splitlines()
     ), f"Staged file should show as added: {status_output}"


### PR DESCRIPTION
# Summary

When executing a command in the service process it must use the working directory of the calling process for resolving relative paths to absolute paths, NOT the service process current working directory.

Ensure that all relative -> absolute translation goes through the helper `make_absolute` function and store the "working directory" to use when doing this resolution in the global args, which makes the service process do the correct resolution.

Also changes the working directory of the service process to the standard root path.

Adds a smoke test that verifies the relative path handling in a service process.

# Testing

Ran `service start` from one path, changed to a different path and did a `clone <relative-path>`. Verified that the cloned instance was in the correct relative path of the new working directory, not in a path relative to the directory where the service process was started (prior to this change it would end up in the original path where the service process was started from).