### PR TITLE
docs: fix link to the ADR decisions index in proposals README

### DIFF
--- a/docs/proposals/README.md
+++ b/docs/proposals/README.md
@@ -3,7 +3,7 @@
 This directory holds **Lore Enhancement Proposals (LEPs)** — public-facing,
 pre-implementation proposals for changes to the Lore wire protocol, on-disk
 format, public APIs (CLI, capi, JS bindings), and cross-cutting features. LEPs are where the design is debated; ADRs in
-[`../decisions/`](../decisions/README.md) record narrow architecture
+[`../developing/decisions/`](../developing/decisions/README.md) record narrow architecture
 decisions after they are made.
 
 ## Lifecycle


### PR DESCRIPTION
`docs/proposals/README.md` refers to the architectural decision records as `` [`../decisions/`](../decisions/README.md) ``, but from `docs/proposals/` that resolves to `docs/decisions/README.md`, which doesn't exist. The ADR index is at `docs/developing/decisions/README.md`.

Updated both the code-span path and the link to `../developing/decisions/`. Verified the target exists (its heading is "Architectural decision records"). Docs-only; commit is DCO signed-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)