### PR TITLE
lore: Support service start stop and automatic use, and a lightweight runtime when using the service

### DIFF
--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -9,7 +9,7 @@ Reference is the technical description of the machinery and how to operate it. A
 ## Reference pages
 
 - [Lore CLI command reference](lore-cli-commands.md) — every `lore` command, subcommand, argument, and flag, generated from `lore --markdown-help`.
-- [Lore CLI configuration reference](lore-cli-config.md) — every field in the per-repository `config.toml` and user-level `cli.toml`, with each field's type, default, and on-disk location.
+- [Lore CLI configuration reference](lore-cli-config.md) — every field in the per-repository `config.toml`, the user-level global `config.toml`, and the user-level `cli.toml`, with each field's type, default, and on-disk location.
 - [Lore Server configuration reference](lore-server-config.md) — every `loreserver` CLI flag, config-file layer, and settings field, including the AWS, DynamoDB, Consul, and hook plugin backends.
 
 ## Suggested starting points

--- a/docs/reference/lore-cli-commands.md
+++ b/docs/reference/lore-cli-commands.md
@@ -2742,4 +2742,3 @@ Manage the shared store
     This document was generated automatically by
     <a href="https://crates.io/crates/clap-markdown"><code>clap-markdown</code></a>.
 </i></small>
-

