### PR TITLE
fix(sync): set remote location when syncing to explicit revision

### DIFF
--- a/lore-revision/src/revision/sync.rs
+++ b/lore-revision/src/revision/sync.rs
@@ -48,6 +48,7 @@ use crate::repository::RepositoryContext;
 use crate::repository::RepositoryWriteToken;
 use crate::repository::THEIRS_SUFFIX;
 use crate::revision;
+use crate::revision::ResolveSearchLocation;
 use crate::state;
 use crate::state::RecordedModifiedTimes;
 use crate::state::State;
@@ -326,6 +327,36 @@ pub async fn sync(
         .await
         .forward::<SyncError>("Failed to find revision")?;
         lore_debug!("Sync resolved revision target is {revision}");
+
+        // Determine location for the explicitly-provided revision.
+        // When the user passes --remote, check whether the resolved
+        // revision is on the remote timeline.  Without this, location
+        // stays Local and the local branch Latest pointer is never
+        // updated, leaving status reporting the branch as behind remote.
+        if matches!(
+            execution_context().globals().search_location(),
+            ResolveSearchLocation::Remote
+        ) {
+            if let Ok(remote) = repository.remote().await {
+                remote_latest =
+                    branch::load_remote_latest(remote.clone(), repository.id, branch_id)
+                        .await
+                        .unwrap_or_default();
+            }
+            if !remote_latest.is_zero() {
+                if revision == remote_latest {
+                    location = LoreBranchLocation::Remote;
+                } else if let Ok((_bp, _remote_history, local_history)) =
+                    history::find_branch_point(repository.clone(), remote_latest, revision).await
+                {
+                    // revision is an ancestor of remote_latest (on the
+                    // remote timeline) when local_history is empty.
+                    if local_history.is_empty() {
+                        location = LoreBranchLocation::Remote;
+                    }
+                }
+            }
+        }
     } else {
         // If there is no revision given, then we determine if the local and remote
         // latest revisions are in line or divergent.
@@ -503,8 +534,12 @@ pub async fn sync(
     }
 
     if !state_current.revision().is_zero() && !force {
-        // Check if we have diverged and need to resort to a merge flow
-        if location == LoreBranchLocation::Remote
+        // Check if we have diverged and need to resort to a merge flow.
+        // Only enter the merge path for implicit (no revision given) syncs;
+        // an explicit revision targets a specific point in history and must
+        // not trigger divergence resolution.
+        if options.revision.is_none()
+            && location == LoreBranchLocation::Remote
             && local_latest_diverged
             && find::find_revision(
                 repository.clone(),

--- a/scripts/test/test_sync.py
+++ b/scripts/test/test_sync.py
@@ -877,3 +877,51 @@ def test_sync_reports_a_file_it_cannot_read(new_lore_repo):
         )
     finally:
         os.chmod(clone_file_path, 0o644)
+
+
+@pytest.mark.smoke
+def test_sync_remote_explicit_revision(new_lore_repo):
+    """
+    Test that syncing to an explicit revision with --remote updates the
+    local branch Latest pointer, preventing 'Local branch is behind remote'
+    status.
+    """
+    repo = new_lore_repo()
+
+    # Create some initial history
+    with repo.open_file("file1.txt", "w+") as f:
+        f.write("v1")
+    repo.stage("file1.txt")
+    repo.commit("Commit 1")
+
+    # Create a side branch
+    repo.branch_create("feature")
+    repo.branch_switch("feature")
+    with repo.open_file("file2.txt", "w+") as f:
+        f.write("v1")
+    repo.stage("file2.txt")
+    repo.commit("Feature commit")
+    repo.push()
+
+    # Switch back to main, merge the feature branch
+    repo.branch_switch("main")
+    repo.branch_merge_start("feature", message="Merge feature into main")
+    repo.push()
+
+    # Get the client to a clean state on an older commit
+    clone = repo.clone()
+    clone.sync("@LATEST~1")
+    # Get the latest revision hash from the remote by running branch_latest
+    import re
+    merge_revision_output = repo.run(["status"])
+    merge_revision = re.search(r'revision \d+ -> ([a-f0-9]+)', merge_revision_output).group(1)
+    # Now simulate the bug: sync explicitly to the merge revision with --remote
+    clone.sync(merge_revision, remote=True)
+
+    # Check that status does NOT complain about being behind remote
+    status_output = clone.status()
+    assert "Local branch is behind remote" not in status_output, "Branch Latest pointer was not updated"
+
+    # Second sync should say Already on branch, without actually syncing anything
+    sync_output = clone.sync()
+    assert "Already on branch" in sync_output, "Sync did not realize we are already at latest"


### PR DESCRIPTION
## Fix: Update branch `Latest` pointer on explicit `--remote` sync

### Summary
Fixes a bug where syncing explicitly to a specific remote revision (`lore sync <revision> --remote`) would correctly update the local working copy but fail to advance the local branch's `Latest` pointer metadata. 

As a result of the stale pointer, `lore status` would falsely report `Local branch is behind remote`, and subsequent `lore sync` operations would fail to realize they were already fully synced.

### Root Cause
When `lore sync` resolves a target implicitly (without a user-provided hash), it compares local vs. remote latest pointers and appropriately sets the internal `location` flag to either `Local` or `Remote`. The local `Latest` metadata pointer is only updated at the end of the sync if `location == Remote`. 

However, when a user explicitly provides a revision hash, this divergence resolution logic was completely bypassed. The target revision was resolved blindly, and `location` was never updated from its default value (`Local`). Consequently, the branch pointer update block was skipped entirely at the end of the sync process.

### Changes
* **`lore-revision/src/revision/sync.rs`**: Added logic in the explicit revision path to search the remote timeline (`history::find_branch_point`) when `--remote` is active. If the explicit revision exists on the remote, the `location` is properly set to `Remote`, allowing the pointer update block to execute normally.
* **`scripts/test/test_sync.py`**: Added an automated end-to-end Python integration test (`test_sync_remote_explicit_revision`) that reproduces the bug structure and asserts that `status` and `sync` behave correctly post-sync.

### Verification
* Verified against the Python `test_sync.py` suite.
* Rust `lore-revision` unit tests and standard `clippy`/`fmt` tasks pass cleanly.
