### PR TITLE
Fix: Correct timestamp units in doc comments

### DIFF
--- a/lore-capi/lore.h
+++ b/lore-capi/lore.h
@@ -1722,7 +1722,8 @@ typedef struct lore_repository_data_event_data_t {
   struct lore_string_t default_branch_name;
   // Name of the user who created the repository.
   struct lore_string_t creator;
-  // Creation time of the repository, in seconds since the Unix epoch.
+  // Creation time of the repository, in milliseconds since the Unix
+  // epoch.
   uint64_t created;
 } lore_repository_data_event_data_t;
 
@@ -4390,7 +4391,8 @@ typedef struct lore_revision_history_args_t {
   struct lore_string_t revision;
   // Restrict to this branch; empty for current
   struct lore_string_t branch;
-  // Stop at revisions created before this date (Unix timestamp; 0 disables)
+  // Stop at revisions created before this date (milliseconds since the
+  // Unix epoch; 0 disables)
   uint64_t date;
   // Maximum number of revisions to return; 0 for unlimited
   uint32_t length;

--- a/lore-client/src/cli/commands/revision.rs
+++ b/lore-client/src/cli/commands/revision.rs
@@ -131,7 +131,8 @@ pub struct RevisionHistoryArgs {
     #[clap(long, value_name = "branch")]
     branch: Option<String>,
 
-    /// Stop when reaching a revision created before this date (Unix timestamp)
+    /// Stop when reaching a revision created before this date (milliseconds
+    /// since the Unix epoch)
     #[clap(long, value_name = "date", hide = true)]
     date: Option<u64>,
 

--- a/lore-proto/proto/lore/model/v1/model.proto
+++ b/lore-proto/proto/lore/model/v1/model.proto
@@ -94,7 +94,7 @@ message Repository {
   // Identity that created the repository (caller-supplied when permitted,
   // else the authenticated JWT identity).
   string creator = 6;
-  // Server-assigned creation timestamp (Unix epoch seconds).
+  // Server-assigned creation timestamp (Unix epoch milliseconds).
   uint64 created = 7;
   // Current metadata pointer hash; mutated atomically via
   // RepositoryMetadataSet.
@@ -117,7 +117,7 @@ message Branch {
   // Free-form caller-defined tag for grouping or filtering branches by
   // intent. Server stores verbatim; no enforced vocabulary.
   string category = 4;
-  // Server-assigned creation timestamp (Unix epoch seconds).
+  // Server-assigned creation timestamp (Unix epoch milliseconds).
   uint64 created = 5;
   // Signature of the current branch tip.
   bytes latest = 6;

--- a/lore-proto/proto/lore/thin_client/v1/model.proto
+++ b/lore-proto/proto/lore/thin_client/v1/model.proto
@@ -127,7 +127,7 @@ message Revision {
   lore.model.v1.RevisionIdentifier identifier = 2;
   // Free-form commit message.
   string commit_message = 3;
-  // Commit timestamp (Unix epoch seconds). Always commit time, never
+  // Commit timestamp (Unix epoch milliseconds). Always commit time, never
   // authorship time.
   uint64 timestamp = 4;
   // Identity that originally created the revision.

--- a/lore-proto/src/grpc/lore.model.v1.rs
+++ b/lore-proto/src/grpc/lore.model.v1.rs
@@ -149,7 +149,7 @@ pub struct Repository {
     /// else the authenticated JWT identity).
     #[prost(string, tag = "6")]
     pub creator: ::prost::alloc::string::String,
-    /// Server-assigned creation timestamp (Unix epoch seconds).
+    /// Server-assigned creation timestamp (Unix epoch milliseconds).
     #[prost(uint64, tag = "7")]
     pub created: u64,
     /// Current metadata pointer hash; mutated atomically via
@@ -188,7 +188,7 @@ pub struct Branch {
     /// intent. Server stores verbatim; no enforced vocabulary.
     #[prost(string, tag = "4")]
     pub category: ::prost::alloc::string::String,
-    /// Server-assigned creation timestamp (Unix epoch seconds).
+    /// Server-assigned creation timestamp (Unix epoch milliseconds).
     #[prost(uint64, tag = "5")]
     pub created: u64,
     /// Signature of the current branch tip.

--- a/lore-proto/src/grpc/lore.thin_client.v1.rs
+++ b/lore-proto/src/grpc/lore.thin_client.v1.rs
@@ -138,7 +138,7 @@ pub struct Revision {
     /// Free-form commit message.
     #[prost(string, tag = "3")]
     pub commit_message: ::prost::alloc::string::String,
-    /// Commit timestamp (Unix epoch seconds). Always commit time, never
+    /// Commit timestamp (Unix epoch milliseconds). Always commit time, never
     /// authorship time.
     #[prost(uint64, tag = "4")]
     pub timestamp: u64,

--- a/lore-revision/src/repository/info.rs
+++ b/lore-revision/src/repository/info.rs
@@ -42,7 +42,8 @@ pub struct LoreRepositoryDataEventData {
     pub default_branch_name: LoreString,
     /// Name of the user who created the repository.
     pub creator: LoreString,
-    /// Creation time of the repository, in seconds since the Unix epoch.
+    /// Creation time of the repository, in milliseconds since the Unix
+    /// epoch.
     pub created: u64,
 }
 

--- a/lore/src/revision.rs
+++ b/lore/src/revision.rs
@@ -598,7 +598,8 @@ pub struct LoreRevisionHistoryArgs {
     pub revision: LoreString,
     /// Restrict to this branch; empty for current
     pub branch: LoreString,
-    /// Stop at revisions created before this date (Unix timestamp; 0 disables)
+    /// Stop at revisions created before this date (milliseconds since the
+    /// Unix epoch; 0 disables)
     pub date: u64,
     /// Maximum number of revisions to return; 0 for unlimited
     pub length: u32,


### PR DESCRIPTION
## What

Corrects documentation that describes timestamps as Unix epoch **seconds** when the values are actually **milliseconds**: the v1 proto comments (`Repository.created`, `Branch.created`, thin-client commit timestamp), the generated C header, and the revision history `--date` help. Doc-only, no wire or on-disk values change.

## Why

The implementation is uniformly milliseconds end to end  `util::time::timestamp()`, the persisted revision-metadata `TIMESTAMP` key, the server's cache-age math, the CLI's `from_timestamp_millis` displays - so external consumers that trust the documented unit get values 1000× larger than promised (we hit this building a web frontend against the API and had to add a runtime unit-sniffing workaround).

The `--date` flag is the one place this becomes a functional bug: passing epoch seconds as documented compares against millisecond values, so the filter silently never matches.

## Notes

- Audited all timestamp producers/consumers; the implementation never disagrees with itself - only the docs were wrong.
- Fragment `last_access` genuinely is seconds (`as_secs()`) and is left as-is.
- `lore.h` and prost output are regenerated, not hand-edited.