--- a/docs/reference/lore-cli-commands.md
+++ b/docs/reference/lore-cli-commands.md
@@ -161,6 +161,7 @@ This page is generated from `lore --markdown-help` (CLI `0.8.2-nightly+31`). Eve
 * [`lore service run`↴](#lore-service-run)
 * [`lore service start`↴](#lore-service-start)
 * [`lore service stop`↴](#lore-service-stop)
+* [`lore service set-use-automatically`↴](#lore-service-set-use-automatically)
 * [`lore notification`↴](#lore-notification)
 * [`lore notification subscribe`↴](#lore-notification-subscribe)
 * [`lore completions`↴](#lore-completions)
@@ -219,8 +220,9 @@ This page is generated from `lore --markdown-help` (CLI `0.8.2-nightly+31`). Eve
 * `--compress-limit <count>` — Set maximum number of parallel compress operations
 * `--search-limit <SEARCH_LIMIT>` — Set maximum number of revisions to search when matching or finding revisions
 * `--search-nearest` — Set to search for nearest match when matching revisions
-* `--gc` — Set to run automatic garbage collection on local store in background
+* `--no-gc` — Prevent automatic incremental garbage collection for this command; it otherwise runs in the background on writes. `lore repository gc` always runs a full pass regardless
 * `--sync-data` — Force sync data to storage media during flush
+* `--cache` — Cache fragment payloads fetched from remote in the local store
 * `--non-interactive` — Disable interactive prompts (e.g., per-link commit messages)
 
 
@@ -2598,8 +2600,9 @@ Manage the repository in a service process
 ###### **Subcommands:**
 
 * `run` — Run this process as the service
-* `start` — Start service for a repository
-* `stop` — Stop service for a repository
+* `start` — Start the service process
+* `stop` — Stop the service process
+* `set-use-automatically` — Set whether to automatically use the service process
 
 
 
@@ -2613,7 +2616,7 @@ Run this process as the service
 
 ## `lore service start`
 
-Start service for a repository
+Start the service process
 
 **Usage:** `lore service start`
 
@@ -2621,13 +2624,21 @@ Start service for a repository
 
 ## `lore service stop`
 
-Stop service for a repository
+Stop the service process
 
-**Usage:** `lore service stop [all]`
+**Usage:** `lore service stop`
+
+
+
+## `lore service set-use-automatically`
+
+Set whether to automatically use the service process
+
+**Usage:** `lore service set-use-automatically <enabled>`
 
 ###### **Arguments:**
 
-* `<all>` — Flag to stop servicing all repositories
+* `<enabled>` — Automatically run Lore commands through the service process
 
   Possible values: `true`, `false`
 
@@ -2731,3 +2742,4 @@ Manage the shared store
     This document was generated automatically by
     <a href="https://crates.io/crates/clap-markdown"><code>clap-markdown</code></a>.
 </i></small>
+

--- a/docs/reference/lore-cli-config.md
+++ b/docs/reference/lore-cli-config.md
@@ -4,10 +4,11 @@
 
 ```text
 <repo>/.lore/config.toml   # per-repository client settings (created on init/clone)
+~/.config/lore/config.toml # user-level global settings (OS user config dir; Linux shown)
 ~/.config/lore/cli.toml    # user-level CLI settings (OS user config dir; Linux shown)
 ```
 
-This page documents the **Lore CLI** client configuration: the per-repository `config.toml` and the user-level `cli.toml` that the `lore` binary reads. These are distinct from the Lore Server daemon's configuration — for server stores, endpoints, topology, and plugin backends, see the [Lore Server configuration reference](lore-server-config.md). The fields below are written by `lore repository create` and `lore clone`, or you edit them by hand; you don't need to read the source to look one up.
+This page documents the **Lore CLI** client configuration: the per-repository `config.toml`, the user-level global `config.toml`, and the user-level `cli.toml` that the `lore` binary reads. These are distinct from the Lore Server daemon's configuration — for server stores, endpoints, topology, and plugin backends, see the [Lore Server configuration reference](lore-server-config.md). The fields below are written by `lore repository create` and `lore clone`, or you edit them by hand; you don't need to read the source to look one up.
 
 ## Per-repository `config.toml`
 
@@ -86,6 +87,36 @@ The table key and both fields accept legacy serde aliases for backward compatibi
 A config that uses the legacy names still loads. New configs use the current names.
 
 Lore normally writes this table for you when you clone with `--use-shared-store`. For how shared stores work and how to set one up, see [Step 6 of the Quickstart](../tutorials/quickstart.md#step-6-set-up-a-shared-store-and-clone-a-second-working-tree); for the `lore clone` and `lore shared-store` flags, see the [Lore CLI command reference](lore-cli-commands.md).
+
+## User-level global `config.toml`
+
+### Location
+
+The global `config.toml` holds settings that apply to every repository, rather than to one. It shares the OS user config directory with `cli.toml`, so on a typical Linux setup it is `~/.config/lore/config.toml`; see the table under `cli.toml` below for the other platforms. Setting `LORE_GLOBAL_PATH` moves the whole directory, which is how the test suite isolates it.
+
+The file is optional. When it is absent, every setting below takes its default.
+
+### Fields
+
+| Field | Type | Default | Description |
+| --- | --- | --- | --- |
+| `use_shared_store_automatically` | bool | `false` | Whether `lore repository create` and `lore clone` configure a shared store without being asked. Read only when a repository is created or cloned; the result is written into that repository's own config. |
+| `use_service_automatically` | bool | `false` | Whether Lore runs every command in the background service process. See below. |
+| `default_shared_stores` | table | empty | Per-remote default shared store paths, keyed by remote URL. |
+
+### Running commands through the service
+
+With `use_service_automatically` enabled, Lore sends each command to a background service process over a local socket instead of executing it in the CLI process, and starts that service automatically if it is not already running. Set it with:
+
+```bash
+lore service set-use-automatically true
+```
+
+`lore service start` and `lore service stop` control the process explicitly. Starting when a service is already running, and stopping when none is, are both no-ops rather than errors.
+
+The `LORE_USE_SERVICE` environment variable overrides the setting for a single invocation: any value other than `0` or `false` forces the service on, and `0`, `false`, or an empty value forces it off.
+
+Automatic start-up only applies to the `lore` CLI. When Lore is embedded as a library the running executable is the host application, which Lore will not relaunch as a service; start the service separately in that case.
 
 ## User-level `cli.toml`
 

--- a/lore-base/src/runtime.rs
+++ b/lore-base/src/runtime.rs
@@ -541,6 +541,15 @@ pub struct TokioSettings {
     #[serde(default = "default_thread_keep_alive")]
     pub thread_keep_alive_seconds: u64,
     pub worker_threads: Option<usize>,
+    /// Whether to build the rayon compute pool up front. Turning this off does
+    /// not make the pool unavailable: [`compute_pool`] still builds it on first
+    /// use, so this only decides whether its threads are paid for eagerly.
+    #[serde(default = "default_eager_compute_pool")]
+    pub eager_compute_pool: bool,
+}
+
+fn default_eager_compute_pool() -> bool {
+    true
 }
 
 impl Default for TokioSettings {
@@ -549,6 +558,23 @@ impl Default for TokioSettings {
             max_blocking_threads: default_blocking_threads(),
             thread_keep_alive_seconds: default_thread_keep_alive(),
             worker_threads: None,
+            eager_compute_pool: true,
+        }
+    }
+}
+
+impl TokioSettings {
+    /// Settings for a process that only relays work elsewhere, such as a client
+    /// whose calls all execute in the Lore service. Sized for IPC rather than
+    /// for doing the work, and with no compute pool, which such a process never
+    /// touches. Each pool keeps [`MIN_THREADS_PER_POOL`] so that neither can
+    /// starve the other.
+    pub fn relay_only() -> Self {
+        TokioSettings {
+            max_blocking_threads: MIN_THREADS_PER_POOL,
+            thread_keep_alive_seconds: default_thread_keep_alive(),
+            worker_threads: Some(MIN_THREADS_PER_POOL),
+            eager_compute_pool: false,
         }
     }
 }
@@ -600,10 +626,12 @@ pub fn runtime_with_settings(settings: Option<TokioSettings>) -> Handle {
             // Build the compute pool off-thread so runtime creation isn't
             // blocked on spawning N rayon workers. No LORE_CONTEXT is active
             // yet, so Handle::spawn directly rather than lore_spawn!.
-            #[allow(clippy::disallowed_methods)]
-            handle.spawn(async {
-                let _ = COMPUTE_POOL.get_or_init(build_compute_pool);
-            });
+            if settings.eager_compute_pool {
+                #[allow(clippy::disallowed_methods)]
+                handle.spawn(async {
+                    let _ = COMPUTE_POOL.get_or_init(build_compute_pool);
+                });
+            }
 
             handle
         }
@@ -693,6 +721,7 @@ mod tests {
             max_blocking_threads: 4,
             thread_keep_alive_seconds: 5,
             worker_threads: Some(2),
+            eager_compute_pool: true,
         };
         let handle = runtime_with_settings(Some(settings));
         handle.block_on(async {

--- a/lore-base/src/runtime.rs
+++ b/lore-base/src/runtime.rs
@@ -589,6 +589,38 @@ pub fn runtime() -> Handle {
 /// If no runtime exists yet, creates one with the provided settings (or defaults if `None`).
 /// If a tokio runtime is already active on the current thread, returns its handle instead.
 /// Respects the `LORE_WORKER_THREADS` environment variable for overriding worker thread count.
+/// The number of tokio worker threads a runtime with these settings is built
+/// with. Precedence: the `LORE_WORKER_THREADS` env override, then an explicit
+/// positive count in the settings, then the budget-derived default. Always a
+/// concrete count, because leaving it unset makes tokio use the raw core count
+/// and ignore the thread limit.
+fn resolve_worker_threads(settings: &TokioSettings) -> usize {
+    match (
+        env_thread_override("LORE_WORKER_THREADS"),
+        settings.worker_threads,
+    ) {
+        (Some(val), _) => val,
+        (None, Some(val)) if val > 0 => val,
+        _ => default_worker_threads(),
+    }
+}
+
+/// Builds a fresh multi-thread tokio runtime from the settings. Does not touch
+/// the shared runtime or the compute pool, so it is safe to call in isolation.
+fn build_tokio_runtime(settings: &TokioSettings) -> tokio::runtime::Runtime {
+    let mut builder = tokio::runtime::Builder::new_multi_thread();
+    builder
+        .enable_all()
+        .max_blocking_threads(settings.max_blocking_threads)
+        .thread_keep_alive(Duration::from_secs(settings.thread_keep_alive_seconds))
+        .thread_name_fn(|| {
+            static ID: AtomicUsize = AtomicUsize::new(0);
+            format!("lore-tokio-{}", ID.fetch_add(1, Ordering::Relaxed))
+        })
+        .worker_threads(resolve_worker_threads(settings));
+    builder.build().expect("Failed to create runtime")
+}
+
 pub fn runtime_with_settings(settings: Option<TokioSettings>) -> Handle {
     if let Ok(handle) = tokio::runtime::Handle::try_current() {
         handle
@@ -598,28 +630,7 @@ pub fn runtime_with_settings(settings: Option<TokioSettings>) -> Handle {
             runtime.handle().clone()
         } else {
             let settings = settings.unwrap_or_default();
-            let mut builder = tokio::runtime::Builder::new_multi_thread();
-            builder
-                .enable_all()
-                .max_blocking_threads(settings.max_blocking_threads)
-                .thread_keep_alive(Duration::from_secs(settings.thread_keep_alive_seconds))
-                .thread_name_fn(|| {
-                    static ID: AtomicUsize = AtomicUsize::new(0);
-                    format!("lore-tokio-{}", ID.fetch_add(1, Ordering::Relaxed))
-                });
-            // Always set an explicit count, else tokio would default to the raw
-            // core count and ignore the thread limit. Precedence: env override,
-            // explicit setting, budget-derived default.
-            let worker_threads = match (
-                env_thread_override("LORE_WORKER_THREADS"),
-                settings.worker_threads,
-            ) {
-                (Some(val), _) => val,
-                (None, Some(val)) if val > 0 => val,
-                _ => default_worker_threads(),
-            };
-            builder.worker_threads(worker_threads);
-            let runtime = builder.build().expect("Failed to create runtime");
+            let runtime = build_tokio_runtime(&settings);
             let handle = runtime.handle().clone();
             *default_runtime = Some(runtime);
 
@@ -735,6 +746,55 @@ mod tests {
         assert_eq!(counts.worker, 8);
         assert_eq!(counts.blocking, std::cmp::min(2 * (8 + 1), 128));
         assert_eq!(counts.compute, 7);
+    }
+
+    #[test]
+    fn relay_only_settings_are_minimal() {
+        let relay = TokioSettings::relay_only();
+        assert_eq!(relay.worker_threads, Some(MIN_THREADS_PER_POOL));
+        assert_eq!(relay.max_blocking_threads, MIN_THREADS_PER_POOL);
+        assert!(
+            !relay.eager_compute_pool,
+            "a relay process never touches the compute pool, so it must not build it eagerly"
+        );
+        assert!(
+            TokioSettings::default().eager_compute_pool,
+            "a full runtime builds the compute pool eagerly"
+        );
+    }
+
+    #[test]
+    fn relay_runtime_is_smaller_than_full() {
+        // The env override, if set in the test environment, would defeat the
+        // per-settings worker count both branches resolve, so skip then.
+        if env_thread_override("LORE_WORKER_THREADS").is_some() {
+            return;
+        }
+
+        let relay = build_tokio_runtime(&TokioSettings::relay_only());
+        let full = build_tokio_runtime(&TokioSettings::default());
+
+        assert_eq!(
+            relay.metrics().num_workers(),
+            MIN_THREADS_PER_POOL,
+            "a relay runtime is sized for IPC, not for doing the work"
+        );
+        assert!(
+            full.metrics().num_workers() >= relay.metrics().num_workers(),
+            "the full runtime is never smaller than the relay one"
+        );
+    }
+
+    #[test]
+    fn built_runtime_honors_resolved_worker_count() {
+        // Independent of any env override: whatever count is resolved is the
+        // count the runtime is actually built with.
+        let settings = TokioSettings::relay_only();
+        let runtime = build_tokio_runtime(&settings);
+        assert_eq!(
+            runtime.metrics().num_workers(),
+            resolve_worker_threads(&settings)
+        );
     }
 
     #[test]

--- a/lore-capi/lore.h
+++ b/lore-capi/lore.h
@@ -4940,16 +4940,21 @@ typedef struct lore_storage_upload_args_t {
   struct lore_storage_upload_item_array_t items;
 } lore_storage_upload_args_t;
 
-// Arguments for starting the Lore service process for the current repository (no parameters).
+// Arguments for starting the Lore service process (no parameters).
 typedef struct lore_service_start_args_t {
   int _unused;
 } lore_service_start_args_t;
 
-// Arguments for stopping the Lore service process for the current or all repositories.
+// Arguments for stopping the Lore service process (no parameters).
 typedef struct lore_service_stop_args_t {
-  // Stop all repositories rather than just the current one
-  uint8_t all;
+  int _unused;
 } lore_service_stop_args_t;
+
+// Arguments for setting whether Lore automatically routes calls through the service process.
+typedef struct lore_service_set_use_automatically_args_t {
+  // Automatically use the service process
+  uint8_t enabled;
+} lore_service_set_use_automatically_args_t;
 
 // Arguments for subscribing to repository notifications (no parameters).
 typedef struct lore_notification_subscribe_args_t {
@@ -10471,6 +10476,49 @@ int32_t lore_service_stop(const struct lore_global_args_t *globals,
 void lore_service_stop_async(const struct lore_global_args_t *globals,
                              const struct lore_service_stop_args_t *args,
                              struct lore_event_callback_config_t callback);
+
+// Set whether Lore automatically routes calls through the background service.
+//
+// When enabled, every Lore call is executed by the service process, which is
+// started automatically if it is not already running.
+//
+// # Events
+//
+// Events are delivered via the callback as `lore_event_t`. Use the `tag` field to identify the event type.
+//
+// ## Standard Events
+//
+// These events are emitted by all interface functions:
+//
+// | Tag | Data Type | Description |
+// |-----|-----------|-------------|
+// | `LORE_EVENT_LOG` | `lore_log_event_data_t` | Diagnostic messages throughout execution |
+// | `LORE_EVENT_ERROR` | `lore_error_event_data_t` | Emitted for a non-fatal error during the operation |
+// | `LORE_EVENT_COMPLETE` | `lore_complete_event_data_t` | Always emitted at the end; `status` is `0` on success or the error code on failure |
+// | `LORE_EVENT_END` | `lore_end_event_data_t` | Always emitted after `COMPLETE` to signal callback termination |
+int32_t lore_service_set_use_automatically(const struct lore_global_args_t *globals,
+                                           const struct lore_service_set_use_automatically_args_t *args,
+                                           struct lore_event_callback_config_t callback);
+
+// Asynchronous version of `lore_service_set_use_automatically`.
+//
+// # Events
+//
+// Events are delivered via the callback as `lore_event_t`. Use the `tag` field to identify the event type.
+//
+// ## Standard Events
+//
+// These events are emitted by all interface functions:
+//
+// | Tag | Data Type | Description |
+// |-----|-----------|-------------|
+// | `LORE_EVENT_LOG` | `lore_log_event_data_t` | Diagnostic messages throughout execution |
+// | `LORE_EVENT_ERROR` | `lore_error_event_data_t` | Emitted for a non-fatal error during the operation |
+// | `LORE_EVENT_COMPLETE` | `lore_complete_event_data_t` | Always emitted at the end; `status` is `0` on success or the error code on failure |
+// | `LORE_EVENT_END` | `lore_end_event_data_t` | Always emitted after `COMPLETE` to signal callback termination |
+void lore_service_set_use_automatically_async(const struct lore_global_args_t *globals,
+                                              const struct lore_service_set_use_automatically_args_t *args,
+                                              struct lore_event_callback_config_t callback);
 
 // Subscribe to repository notifications.
 //

--- a/lore-client/src/cli/client_main.rs
+++ b/lore-client/src/cli/client_main.rs
@@ -84,3 +84,38 @@ pub fn client_main() -> ExitCode {
 
     return ExitCode::from(result);
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn command(args: &[&str]) -> LoreCommands {
+        LoreCli::try_parse_from(args)
+            .expect("args should parse")
+            .command
+            .expect("a subcommand should be present")
+    }
+
+    #[test]
+    fn only_service_run_does_work_in_this_process() {
+        // The service process itself keeps the full runtime.
+        assert!(runs_work_in_this_process(&command(&[
+            "lore", "service", "run"
+        ])));
+
+        // Everything else relays to the service and must not be excluded, so it
+        // can be sized lean. The service-control commands run locally but are
+        // light, and a regular command routes through the service.
+        for relaying in [
+            vec!["lore", "service", "start"],
+            vec!["lore", "service", "stop"],
+            vec!["lore", "service", "set-use-automatically", "true"],
+            vec!["lore", "status"],
+        ] {
+            assert!(
+                !runs_work_in_this_process(&command(&relaying)),
+                "{relaying:?} must not be treated as doing work in this process"
+            );
+        }
+    }
+}

--- a/lore-client/src/cli/client_main.rs
+++ b/lore-client/src/cli/client_main.rs
@@ -5,10 +5,22 @@ use clap::CommandFactory;
 use clap::Parser;
 
 use crate::cli::LoreCli;
+use crate::cli::LoreCommands;
 use crate::cli::handle_lore_commands;
 use crate::cli::lore_globals_from_args;
+use crate::commands::service::ServiceCommands;
 use crate::config::setup_config;
 use crate::logging;
+
+/// Whether this command does its own work rather than relaying it to the Lore
+/// service. Only `service run` does: it *is* the service, so it needs the full
+/// complement of threads however the calling user has configured routing.
+fn runs_work_in_this_process(command: &LoreCommands) -> bool {
+    matches!(
+        command,
+        LoreCommands::Service(args) if matches!(args.command, ServiceCommands::Run(_))
+    )
+}
 
 pub fn client_main() -> ExitCode {
     #[cfg(target_family = "windows")]
@@ -54,6 +66,10 @@ pub fn client_main() -> ExitCode {
 
     if let Some(max_threads) = cli.max_threads {
         lore::set_thread_limit(max_threads);
+    }
+
+    if !runs_work_in_this_process(cli_command) && lore::will_use_service() {
+        lore::size_threads_for_relaying();
     }
 
     let globals = lore_globals_from_args(&cli);

--- a/lore-client/src/cli/commands/service.rs
+++ b/lore-client/src/cli/commands/service.rs
@@ -6,6 +6,7 @@ use clap::Args;
 use clap::Subcommand;
 use lore::interface::LoreEvent;
 use lore::interface::LoreGlobalArgs;
+use lore::interface::LoreServiceSetUseAutomaticallyArgs;
 use lore::interface::LoreServiceStartArgs;
 use lore::interface::LoreServiceStopArgs;
 use lore::runtime;
@@ -32,10 +33,13 @@ pub struct ServiceRunArgs {}
 pub struct ServiceStartArgs {}
 
 #[derive(Args)]
-pub struct ServiceStopArgs {
-    /// Flag to stop servicing all repositories
-    #[clap(value_name = "all")]
-    all: Option<bool>,
+pub struct ServiceStopArgs {}
+
+#[derive(Args)]
+pub struct ServiceSetUseAutomaticallyArgs {
+    /// Automatically run Lore commands through the service process
+    #[clap(value_name = "enabled", value_parser = clap::value_parser!(bool), action = clap::ArgAction::Set)]
+    enabled: bool,
 }
 
 #[derive(Subcommand)]
@@ -43,11 +47,14 @@ pub enum ServiceCommands {
     ///Run this process as the service
     Run(ServiceRunArgs),
 
-    /// Start service for a repository
+    /// Start the service process
     Start(ServiceStartArgs),
 
-    /// Stop service for a repository
+    /// Stop the service process
     Stop(ServiceStopArgs),
+
+    /// Set whether to automatically use the service process
+    SetUseAutomatically(ServiceSetUseAutomaticallyArgs),
 }
 
 fn handle_service_run(_globals: LoreGlobalArgs, _args: &ServiceRunArgs) -> u8 {
@@ -81,10 +88,8 @@ fn handle_service_start(globals: LoreGlobalArgs, _args: &ServiceStartArgs) -> u8
     return runtime().block_on(service::start(globals, start_args, callback)) as u8;
 }
 
-fn handle_service_stop(globals: LoreGlobalArgs, args: &ServiceStopArgs) -> u8 {
-    let stop_args = LoreServiceStopArgs {
-        all: if args.all.unwrap_or_default() { 1 } else { 0 },
-    };
+fn handle_service_stop(globals: LoreGlobalArgs, _args: &ServiceStopArgs) -> u8 {
+    let stop_args = LoreServiceStopArgs {};
 
     let callback = output_formatter().unwrap_or(Some(
         (Box::new(move |event: &LoreEvent| match event {
@@ -100,6 +105,28 @@ fn handle_service_stop(globals: LoreGlobalArgs, args: &ServiceStopArgs) -> u8 {
     return runtime().block_on(service::stop(globals, stop_args, callback)) as u8;
 }
 
+fn handle_service_set_use_automatically(
+    globals: LoreGlobalArgs,
+    args: &ServiceSetUseAutomaticallyArgs,
+) -> u8 {
+    let set_args = LoreServiceSetUseAutomaticallyArgs {
+        enabled: u8::from(args.enabled),
+    };
+
+    let callback = output_formatter().unwrap_or(Some(
+        (Box::new(move |event: &LoreEvent| match event {
+            LoreEvent::Complete(_) => {}
+            LoreEvent::Maintenance(data) => {
+                util::handle_maintenance_event(data);
+            }
+            _ => (),
+        }) as EventCallbackFn)
+            .with_defaults(),
+    ));
+
+    return runtime().block_on(service::set_use_automatically(globals, set_args, callback)) as u8;
+}
+
 pub fn handle_service_commands(cmd: &ServiceCommands, globals: LoreGlobalArgs) -> u8 {
     match cmd {
         ServiceCommands::Run(args) => {
@@ -110,6 +137,9 @@ pub fn handle_service_commands(cmd: &ServiceCommands, globals: LoreGlobalArgs) -
         }
         ServiceCommands::Stop(args) => {
             return handle_service_stop(globals, args);
+        }
+        ServiceCommands::SetUseAutomatically(args) => {
+            return handle_service_set_use_automatically(globals, args);
         }
     }
 }

--- a/lore-client/src/cli/commands/service.rs
+++ b/lore-client/src/cli/commands/service.rs
@@ -42,6 +42,9 @@ pub struct ServiceSetUseAutomaticallyArgs {
     enabled: bool,
 }
 
+// TODO: add a `status` command reporting whether the service is running
+// (process::is_running) and whether use_service_automatically is enabled,
+// mirroring the `shared-store info` command.
 #[derive(Subcommand)]
 pub enum ServiceCommands {
     ///Run this process as the service

--- a/lore-client/src/cli/commands/service/run.rs
+++ b/lore-client/src/cli/commands/service/run.rs
@@ -4,7 +4,6 @@ use std::io::Write;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
-use std::time::Duration;
 
 use lore::interface::LoreEvent;
 use lore::remote::connection::ConnectionError;
@@ -19,6 +18,7 @@ use lore::remote::message::write_v1_message;
 use lore::remote::network::UdsListener;
 use lore::remote::network::UdsStream;
 use lore::remote::network::uds_supported;
+use lore::remote::process;
 use lore::runtime;
 use lore_error_set::prelude::*;
 use tokio::sync::mpsc;
@@ -29,11 +29,6 @@ use crate::util::listen_for_termination;
 
 #[error_set]
 pub enum ServiceMainError {}
-
-/// Bounds how long shutdown waits for the accept loop to unwind, so that a
-/// wake-up connection that never lands cannot keep the process alive. Anything
-/// left behind is a stale socket, which the next start detects and removes.
-const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Where the service parks its working directory. It inherits one from whoever
 /// started it, which is unrelated to the directories its callers run in, and
@@ -54,6 +49,13 @@ fn detached_working_directory() -> std::path::PathBuf {
     }
 }
 
+/// Runs this process as the Lore service until it is stopped.
+///
+/// Shutdown has two triggers, a termination signal and a `service stop`
+/// delivered over IPC, and both end the same way: they set the shared flag and
+/// connect to the socket so the blocked `accept` returns and the loop can
+/// observe it. Waiting on the accept loop rather than on the signal is what
+/// makes the IPC trigger end the process too.
 pub async fn service_main(
     listening_signal: Option<tokio::sync::oneshot::Sender<()>>,
 ) -> Result<(), ServiceMainError> {
@@ -79,6 +81,7 @@ pub async fn service_main(
 
     let shutting_down = Arc::new(AtomicBool::new(false));
     let accept_shutting_down = Arc::clone(&shutting_down);
+    process::register_shutdown_flag(Arc::clone(&shutting_down));
 
     let accept_task = runtime().spawn_blocking(move || {
         let mut connection_id = 0;
@@ -106,27 +109,18 @@ pub async fn service_main(
         }
     });
 
-    match listen_for_termination(None).await {
-        Ok(()) => {
-            println!("Shutting down Lore service");
-            shutting_down.store(true, Ordering::SeqCst);
-            if let Err(error) = UdsStream::connect() {
-                eprintln!("Failed to wake the accept loop: {error}");
-            }
-            if tokio::time::timeout(SHUTDOWN_TIMEOUT, accept_task)
-                .await
-                .is_err()
-            {
-                eprintln!("Timed out waiting for the accept loop to stop");
-            }
-        }
-        Err(error) => {
-            // Without signal handling there is no graceful path, so keep
-            // serving until the process is killed.
+    runtime().spawn(async move {
+        if let Err(error) = listen_for_termination(None).await {
             eprintln!("Failed to listen for termination signals: {error}");
-            let _ = accept_task.await;
+            return;
         }
-    }
+        println!("Shutting down Lore service");
+        if let Err(error) = process::request_shutdown() {
+            eprintln!("Failed to stop the accept loop: {error}");
+        }
+    });
+
+    let _ = accept_task.await;
 
     Ok(())
 }

--- a/lore-client/src/cli/commands/service/run.rs
+++ b/lore-client/src/cli/commands/service/run.rs
@@ -56,6 +56,13 @@ fn detached_working_directory() -> std::path::PathBuf {
 /// connect to the socket so the blocked `accept` returns and the loop can
 /// observe it. Waiting on the accept loop rather than on the signal is what
 /// makes the IPC trigger end the process too.
+///
+/// Only the accept loop is awaited, not the per-connection handlers it spawned.
+/// In-flight requests are therefore not drained: a client mid-operation sees the
+/// connection close and reports it, and a request that was writing is truncated,
+/// with recovery left to the store's crash-consistency (the same guarantee a
+/// locally interrupted command relies on). A bounded drain of outstanding
+/// handlers before exit is a possible future improvement.
 pub async fn service_main(
     listening_signal: Option<tokio::sync::oneshot::Sender<()>>,
 ) -> Result<(), ServiceMainError> {

--- a/lore-revision/src/global.rs
+++ b/lore-revision/src/global.rs
@@ -74,6 +74,7 @@ pub struct GlobalConfig {
     default_shared_stores: BTreeMap<String, DefaultSharedStoreConfigValue>,
     #[serde(alias = "use_global_store_automatically")]
     pub use_shared_store_automatically: Option<bool>,
+    pub use_service_automatically: Option<bool>,
 }
 
 impl GlobalConfig {
@@ -114,6 +115,9 @@ impl GlobalConfig {
     }
     pub fn use_shared_store_automatically(&self) -> bool {
         self.use_shared_store_automatically.unwrap_or(false)
+    }
+    pub fn use_service_automatically(&self) -> bool {
+        self.use_service_automatically.unwrap_or(false)
     }
     pub fn suggested_path_for_remote_url(remote_url: &str) -> Result<PathBuf, GlobalConfigError> {
         let data_dir = get_global_data_dir()?;

--- a/lore/cbindgen.toml
+++ b/lore/cbindgen.toml
@@ -414,6 +414,7 @@ include = [
 "LoreSharedStoreSetUseAutomaticallyArgs" = "lore_shared_store_set_use_automatically_args_t"
 "LoreServiceStartArgs" = "lore_service_start_args_t"
 "LoreServiceStopArgs" = "lore_service_stop_args_t"
+"LoreServiceSetUseAutomaticallyArgs" = "lore_service_set_use_automatically_args_t"
 "LoreStore" = "lore_store_t"
 "LoreStorageCloseArgs" = "lore_storage_close_args_t"
 "LoreStorageFlushArgs" = "lore_storage_flush_args_t"

--- a/lore/src/call_delegation.rs
+++ b/lore/src/call_delegation.rs
@@ -18,11 +18,23 @@ const USE_SERVICE_VAR: &str = "LORE_USE_SERVICE";
 /// Caches `use_service_automatically` for the life of the process. Every public
 /// API entry point consults it, and reading it means parsing the global TOML
 /// config, so it must not happen per call.
+///
+/// The cache lives for the whole process and is only refreshed by a write in
+/// this process (see [`invalidate_use_service_cache`]). A change made elsewhere
+/// — an external `lore service set-use-automatically`, or a hand-edited config —
+/// is not observed until the process restarts. That is acceptable because the
+/// setting is a deploy-time choice that rarely changes under a running process,
+/// and the CLI runs one command per process regardless.
 static USE_SERVICE: RwLock<Option<bool>> = RwLock::new(None);
 
-/// Drops the cached setting so the next call rereads it. Called after the
-/// setting is written, so a long-lived embedder does not keep using the old
-/// value.
+/// Drops the cached setting so the next call in this process rereads it. Called
+/// after the setting is written here.
+///
+/// This refreshes only writes made by this process, and it races a concurrent
+/// reader: a [`use_service`] that loads the old config and fills the cache after
+/// this runs can leave the stale value in place until the next write. The window
+/// is narrow and self-heals on any later write; only a long-lived multi-threaded
+/// embedder that flips the setting mid-run is exposed.
 pub(crate) fn invalidate_use_service_cache() {
     *USE_SERVICE.write() = None;
 }

--- a/lore/src/call_delegation.rs
+++ b/lore/src/call_delegation.rs
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: 2026 Epic Games, Inc.
 // SPDX-License-Identifier: MIT
+use lore_revision::global::CONFIG as GLOBAL_CONFIG;
 use lore_revision::global::GlobalConfig;
+use lore_revision::global::get_global_config_dir;
 use lore_revision::interface::LoreGlobalArgs;
 use lore_revision::lore_debug;
 use parking_lot::RwLock;
@@ -56,6 +58,30 @@ pub(crate) async fn use_service() -> bool {
         .await
         .map(|config| config.use_service_automatically())
         .unwrap_or(false);
+    *USE_SERVICE.write() = Some(enabled);
+    enabled
+}
+
+/// Answers the same question as [`use_service`] without a runtime, for callers
+/// that must decide before one exists. Reads the global config directly rather
+/// than through its async loader, and fills the same cache, so a later
+/// [`use_service`] cannot reach a different answer.
+pub fn will_use_service() -> bool {
+    if let Some(value) = use_service_override() {
+        return value;
+    }
+    if cfg!(test) {
+        return false;
+    }
+    if let Some(cached) = *USE_SERVICE.read() {
+        return cached;
+    }
+    let enabled = get_global_config_dir()
+        .ok()
+        .map(|dir| dir.join(GLOBAL_CONFIG))
+        .and_then(|path| std::fs::read_to_string(path).ok())
+        .and_then(|text| toml::from_str::<GlobalConfig>(&text).ok())
+        .is_some_and(|config| config.use_service_automatically());
     *USE_SERVICE.write() = Some(enabled);
     enabled
 }

--- a/lore/src/call_delegation.rs
+++ b/lore/src/call_delegation.rs
@@ -76,8 +76,7 @@ pub(crate) async fn use_service() -> bool {
     }
     let enabled = GlobalConfig::load()
         .await
-        .map(|config| config.use_service_automatically())
-        .unwrap_or(false);
+        .is_ok_and(|config| config.use_service_automatically());
     *USE_SERVICE.write() = Some(enabled);
     enabled
 }

--- a/lore/src/call_delegation.rs
+++ b/lore/src/call_delegation.rs
@@ -1,11 +1,64 @@
 // SPDX-FileCopyrightText: 2026 Epic Games, Inc.
 // SPDX-License-Identifier: MIT
+use lore_revision::global::GlobalConfig;
 use lore_revision::interface::LoreGlobalArgs;
+use lore_revision::lore_debug;
+use parking_lot::RwLock;
 
 use crate::args::InvokableLoreArgs;
 use crate::interface::LoreEventCallback;
 use crate::interface::LoreEventCallbackConfig;
 use crate::remote::call::service_call;
+use crate::remote::process;
+
+const USE_SERVICE_VAR: &str = "LORE_USE_SERVICE";
+
+/// Caches `use_service_automatically` for the life of the process. Every public
+/// API entry point consults it, and reading it means parsing the global TOML
+/// config, so it must not happen per call.
+static USE_SERVICE: RwLock<Option<bool>> = RwLock::new(None);
+
+/// Drops the cached setting so the next call rereads it. Called after the
+/// setting is written, so a long-lived embedder does not keep using the old
+/// value.
+pub(crate) fn invalidate_use_service_cache() {
+    *USE_SERVICE.write() = None;
+}
+
+/// `LORE_USE_SERVICE` overrides the stored setting when set, so that tests and
+/// one-off invocations can route through the service without writing config.
+/// An empty value, or `0`/`false`, means "do not use the service".
+fn use_service_override() -> Option<bool> {
+    let value = std::env::var(USE_SERVICE_VAR).ok()?;
+    if value.is_empty() {
+        return Some(false);
+    }
+    Some(!value.eq_ignore_ascii_case("0") && !value.eq_ignore_ascii_case("false"))
+}
+
+/// Whether calls should be routed through the service process.
+///
+/// Test builds never read the stored setting, so that the suite runs against a
+/// clean global config rather than whatever the developer has configured on
+/// their own machine. `LORE_USE_SERVICE` is still honoured, so a test that wants
+/// the service path can ask for it explicitly.
+pub(crate) async fn use_service() -> bool {
+    if let Some(value) = use_service_override() {
+        return value;
+    }
+    if cfg!(test) {
+        return false;
+    }
+    if let Some(cached) = *USE_SERVICE.read() {
+        return cached;
+    }
+    let enabled = GlobalConfig::load()
+        .await
+        .map(|config| config.use_service_automatically())
+        .unwrap_or(false);
+    *USE_SERVICE.write() = Some(enabled);
+    enabled
+}
 
 pub(crate) fn run_synchronously<
     ArgsType: InvokableLoreArgs + Clone + Send + 'static,
@@ -39,6 +92,9 @@ pub(crate) fn run_asynchronously<
     drop(lore_base::lore_spawn!(handler(globals, args, callback)));
 }
 
+/// Runs a call either in the service process or locally, according to
+/// [`use_service`]. A call already executing inside the service always runs
+/// locally, so that it cannot dispatch back into the service it is running in.
 pub(crate) async fn dispatch_call<
     ArgsType: InvokableLoreArgs + Clone + Send + 'static,
     Handler: Fn(LoreGlobalArgs, ArgsType, LoreEventCallback) -> Fut,
@@ -49,9 +105,11 @@ pub(crate) async fn dispatch_call<
     callback: LoreEventCallback,
     handler: Handler,
 ) -> i32 {
-    if let Ok(environment_value) = std::env::var("LORE_USE_SERVICE")
-        && !environment_value.is_empty()
-    {
+    if use_service().await && !process::running_as_service() {
+        lore_debug!(
+            "Using Lore service process for {}",
+            std::any::type_name::<ArgsType>()
+        );
         service_call(globals, args, callback).await
     } else {
         handler(globals, args, callback).await

--- a/lore/src/call_delegation.rs
+++ b/lore/src/call_delegation.rs
@@ -27,15 +27,23 @@ pub(crate) fn invalidate_use_service_cache() {
     *USE_SERVICE.write() = None;
 }
 
+/// Whether a `LORE_USE_SERVICE` value turns the service on. Off values, matched
+/// case-insensitively with surrounding whitespace ignored, are an empty value
+/// and `0`, `false`, `f`, `no`, `n`, and `off`; any other value is on.
+fn use_service_from_value(value: &str) -> bool {
+    !matches!(
+        value.trim().to_ascii_lowercase().as_str(),
+        "" | "0" | "false" | "f" | "no" | "n" | "off"
+    )
+}
+
 /// `LORE_USE_SERVICE` overrides the stored setting when set, so that tests and
 /// one-off invocations can route through the service without writing config.
-/// An empty value, or `0`/`false`, means "do not use the service".
+/// See [`use_service_from_value`] for how the value is interpreted.
 fn use_service_override() -> Option<bool> {
-    let value = std::env::var(USE_SERVICE_VAR).ok()?;
-    if value.is_empty() {
-        return Some(false);
-    }
-    Some(!value.eq_ignore_ascii_case("0") && !value.eq_ignore_ascii_case("false"))
+    std::env::var(USE_SERVICE_VAR)
+        .ok()
+        .map(|value| use_service_from_value(&value))
 }
 
 /// Whether calls should be routed through the service process.
@@ -159,6 +167,24 @@ mod tests {
 
     use super::*;
     use crate::interface::LoreString;
+
+    #[test]
+    fn use_service_value_parsing() {
+        for on in ["1", "true", "TRUE", "yes", "on", "enabled", "  1 "] {
+            assert!(
+                use_service_from_value(on),
+                "{on:?} should enable the service"
+            );
+        }
+        for off in [
+            "", "  ", "0", "false", "FALSE", "f", "no", "n", "off", " off ",
+        ] {
+            assert!(
+                !use_service_from_value(off),
+                "{off:?} should disable the service"
+            );
+        }
+    }
 
     // A concrete error whose `NotFound` variant carries error code 13, so the
     // async failure path has a known non-`1` code to assert against.

--- a/lore/src/call_delegation.rs
+++ b/lore/src/call_delegation.rs
@@ -106,6 +106,20 @@ pub fn will_use_service() -> bool {
     enabled
 }
 
+/// Sizes the shared runtime before an FFI entry point first builds it: lean when
+/// the call will be relayed to the service, so an embedder whose first call is a
+/// routed API does not build the full runtime it never uses. A no-op once the
+/// runtime exists, and when the service is not in use. The routed operations all
+/// relay and the local ones (`service start`/`stop`/`set-use-automatically`) are
+/// lightweight, so the lean runtime suits both.
+fn size_runtime_for_dispatch() {
+    if will_use_service() {
+        drop(lore_base::runtime::runtime_with_settings(Some(
+            lore_base::runtime::TokioSettings::relay_only(),
+        )));
+    }
+}
+
 pub(crate) fn run_synchronously<
     ArgsType: InvokableLoreArgs + Clone + Send + 'static,
     Handler: Fn(LoreGlobalArgs, ArgsType, LoreEventCallback) -> Fut,
@@ -116,6 +130,7 @@ pub(crate) fn run_synchronously<
     callback: LoreEventCallbackConfig,
     handler: Handler,
 ) -> i32 {
+    size_runtime_for_dispatch();
     let callback = lore_revision::event::convert_event_callback(callback);
     let globals = globals.clone();
     let args = args.clone();
@@ -132,6 +147,7 @@ pub(crate) fn run_asynchronously<
     callback: LoreEventCallbackConfig,
     handler: Handler,
 ) {
+    size_runtime_for_dispatch();
     let callback = lore_revision::event::convert_event_callback(callback);
     let globals = globals.clone();
     let args = args.clone();

--- a/lore/src/interface.rs
+++ b/lore/src/interface.rs
@@ -6804,6 +6804,71 @@ pub extern "C" fn lore_service_stop_async(
     run_asynchronously(globals, args, callback, crate::service::stop);
 }
 
+pub type LoreServiceSetUseAutomaticallyArgs = crate::service::LoreServiceSetUseAutomaticallyArgs;
+
+/// Set whether Lore automatically routes calls through the background service.
+///
+/// When enabled, every Lore call is executed by the service process, which is
+/// started automatically if it is not already running.
+///
+/// # Events
+///
+/// Events are delivered via the callback as `lore_event_t`. Use the `tag` field to identify the event type.
+///
+/// ## Standard Events
+///
+/// These events are emitted by all interface functions:
+///
+/// | Tag | Data Type | Description |
+/// |-----|-----------|-------------|
+/// | `LORE_EVENT_LOG` | `lore_log_event_data_t` | Diagnostic messages throughout execution |
+/// | `LORE_EVENT_ERROR` | `lore_error_event_data_t` | Emitted for a non-fatal error during the operation |
+/// | `LORE_EVENT_COMPLETE` | `lore_complete_event_data_t` | Always emitted at the end; `status` is `0` on success or the error code on failure |
+/// | `LORE_EVENT_END` | `lore_end_event_data_t` | Always emitted after `COMPLETE` to signal callback termination |
+#[unsafe(no_mangle)]
+pub extern "C" fn lore_service_set_use_automatically(
+    globals: &LoreGlobalArgs,
+    args: &LoreServiceSetUseAutomaticallyArgs,
+    callback: LoreEventCallbackConfig,
+) -> i32 {
+    run_synchronously(
+        globals,
+        args,
+        callback,
+        crate::service::set_use_automatically,
+    )
+}
+
+/// Asynchronous version of `lore_service_set_use_automatically`.
+///
+/// # Events
+///
+/// Events are delivered via the callback as `lore_event_t`. Use the `tag` field to identify the event type.
+///
+/// ## Standard Events
+///
+/// These events are emitted by all interface functions:
+///
+/// | Tag | Data Type | Description |
+/// |-----|-----------|-------------|
+/// | `LORE_EVENT_LOG` | `lore_log_event_data_t` | Diagnostic messages throughout execution |
+/// | `LORE_EVENT_ERROR` | `lore_error_event_data_t` | Emitted for a non-fatal error during the operation |
+/// | `LORE_EVENT_COMPLETE` | `lore_complete_event_data_t` | Always emitted at the end; `status` is `0` on success or the error code on failure |
+/// | `LORE_EVENT_END` | `lore_end_event_data_t` | Always emitted after `COMPLETE` to signal callback termination |
+#[unsafe(no_mangle)]
+pub extern "C" fn lore_service_set_use_automatically_async(
+    globals: &LoreGlobalArgs,
+    args: &LoreServiceSetUseAutomaticallyArgs,
+    callback: LoreEventCallbackConfig,
+) {
+    run_asynchronously(
+        globals,
+        args,
+        callback,
+        crate::service::set_use_automatically,
+    );
+}
+
 pub type LoreNotificationSubscribeArgs = crate::notification::LoreNotificationSubscribeArgs;
 
 /// Subscribe to repository notifications.

--- a/lore/src/lib.rs
+++ b/lore/src/lib.rs
@@ -90,6 +90,13 @@ pub fn will_use_service() -> bool {
 /// service, rather than performing it. Creates the runtime, so it must be
 /// called before the first Lore operation and only by a process that does no
 /// work of its own; the service process itself must never call it.
+///
+/// The sizing is applied once, when the runtime is built, and cannot be undone:
+/// later settings are ignored because the runtime already exists. A long-lived
+/// process that turns the service off after this has been called (for example
+/// via [`service::set_use_automatically`](crate::service::set_use_automatically))
+/// then runs its work locally on this relay-sized runtime, which is correct but
+/// slow. Decide routing once at start-up and do not flip it mid-process.
 pub fn size_threads_for_relaying() {
     drop(lore_base::runtime::runtime_with_settings(Some(
         lore_base::runtime::TokioSettings::relay_only(),

--- a/lore/src/lib.rs
+++ b/lore/src/lib.rs
@@ -79,6 +79,23 @@ pub fn set_thread_limit(count: usize) -> bool {
     lore_base::runtime::set_thread_limit(count)
 }
 
+/// Whether calls will be executed by the Lore service process rather than in
+/// this one. Safe to call before a runtime exists, so a caller can size its
+/// threading before doing any work. See [`size_threads_for_relaying`].
+pub fn will_use_service() -> bool {
+    call_delegation::will_use_service()
+}
+
+/// Sizes the shared runtime for a process that only relays its work to the Lore
+/// service, rather than performing it. Creates the runtime, so it must be
+/// called before the first Lore operation and only by a process that does no
+/// work of its own; the service process itself must never call it.
+pub fn size_threads_for_relaying() {
+    drop(lore_base::runtime::runtime_with_settings(Some(
+        lore_base::runtime::TokioSettings::relay_only(),
+    )));
+}
+
 pub fn log_file_path() -> LoreString {
     log::get_logs_path().into()
 }

--- a/lore/src/remote.rs
+++ b/lore/src/remote.rs
@@ -6,5 +6,26 @@ pub mod connection;
 pub mod message;
 
 pub mod network;
+pub mod process;
 
 pub const LORE_SERVICE_SOCKET_NAME: &str = "lore_service";
+
+#[cfg(test)]
+static SOCKET_NAME_OVERRIDE: std::sync::OnceLock<String> = std::sync::OnceLock::new();
+
+/// Points the transport at a socket of its own for the duration of the test
+/// binary, so that it neither collides with nor disturbs a service already
+/// running on the machine.
+#[cfg(test)]
+pub(crate) fn set_service_socket_name_for_test(name: &str) {
+    let _ = SOCKET_NAME_OVERRIDE.set(name.to_owned());
+}
+
+/// The socket file name the service listens on.
+pub(crate) fn service_socket_name() -> &'static str {
+    #[cfg(test)]
+    if let Some(name) = SOCKET_NAME_OVERRIDE.get() {
+        return name.as_str();
+    }
+    LORE_SERVICE_SOCKET_NAME
+}

--- a/lore/src/remote/call.rs
+++ b/lore/src/remote/call.rs
@@ -105,14 +105,13 @@ pub async fn service_call_impl<ArgsType: LoreArgs + Clone + Send + 'static>(
     // Send to an existing service first, and only start one if that fails, so
     // the common path opens a single connection rather than a liveness probe
     // followed by the real one.
-    let connection = match connect_and_send(message_bytes.clone()).await {
-        Ok(connection) => connection,
-        Err(_) => {
-            crate::remote::process::ensure_running()
-                .await
-                .forward::<ServiceCallError>("starting the Lore service")?;
-            connect_and_send(message_bytes).await?
-        }
+    let connection = if let Ok(connection) = connect_and_send(message_bytes.clone()).await {
+        connection
+    } else {
+        crate::remote::process::ensure_running()
+            .await
+            .forward::<ServiceCallError>("starting the Lore service")?;
+        connect_and_send(message_bytes).await?
     };
 
     'read_from_stream: loop {

--- a/lore/src/remote/call.rs
+++ b/lore/src/remote/call.rs
@@ -79,6 +79,10 @@ pub async fn service_call_impl<ArgsType: LoreArgs + Clone + Send + 'static>(
         return Err(ServiceCallError::internal("OS doesn't support IPC"));
     }
 
+    crate::remote::process::ensure_running()
+        .await
+        .forward::<ServiceCallError>("starting the Lore service")?;
+
     let connection = lore_base::lore_spawn_blocking!(|| {
         let mut connection =
             UdsStream::connect().forward::<ServiceCallError>("connecting to local socket")?;
@@ -122,6 +126,40 @@ pub async fn service_call_impl<ArgsType: LoreArgs + Clone + Send + 'static>(
     Err(ServiceCallError::internal(
         "Lore service closed connection without sending a result",
     ))
+}
+
+/// Sends one command to a service that is already running and returns as soon
+/// as it is written, without waiting for a result. Used for requests whose
+/// effect is that the service exits, where waiting for a reply would race the
+/// service's own shutdown. Does not start a service.
+pub async fn service_send_no_reply<ArgsType: LoreArgs + Clone + Send + 'static>(
+    globals: LoreGlobalArgs,
+    args: ArgsType,
+) -> Result<(), ServiceCallError> {
+    if !uds_supported() {
+        return Err(ServiceCallError::internal("OS doesn't support IPC"));
+    }
+
+    lore_base::lore_spawn_blocking!(|| {
+        let mut connection =
+            UdsStream::connect().forward::<ServiceCallError>("connecting to local socket")?;
+
+        let message = MessageToServer {
+            globals,
+            command: args.to_command(),
+        };
+
+        let message_bytes = write_v1_message(message, SerializationType::Json)
+            .forward::<ServiceCallError>("serializing message")?;
+
+        connection
+            .writer()
+            .write_all(&message_bytes)
+            .internal("sending message")?;
+        Ok::<(), ServiceCallError>(())
+    })
+    .await
+    .internal("joining send task")?
 }
 
 pub fn handle_message(

--- a/lore/src/remote/call.rs
+++ b/lore/src/remote/call.rs
@@ -124,7 +124,8 @@ pub async fn service_call_impl<ArgsType: LoreArgs + Clone + Send + 'static>(
     }
 
     Err(ServiceCallError::internal(
-        "Lore service closed connection without sending a result",
+        "Lore service closed the connection without sending a result; \
+         it may have been stopped or terminated while the request was in flight",
     ))
 }
 

--- a/lore/src/remote/call.rs
+++ b/lore/src/remote/call.rs
@@ -70,6 +70,22 @@ pub async fn service_call<ArgsType: LoreArgs + Clone + Send + 'static>(
         })
 }
 
+/// Opens a connection to the service and writes the already-serialized message,
+/// returning the connection to read the reply from.
+async fn connect_and_send(message_bytes: Vec<u8>) -> Result<UdsStream, ServiceCallError> {
+    lore_base::lore_spawn_blocking!(move || {
+        let mut connection =
+            UdsStream::connect().forward::<ServiceCallError>("connecting to local socket")?;
+        connection
+            .writer()
+            .write_all(&message_bytes)
+            .internal("sending message")?;
+        Ok::<UdsStream, ServiceCallError>(connection)
+    })
+    .await
+    .internal("joining connection task")?
+}
+
 pub async fn service_call_impl<ArgsType: LoreArgs + Clone + Send + 'static>(
     event_dispatcher: &mut EventDispatcher,
     globals: LoreGlobalArgs,
@@ -79,30 +95,25 @@ pub async fn service_call_impl<ArgsType: LoreArgs + Clone + Send + 'static>(
         return Err(ServiceCallError::internal("OS doesn't support IPC"));
     }
 
-    crate::remote::process::ensure_running()
-        .await
-        .forward::<ServiceCallError>("starting the Lore service")?;
+    let message = MessageToServer {
+        globals,
+        command: args.to_command(),
+    };
+    let message_bytes = write_v1_message(message, SerializationType::Json)
+        .forward::<ServiceCallError>("serializing message")?;
 
-    let connection = lore_base::lore_spawn_blocking!(|| {
-        let mut connection =
-            UdsStream::connect().forward::<ServiceCallError>("connecting to local socket")?;
-
-        let message = MessageToServer {
-            globals,
-            command: args.to_command(),
-        };
-
-        let message_bytes = write_v1_message(message, SerializationType::Json)
-            .forward::<ServiceCallError>("serializing message")?;
-
-        connection
-            .writer()
-            .write_all(&message_bytes)
-            .internal("sending message")?;
-        Ok::<UdsStream, ServiceCallError>(connection)
-    })
-    .await
-    .internal("joining connection task")??;
+    // Send to an existing service first, and only start one if that fails, so
+    // the common path opens a single connection rather than a liveness probe
+    // followed by the real one.
+    let connection = match connect_and_send(message_bytes.clone()).await {
+        Ok(connection) => connection,
+        Err(_) => {
+            crate::remote::process::ensure_running()
+                .await
+                .forward::<ServiceCallError>("starting the Lore service")?;
+            connect_and_send(message_bytes).await?
+        }
+    };
 
     'read_from_stream: loop {
         let mut connection = connection.try_clone().internal("cloning connection")?;

--- a/lore/src/remote/command.rs
+++ b/lore/src/remote/command.rs
@@ -121,6 +121,7 @@ pub enum LoreCommand {
     RevisionSync(crate::revision::LoreRevisionSyncArgs),
     ServiceStart(crate::service::LoreServiceStartArgs),
     ServiceStop(crate::service::LoreServiceStopArgs),
+    ServiceSetUseAutomatically(crate::service::LoreServiceSetUseAutomaticallyArgs),
     NotificationSubscribe(crate::notification::LoreNotificationSubscribeArgs),
     NotificationUnsubscribe(crate::notification::LoreNotificationUnsubscribeArgs),
     SharedStoreCreate(crate::shared_store::LoreSharedStoreCreateArgs),

--- a/lore/src/remote/network.rs
+++ b/lore/src/remote/network.rs
@@ -80,6 +80,10 @@ mod tests {
     }
 
     fn run_both() -> String {
+        crate::remote::set_service_socket_name_for_test(&format!(
+            "lore_service_test_{}",
+            std::process::id()
+        ));
         let (sender, receiver) = std::sync::mpsc::channel::<()>();
         let service = std::thread::spawn(move || run_service(sender));
         receiver.recv().unwrap();

--- a/lore/src/remote/network/unix.rs
+++ b/lore/src/remote/network/unix.rs
@@ -8,10 +8,10 @@ use std::path::PathBuf;
 
 use lore_error_set::prelude::*;
 
-use crate::remote::LORE_SERVICE_SOCKET_NAME;
 use crate::remote::network::UdsAcceptError;
 use crate::remote::network::UdsConnectionError;
 use crate::remote::network::UdsListenerError;
+use crate::remote::service_socket_name;
 
 pub fn uds_supported() -> bool {
     true
@@ -37,7 +37,7 @@ fn uds_sock_dir() -> PathBuf {
 }
 
 fn uds_sock_path() -> PathBuf {
-    uds_sock_dir().join(LORE_SERVICE_SOCKET_NAME)
+    uds_sock_dir().join(service_socket_name())
 }
 
 pub struct UdsListener {
@@ -53,7 +53,7 @@ impl UdsListener {
         fs::set_permissions(&dir, fs::Permissions::from_mode(0o700))
             .internal_with(|| format!("restricting socket directory {}", dir.display()))?;
 
-        let path = dir.join(LORE_SERVICE_SOCKET_NAME);
+        let path = dir.join(service_socket_name());
 
         if path.exists() {
             if UnixStream::connect(&path).is_ok() {

--- a/lore/src/remote/network/windows.rs
+++ b/lore/src/remote/network/windows.rs
@@ -17,10 +17,10 @@ use windows_sys::Win32::Networking::WinSock::WSAGetLastError;
 use windows_sys::Win32::Storage::FileSystem::DeleteFileW;
 use windows_sys::Win32::Storage::FileSystem::GetTempPathW;
 
-use crate::remote::LORE_SERVICE_SOCKET_NAME;
 use crate::remote::network::UdsAcceptError;
 use crate::remote::network::UdsConnectionError;
 use crate::remote::network::UdsListenerError;
+use crate::remote::service_socket_name;
 
 const LISTENER_BACKLOG: i32 = 10;
 
@@ -190,7 +190,7 @@ fn uds_sock_path() -> Vec<u16> {
     }
     // Append the file name, taking into account the null terminator.
     path.resize(path.len() - 1, 0);
-    path.extend(LORE_SERVICE_SOCKET_NAME.encode_utf16());
+    path.extend(service_socket_name().encode_utf16());
     // Reinsert the null terminator.
     path.push(0);
     path

--- a/lore/src/remote/process.rs
+++ b/lore/src/remote/process.rs
@@ -1,0 +1,168 @@
+// SPDX-FileCopyrightText: 2026 Epic Games, Inc.
+// SPDX-License-Identifier: MIT
+use std::process::Command;
+use std::process::Stdio;
+use std::sync::Arc;
+use std::sync::OnceLock;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
+use std::time::Duration;
+use std::time::Instant;
+
+use lore_error_set::prelude::*;
+use lore_revision::lore_debug;
+
+use crate::remote::network::UdsStream;
+use crate::remote::network::uds_supported;
+
+#[error_set]
+pub enum ServiceProcessError {}
+
+/// How long `ensure_running` waits for a freshly spawned service to bind its
+/// socket before giving up.
+const START_TIMEOUT: Duration = Duration::from_secs(10);
+const START_POLL_INTERVAL: Duration = Duration::from_millis(50);
+/// How long `wait_until_stopped` gives the service to release its socket. The
+/// service itself bounds its shutdown at five seconds, so this allows for that
+/// plus the time to unwind.
+const STOP_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Set by the service process itself, holding the flag its accept loop watches.
+/// Its presence is also what tells a command handler that it is executing
+/// inside the service rather than in a client.
+static SHUTDOWN_FLAG: OnceLock<Arc<AtomicBool>> = OnceLock::new();
+
+/// Called by the service process at startup to publish the flag that stops its
+/// accept loop, so that a `ServiceStop` arriving over IPC can trip it.
+pub fn register_shutdown_flag(flag: Arc<AtomicBool>) {
+    let _ = SHUTDOWN_FLAG.set(flag);
+}
+
+pub fn running_as_service() -> bool {
+    SHUTDOWN_FLAG.get().is_some()
+}
+
+/// Stops this process's own service loop. The accept loop is blocked in
+/// `accept`, so it also needs a connection to wake it before it can observe the
+/// flag; a failure to make that connection leaves the loop parked, so it is
+/// reported rather than ignored.
+pub fn request_shutdown() -> Result<(), ServiceProcessError> {
+    let Some(flag) = SHUTDOWN_FLAG.get() else {
+        return Err(ServiceProcessError::internal(
+            "this process is not running as a service",
+        ));
+    };
+    lore_debug!("Stopping Lore service process");
+    flag.store(true, Ordering::SeqCst);
+    UdsStream::connect().forward::<ServiceProcessError>("waking the accept loop")?;
+    Ok(())
+}
+
+pub fn is_running() -> bool {
+    uds_supported() && UdsStream::connect().is_ok()
+}
+
+/// The executable to relaunch as the service.
+///
+/// Auto-start only fires for the Lore CLI. When Lore is embedded as a library
+/// the current executable is the host application, and running it with
+/// `service run` would launch something arbitrary, so that case is refused and
+/// the caller is told to start the service itself.
+fn service_executable() -> Result<std::path::PathBuf, ServiceProcessError> {
+    let path = std::env::current_exe().internal("resolving the current executable")?;
+    let name = path
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .unwrap_or_default();
+    if !name.eq_ignore_ascii_case("lore") {
+        return Err(ServiceProcessError::internal(format!(
+            "cannot start the Lore service automatically from {}; run `lore service start` instead",
+            path.display()
+        )));
+    }
+    Ok(path)
+}
+
+/// Spawns a detached `lore service run`. The child keeps running after this
+/// process exits, so it is given no console and no inherited standard streams.
+pub fn spawn() -> Result<(), ServiceProcessError> {
+    let executable = service_executable()?;
+    lore_debug!("Starting Lore service process: {}", executable.display());
+
+    let mut command = Command::new(&executable);
+    command
+        .arg("service")
+        .arg("run")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+
+    #[cfg(target_family = "unix")]
+    {
+        use std::os::unix::process::CommandExt;
+        // Safety: setsid is async-signal-safe and is the documented way to
+        // detach the child from the caller's session and controlling terminal.
+        unsafe {
+            command.pre_exec(|| {
+                libc::setsid();
+                Ok(())
+            });
+        }
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        use std::os::windows::process::CommandExt;
+        const DETACHED_PROCESS: u32 = 0x0000_0008;
+        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+        command.creation_flags(DETACHED_PROCESS | CREATE_NO_WINDOW);
+    }
+
+    command
+        .spawn()
+        .internal_with(|| format!("spawning {}", executable.display()))?;
+
+    Ok(())
+}
+
+/// Makes sure a service process is listening, starting one if it is not.
+/// Returns `true` if a new process was spawned.
+pub async fn ensure_running() -> Result<bool, ServiceProcessError> {
+    if !uds_supported() {
+        return Err(ServiceProcessError::internal(
+            "the Lore service is not supported on this OS",
+        ));
+    }
+    if is_running() {
+        return Ok(false);
+    }
+
+    spawn()?;
+
+    let deadline = Instant::now() + START_TIMEOUT;
+    while Instant::now() < deadline {
+        if is_running() {
+            lore_debug!("Lore service process is listening");
+            return Ok(true);
+        }
+        tokio::time::sleep(START_POLL_INTERVAL).await;
+    }
+
+    Err(ServiceProcessError::internal(format!(
+        "the Lore service did not start listening within {} seconds",
+        START_TIMEOUT.as_secs()
+    )))
+}
+
+/// Waits for a stopping service to stop answering on its socket. Returns
+/// `false` if it is still listening when the timeout expires.
+pub async fn wait_until_stopped() -> bool {
+    let deadline = Instant::now() + STOP_TIMEOUT;
+    while Instant::now() < deadline {
+        if !is_running() {
+            return true;
+        }
+        tokio::time::sleep(START_POLL_INTERVAL).await;
+    }
+    !is_running()
+}

--- a/lore/src/remote/process.rs
+++ b/lore/src/remote/process.rs
@@ -45,7 +45,15 @@ pub fn running_as_service() -> bool {
 /// Stops this process's own service loop. The accept loop is blocked in
 /// `accept`, so it also needs a connection to wake it before it can observe the
 /// flag; a failure to make that connection leaves the loop parked, so it is
-/// reported rather than ignored.
+/// returned rather than ignored.
+///
+/// Shutdown therefore depends on this wake-up connection succeeding. A caller
+/// that polls afterwards (the client `service stop`, via `wait_until_stopped`)
+/// self-corrects, because its probes are themselves connections that wake the
+/// loop. The termination-signal path does not poll and discards this error to a
+/// detached process's null stderr, so on the rare failure — connecting to one's
+/// own listening socket essentially only fails under backlog exhaustion or a
+/// removed socket file — exit is delayed until another connection arrives.
 pub fn request_shutdown() -> Result<(), ServiceProcessError> {
     let Some(flag) = SHUTDOWN_FLAG.get() else {
         return Err(ServiceProcessError::internal(

--- a/lore/src/remote/process.rs
+++ b/lore/src/remote/process.rs
@@ -34,6 +34,12 @@ static SHUTDOWN_FLAG: OnceLock<Arc<AtomicBool>> = OnceLock::new();
 
 /// Called by the service process at startup to publish the flag that stops its
 /// accept loop, so that a `ServiceStop` arriving over IPC can trip it.
+///
+/// Supports a single service per process: the `OnceLock` keeps the first flag,
+/// so a second `service_main` in the same process would run an accept loop
+/// watching a flag this never trips, and could not be stopped. The CLI runs
+/// `service run` once per process, so this only constrains a future embedder or
+/// in-process test that starts the service more than once.
 pub fn register_shutdown_flag(flag: Arc<AtomicBool>) {
     let _ = SHUTDOWN_FLAG.set(flag);
 }

--- a/lore/src/service.rs
+++ b/lore/src/service.rs
@@ -56,9 +56,6 @@ async fn start_local(
     callback: LoreEventCallback,
 ) -> i32 {
     let command = async move |_args| -> Result<(), ServiceError> {
-        if process::running_as_service() {
-            return Ok(());
-        }
         process::ensure_running()
             .await
             .forward::<ServiceError>("starting the Lore service")?;

--- a/lore/src/service.rs
+++ b/lore/src/service.rs
@@ -114,9 +114,16 @@ async fn stop_local(
             return Ok(());
         }
 
-        service_send_no_reply(globals_for_send, args)
-            .await
-            .forward::<ServiceError>("sending stop to the Lore service")?;
+        // The service can exit between the check above and the send below —
+        // another stop, or a termination signal. A failed send is then only an
+        // error if the service is somehow still running; a stopped service is
+        // exactly the outcome asked for.
+        if let Err(error) = service_send_no_reply(globals_for_send, args).await {
+            if process::is_running() {
+                return Err(error).forward::<ServiceError>("sending stop to the Lore service");
+            }
+            return Ok(());
+        }
 
         if !process::wait_until_stopped().await {
             return Err(ServiceError::internal(

--- a/lore/src/service.rs
+++ b/lore/src/service.rs
@@ -61,7 +61,7 @@ async fn start_local(
             .forward::<ServiceError>("starting the Lore service")?;
         Ok(())
     };
-    no_repository_call(globals, callback, args, "service start", command).await
+    no_repository_call(globals, callback, args, start, command).await
 }
 
 #[repr(C)]
@@ -129,7 +129,7 @@ async fn stop_local(
         }
         Ok(())
     };
-    no_repository_call(globals, callback, args, "service stop", command).await
+    no_repository_call(globals, callback, args, stop, command).await
 }
 
 #[repr(C)]
@@ -185,12 +185,5 @@ async fn set_use_automatically_local(
             invalidate_use_service_cache();
             Ok(())
         };
-    no_repository_call(
-        globals,
-        callback,
-        args,
-        "service set-use-automatically",
-        command,
-    )
-    .await
+    no_repository_call(globals, callback, args, set_use_automatically, command).await
 }

--- a/lore/src/service.rs
+++ b/lore/src/service.rs
@@ -1,20 +1,34 @@
 // SPDX-FileCopyrightText: 2026 Epic Games, Inc.
 // SPDX-License-Identifier: MIT
+use lore_error_set::prelude::*;
 use lore_macro::LoreArgs;
+use lore_revision::event::EventError;
+use lore_revision::global::GlobalConfig;
 use lore_revision::interface::LoreGlobalArgs;
 use serde::Deserialize;
 use serde::Serialize;
 
-use crate::call_delegation::dispatch_call;
+use crate::call::no_repository_call;
+use crate::call_delegation::invalidate_use_service_cache;
 use crate::interface::LoreEventCallback;
+use crate::remote::call::service_send_no_reply;
+use crate::remote::process;
+
+#[error_set]
+pub enum ServiceError {}
+
+impl EventError for ServiceError {}
 
 #[repr(C)]
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize, LoreArgs)]
 #[handler(start_local)]
-/// Arguments for starting the Lore service process for the current repository (no parameters).
+/// Arguments for starting the Lore service process (no parameters).
 pub struct LoreServiceStartArgs {}
 
-/// Start the Lore service process to manage the current repository.
+/// Start the Lore service process, if it is not already running.
+///
+/// Always runs locally rather than being dispatched to the service, which
+/// cannot be asked to start itself while it is not running.
 ///
 /// # Events
 ///
@@ -28,41 +42,41 @@ pub struct LoreServiceStartArgs {}
 /// | [`LoreEvent::Error`](crate::interface::LoreEvent::Error) | Emitted for a non-fatal error during the operation |
 /// | [`LoreEvent::Complete`](crate::interface::LoreEvent::Complete) | Always emitted at the end; `status` is `0` on success or the error code on failure |
 /// | [`LoreEvent::End`](crate::interface::LoreEvent::End) | Always emitted after `Complete` to signal callback termination |
-#[allow(clippy::unused_async)]
 pub async fn start(
     globals: LoreGlobalArgs,
     args: LoreServiceStartArgs,
     callback: LoreEventCallback,
 ) -> i32 {
-    dispatch_call(globals, args, callback, start_local).await
+    start_local(globals, args, callback).await
 }
 
 async fn start_local(
-    _globals: LoreGlobalArgs,
-    _args: LoreServiceStartArgs,
-    _callback: LoreEventCallback,
+    globals: LoreGlobalArgs,
+    args: LoreServiceStartArgs,
+    callback: LoreEventCallback,
 ) -> i32 {
-    // Set sentinel in repository that it is being controlled by service process
-
-    // Attempt to connect to service process
-
-    // If fail, try starting a new service process and connect again
-
-    // Send a message to service the given repository
-
-    1
+    let command = async move |_args| -> Result<(), ServiceError> {
+        if process::running_as_service() {
+            return Ok(());
+        }
+        process::ensure_running()
+            .await
+            .forward::<ServiceError>("starting the Lore service")?;
+        Ok(())
+    };
+    no_repository_call(globals, callback, args, "service start", command).await
 }
 
 #[repr(C)]
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize, LoreArgs)]
 #[handler(stop_local)]
-/// Arguments for stopping the Lore service process for the current or all repositories.
-pub struct LoreServiceStopArgs {
-    /// Stop all repositories rather than just the current one
-    pub all: u8,
-}
+/// Arguments for stopping the Lore service process (no parameters).
+pub struct LoreServiceStopArgs {}
 
-/// Stop the Lore service process for the current or all repositories.
+/// Stop the Lore service process, if it is running.
+///
+/// Always runs locally rather than being dispatched to the service, which would
+/// start a service in order to deliver the request to stop it.
 ///
 /// # Events
 ///
@@ -76,25 +90,103 @@ pub struct LoreServiceStopArgs {
 /// | [`LoreEvent::Error`](crate::interface::LoreEvent::Error) | Emitted for a non-fatal error during the operation |
 /// | [`LoreEvent::Complete`](crate::interface::LoreEvent::Complete) | Always emitted at the end; `status` is `0` on success or the error code on failure |
 /// | [`LoreEvent::End`](crate::interface::LoreEvent::End) | Always emitted after `Complete` to signal callback termination |
-#[allow(clippy::unused_async)]
 pub async fn stop(
     globals: LoreGlobalArgs,
     args: LoreServiceStopArgs,
     callback: LoreEventCallback,
 ) -> i32 {
-    dispatch_call(globals, args, callback, stop_local).await
+    stop_local(globals, args, callback).await
 }
 
 async fn stop_local(
-    _globals: LoreGlobalArgs,
-    _args: LoreServiceStopArgs,
-    _callback: LoreEventCallback,
+    globals: LoreGlobalArgs,
+    args: LoreServiceStopArgs,
+    callback: LoreEventCallback,
 ) -> i32 {
-    // Attempt to connect to service process
+    let globals_for_send = globals.clone();
+    let command = async move |args| -> Result<(), ServiceError> {
+        if process::running_as_service() {
+            process::request_shutdown().forward::<ServiceError>("stopping the Lore service")?;
+            return Ok(());
+        }
 
-    // If successful, send a message to service the given repository
+        if !process::is_running() {
+            return Ok(());
+        }
 
-    // Remove sentinel in repository so that it is no longer being controlled by service process
+        service_send_no_reply(globals_for_send, args)
+            .await
+            .forward::<ServiceError>("sending stop to the Lore service")?;
 
-    1
+        if !process::wait_until_stopped().await {
+            return Err(ServiceError::internal(
+                "the Lore service did not stop in time",
+            ));
+        }
+        Ok(())
+    };
+    no_repository_call(globals, callback, args, "service stop", command).await
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize, LoreArgs)]
+#[handler(set_use_automatically_local)]
+/// Arguments for setting whether Lore automatically routes calls through the service process.
+pub struct LoreServiceSetUseAutomaticallyArgs {
+    /// Automatically use the service process
+    pub enabled: u8,
+}
+
+/// Sets whether Lore automatically routes calls through the service process.
+///
+/// Always runs locally rather than being dispatched to the service, which would
+/// start a service only to be told that the service should no longer be used.
+///
+/// # Events
+///
+/// ## Standard Events
+///
+/// These events are emitted by all interface functions:
+///
+/// | Event | Description |
+/// |-------|-------------|
+/// | [`LoreEvent::Log`](crate::interface::LoreEvent::Log) | Diagnostic messages throughout execution |
+/// | [`LoreEvent::Error`](crate::interface::LoreEvent::Error) | Emitted for a non-fatal error during the operation |
+/// | [`LoreEvent::Complete`](crate::interface::LoreEvent::Complete) | Always emitted at the end; `status` is `0` on success or the error code on failure |
+/// | [`LoreEvent::End`](crate::interface::LoreEvent::End) | Always emitted after `Complete` to signal callback termination |
+pub async fn set_use_automatically(
+    globals: LoreGlobalArgs,
+    args: LoreServiceSetUseAutomaticallyArgs,
+    callback: LoreEventCallback,
+) -> i32 {
+    set_use_automatically_local(globals, args, callback).await
+}
+
+async fn set_use_automatically_local(
+    globals: LoreGlobalArgs,
+    args: LoreServiceSetUseAutomaticallyArgs,
+    callback: LoreEventCallback,
+) -> i32 {
+    let command =
+        async move |args: LoreServiceSetUseAutomaticallyArgs| -> Result<(), ServiceError> {
+            let (mut config, lock) = GlobalConfig::load_locked()
+                .await
+                .internal("loading global config")?;
+            if args.enabled != 0 {
+                config.use_service_automatically = Some(true);
+            } else {
+                config.use_service_automatically = None;
+            }
+            config.save(lock).await.internal("saving global config")?;
+            invalidate_use_service_cache();
+            Ok(())
+        };
+    no_repository_call(
+        globals,
+        callback,
+        args,
+        "service set-use-automatically",
+        command,
+    )
+    .await
 }

--- a/lore/tests/dispatch_runtime.rs
+++ b/lore/tests/dispatch_runtime.rs
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: 2026 Epic Games, Inc.
+// SPDX-License-Identifier: MIT
+
+//! An embedder's first FFI call, when the service is enabled, must size the
+//! shared runtime for relaying rather than build the full runtime it never
+//! uses. This runs in its own test binary so the process-wide runtime is built
+//! fresh here.
+
+#[test]
+fn first_ffi_call_sizes_runtime_for_relaying_when_service_enabled() {
+    let global = std::env::temp_dir().join("lore_dispatch_runtime_test_global");
+    // Safety: set before any runtime use, and this test binary is
+    // single-threaded at this point.
+    unsafe {
+        std::env::set_var("LORE_USE_SERVICE", "1");
+        std::env::set_var("LORE_GLOBAL_PATH", &global);
+        std::env::remove_var("LORE_WORKER_THREADS");
+    }
+
+    // Any FFI call goes through the synchronous runner, which sizes the runtime
+    // before building it. `set-use-automatically` only writes the global config
+    // — here the isolated one under LORE_GLOBAL_PATH — so it touches no socket
+    // and starts no service.
+    let globals = lore::interface::LoreGlobalArgs::default();
+    let args = lore::interface::LoreServiceSetUseAutomaticallyArgs { enabled: 1 };
+    let callback = lore::interface::LoreEventCallbackConfig {
+        user_context: 0,
+        func: None,
+    };
+    lore::interface::lore_service_set_use_automatically(&globals, &args, callback);
+
+    assert_eq!(
+        lore::runtime().metrics().num_workers(),
+        2,
+        "the first FFI call must size the runtime lean when the service is enabled"
+    );
+}

--- a/scripts/test/conftest.py
+++ b/scripts/test/conftest.py
@@ -181,10 +181,13 @@ def _service_unreachable(output):
     return platform.system() == "Windows" and "10022" in output
 
 
-def _wait_for_service_ready(lore_executable_path, service_process, attempts=30):
+def _wait_for_service_ready(
+    lore_executable_path, service_process, global_dir, attempts=30
+):
     """Block until the background service answers a probe."""
     probe_env = os.environ.copy()
     probe_env["LORE_USE_SERVICE"] = "1"
+    probe_env["LORE_GLOBAL_PATH"] = global_dir
     for _ in range(attempts):
         if service_process.poll() is not None:
             pytest.fail(
@@ -219,7 +222,7 @@ def lore_service_in_directory(lore_executable_path, global_dir_name):
             [lore_executable_path, "service", "run"], cwd=str(directory), env=env
         )
         processes.append(service_process)
-        _wait_for_service_ready(lore_executable_path, service_process)
+        _wait_for_service_ready(lore_executable_path, service_process, global_dir_name)
         return service_process
 
     yield start
@@ -234,12 +237,17 @@ def lore_service_in_directory(lore_executable_path, global_dir_name):
 
 
 @pytest.fixture(scope="function")
-def background_lore_service(lore_executable_path):
+def background_lore_service(lore_executable_path, global_dir_name):
+    # Give the service the test's isolated global config so that anything it
+    # writes there (for example a shared store created while serving a command)
+    # never lands in the developer's real global config.
+    env = os.environ.copy()
+    env["LORE_GLOBAL_PATH"] = global_dir_name
     command_args = [lore_executable_path, "service", "run"]
     logger.info("Executing Lore service command: %s", command_args)
-    service_process = subprocess.Popen(command_args)
+    service_process = subprocess.Popen(command_args, env=env)
 
-    _wait_for_service_ready(lore_executable_path, service_process)
+    _wait_for_service_ready(lore_executable_path, service_process, global_dir_name)
 
     yield service_process
 

--- a/scripts/test/lore.py
+++ b/scripts/test/lore.py
@@ -2256,8 +2256,16 @@ class Lore:
     def service_start(self, **kwargs: Unpack[GlobalOptions]):
         return self.run(["service", "start"], **kwargs)
 
-    def service_stop(self, stop_all: bool = False, **kwargs: Unpack[GlobalOptions]):
-        return self.run(["service", "stop", "true" if stop_all else "false"], **kwargs)
+    def service_stop(self, **kwargs: Unpack[GlobalOptions]):
+        return self.run(["service", "stop"], **kwargs)
+
+    def service_set_use_automatically(
+        self, enabled: bool, **kwargs: Unpack[GlobalOptions]
+    ):
+        return self.run(
+            ["service", "set-use-automatically", "true" if enabled else "false"],
+            **kwargs,
+        )
 
     def notification_subscribe(
         self, timeout: int | None = None, **kwargs: Unpack[GlobalOptions]

--- a/scripts/test/test_service.py
+++ b/scripts/test/test_service.py
@@ -3,6 +3,7 @@
 import logging
 import os
 import platform
+import shutil
 import subprocess
 
 import pytest
@@ -88,6 +89,73 @@ def test_service_set_use_automatically(lore_executable_path, global_dir_name):
     assert disable.returncode == 0, disable.stdout + disable.stderr
     with open(config_path, encoding="utf-8") as config_file:
         assert "use_service_automatically" not in config_file.read()
+
+
+@pytest.mark.smoke
+@pytest.mark.xdist_group("lore_service")
+@pytest.mark.skipif(
+    not service_supported(), reason="Service not supported on " + platform.system()
+)
+def test_config_setting_routes_to_service(
+    lore_executable_path, global_dir_name, tmp_path, stopped_service
+):
+    """The use_service_automatically config setting routes commands through the
+    service, without the LORE_USE_SERVICE override.
+
+    Everything runs against the test's isolated LORE_GLOBAL_PATH, so the
+    developer's real global config is never read or written. Routing is proven
+    without starting a real daemon: a binary not named `lore` refuses to
+    auto-start the service, so a command that tries to route fails with that
+    refusal, while the same binary forced to run locally does not.
+    """
+    refusal = "start the Lore service automatically"
+
+    # No service must be listening, so a routed command takes the auto-start
+    # path where a non-`lore` binary refuses.
+    run_lore(lore_executable_path, ["service", "stop"], global_dir_name)
+
+    enable = run_lore(
+        lore_executable_path,
+        ["service", "set-use-automatically", "true"],
+        global_dir_name,
+    )
+    assert enable.returncode == 0, enable.stdout + enable.stderr
+
+    binary_name = "notlore.exe" if platform.system() == "Windows" else "notlore"
+    not_lore = tmp_path / binary_name
+    shutil.copy(lore_executable_path, not_lore)
+    not_lore.chmod(0o755)
+
+    env = os.environ.copy()
+    env["LORE_GLOBAL_PATH"] = global_dir_name
+
+    routed = subprocess.run(
+        [str(not_lore), "status"],
+        capture_output=True,
+        text=True,
+        cwd=str(tmp_path),
+        env=env,
+    )
+    assert refusal in (routed.stdout + routed.stderr), (
+        "the config setting should have routed the command to the service, "
+        f"got: {routed.stdout}{routed.stderr}"
+    )
+
+    # Control: the same binary forced to run locally does not try to reach the
+    # service, so the failure above was the routing decision, not the rename.
+    local_env = env.copy()
+    local_env["LORE_USE_SERVICE"] = "0"
+    local = subprocess.run(
+        [str(not_lore), "status"],
+        capture_output=True,
+        text=True,
+        cwd=str(tmp_path),
+        env=local_env,
+    )
+    assert refusal not in (local.stdout + local.stderr), (
+        f"forcing local execution should not route to the service: "
+        f"{local.stdout}{local.stderr}"
+    )
 
 
 @pytest.mark.smoke

--- a/scripts/test/test_service.py
+++ b/scripts/test/test_service.py
@@ -4,6 +4,7 @@ import logging
 import os
 import platform
 import shutil
+import signal
 import subprocess
 
 import pytest
@@ -276,3 +277,62 @@ def test_service_starts_on_demand(new_lore_repo, stopped_service):
     assert "A " + file_name in map(
         lambda line: line.strip(" "), repo.status().splitlines()
     )
+
+
+@pytest.mark.smoke
+@pytest.mark.xdist_group("lore_service")
+@pytest.mark.skipif(
+    platform.system() not in ("Linux", "Darwin"),
+    reason="POSIX termination signals",
+)
+@pytest.mark.parametrize("sig", [signal.SIGTERM, signal.SIGINT])
+def test_service_shuts_down_gracefully_on_signal(
+    lore_service_in_directory, tmp_path, sig
+):
+    """A termination signal stops the service cleanly, exiting with code 0."""
+    service_directory = tmp_path / f"service_{sig}"
+    service_directory.mkdir()
+    service_process = lore_service_in_directory(service_directory)
+
+    service_process.send_signal(sig)
+    try:
+        code = service_process.wait(timeout=10)
+    except subprocess.TimeoutExpired:
+        service_process.kill()
+        pytest.fail(f"the service did not exit on {sig!r}")
+    assert code == 0, f"the service should exit cleanly on {sig!r}, got {code}"
+
+
+@pytest.mark.smoke
+@pytest.mark.xdist_group("lore_service")
+@pytest.mark.skipif(
+    not service_supported(), reason="Service not supported on " + platform.system()
+)
+def test_concurrent_service_stop_all_succeed(
+    lore_executable_path, global_dir_name, stopped_service
+):
+    """Two stops racing one live service both report success.
+
+    The one whose send finds the service already gone must still exit 0 rather
+    than fail on the closed connection.
+    """
+    env = os.environ.copy()
+    env["LORE_GLOBAL_PATH"] = global_dir_name
+
+    for _ in range(3):
+        start = run_lore(lore_executable_path, ["service", "start"], global_dir_name)
+        assert start.returncode == 0, start.stdout + start.stderr
+
+        stops = [
+            subprocess.Popen(
+                [lore_executable_path, "service", "stop"],
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            for _ in range(2)
+        ]
+        for stop in stops:
+            out, err = stop.communicate(timeout=15)
+            assert stop.returncode == 0, f"a concurrent stop failed: {out}{err}"

--- a/scripts/test/test_service.py
+++ b/scripts/test/test_service.py
@@ -42,6 +42,7 @@ def stopped_service(lore_executable_path, global_dir_name):
 
 
 @pytest.mark.smoke
+@pytest.mark.xdist_group("lore_service")
 @pytest.mark.skipif(
     not service_supported(), reason="Service not supported on " + platform.system()
 )
@@ -63,6 +64,7 @@ def test_service_start_stop(lore_executable_path, global_dir_name, stopped_servi
 
 
 @pytest.mark.smoke
+@pytest.mark.xdist_group("lore_service")
 @pytest.mark.skipif(
     not service_supported(), reason="Service not supported on " + platform.system()
 )
@@ -185,6 +187,7 @@ def test_service_resolves_relative_paths_against_caller(
 
 
 @pytest.mark.smoke
+@pytest.mark.xdist_group("lore_service")
 @pytest.mark.skipif(
     not service_supported(), reason="Service not supported on " + platform.system()
 )

--- a/scripts/test/test_service.py
+++ b/scripts/test/test_service.py
@@ -3,10 +3,10 @@
 import logging
 import os
 import platform
+import subprocess
 
 import pytest
 
-from error_types import ServiceCallError
 from lore import Lore
 
 logger = logging.getLogger(__name__)
@@ -18,15 +18,74 @@ def service_supported():
     return platform.system() in ("Windows", "Linux", "Darwin")
 
 
+def run_lore(lore_executable_path, args, global_dir):
+    """Runs the Lore CLI with an isolated global config directory."""
+    environment = os.environ.copy()
+    environment["LORE_GLOBAL_PATH"] = global_dir
+    return subprocess.run(
+        [lore_executable_path, *args],
+        capture_output=True,
+        text=True,
+        env=environment,
+    )
+
+
+@pytest.fixture
+def stopped_service(lore_executable_path, global_dir_name):
+    """Leaves no service process behind.
+
+    The socket is per user rather than per test, so a service surviving one
+    test would be picked up by the next one.
+    """
+    yield
+    run_lore(lore_executable_path, ["service", "stop"], global_dir_name)
+
+
 @pytest.mark.smoke
-@pytest.mark.xdist_group("lore_service")
-@pytest.mark.skip(reason="Unknown issue specifically running in CI for OSS")
 @pytest.mark.skipif(
     not service_supported(), reason="Service not supported on " + platform.system()
 )
-def test_service_down(new_lore_repo):
-    with pytest.raises(ServiceCallError):
-        new_lore_repo(environment_vars=LORE_SERVICE_ENVIRONMENT.copy())
+def test_service_start_stop(lore_executable_path, global_dir_name, stopped_service):
+    start = run_lore(lore_executable_path, ["service", "start"], global_dir_name)
+    assert start.returncode == 0, start.stdout + start.stderr
+
+    # Starting again is a no-op rather than an error, because a service is
+    # already listening.
+    again = run_lore(lore_executable_path, ["service", "start"], global_dir_name)
+    assert again.returncode == 0, again.stdout + again.stderr
+
+    stop = run_lore(lore_executable_path, ["service", "stop"], global_dir_name)
+    assert stop.returncode == 0, stop.stdout + stop.stderr
+
+    # Stopping when nothing is running is also a no-op.
+    stop_again = run_lore(lore_executable_path, ["service", "stop"], global_dir_name)
+    assert stop_again.returncode == 0, stop_again.stdout + stop_again.stderr
+
+
+@pytest.mark.smoke
+@pytest.mark.skipif(
+    not service_supported(), reason="Service not supported on " + platform.system()
+)
+def test_service_set_use_automatically(lore_executable_path, global_dir_name):
+    config_path = os.path.join(global_dir_name, "config", "config.toml")
+
+    enable = run_lore(
+        lore_executable_path,
+        ["service", "set-use-automatically", "true"],
+        global_dir_name,
+    )
+    assert enable.returncode == 0, enable.stdout + enable.stderr
+    with open(config_path, encoding="utf-8") as config_file:
+        assert "use_service_automatically = true" in config_file.read()
+
+    disable = run_lore(
+        lore_executable_path,
+        ["service", "set-use-automatically", "false"],
+        global_dir_name,
+    )
+    assert disable.returncode == 0, disable.stdout + disable.stderr
+    with open(config_path, encoding="utf-8") as config_file:
+        assert "use_service_automatically" not in config_file.read()
 
 
 @pytest.mark.smoke
@@ -123,3 +182,26 @@ def test_service_resolves_relative_paths_against_caller(
     assert "A " + file_name in map(
         lambda line: line.strip(" "), status_output.splitlines()
     ), f"Staged file should show as added: {status_output}"
+
+
+@pytest.mark.smoke
+@pytest.mark.skipif(
+    not service_supported(), reason="Service not supported on " + platform.system()
+)
+def test_service_starts_on_demand(new_lore_repo, stopped_service):
+    """A call routed to the service starts one when none is running.
+
+    This replaces an older test asserting the opposite: before automatic
+    start-up, the same call failed with a connection error.
+    """
+    repo: Lore = new_lore_repo(environment_vars=LORE_SERVICE_ENVIRONMENT.copy())
+
+    file_name = "test.uasset"
+    with repo.open_file(file_name, "w+b") as output_file:
+        output_file.write(os.urandom(30))
+
+    repo.stage(scan=True)
+
+    assert "A " + file_name in map(
+        lambda line: line.strip(" "), repo.status().splitlines()
+    )


### PR DESCRIPTION
## Motivation
Lore's service process start/stop were stubs that returned failure, and the only way to route through the service was an undocumented env var, with no persistent opt-in.

A client relaying all its work to the service also still built the full runtime it never uses, since all processing is routed over IPC and executed in the service process.

## Summary
Implement lore service start / stop (both idempotent).

Add a `use_service_automatically` global setting (`lore service set-use-automatically <bool>`): when on, every command routes through the service, auto-starting it on demand. Off by default; `LORE_USE_SERVICE` still overrides per-invocation.

Manage the daemon lifecycle: detached start, working directory parked away from the caller's, clean shutdown on signal or on a stop over the socket.

Size a relaying client's runtime lean (no compute pool, fewer threads); local work and the service process itself keep the full runtime.

Document the setting and commands.

## Testing
Rust unit tests added and verified: `LORE_USE_SERVICE` parsing; runtime sizing (relay vs full); the service run-only full-runtime classification.

Python smoke tests added: start/stop idempotency, config-driven routing, auto-start on demand, working-directory resolution, SIGTERM/SIGINT shutdown, concurrent stop — all against an isolated global config (verified a run leaves the real system config byte-identical).
