### PR TITLE
fix:(feat): use random nonce for encryption key generation

### DIFF
--- a/lore-credential/src/token_store.rs
+++ b/lore-credential/src/token_store.rs
@@ -1097,8 +1097,11 @@ fn generate_encryption_key_nonce() -> Vec<u8> {
     let rand = SystemRandom::new();
     let mut key_bytes = vec![0; AES_256_GCM.key_len()];
     let _ = rand.fill(&mut key_bytes);
+    let mut nonce_bytes = [0u8; 4];
+    let _ = rand.fill(&mut nonce_bytes);
+    let nonce = u32::from_le_bytes(nonce_bytes);
     lore_debug!("Generated new encryption key");
-    get_encryption_key_with_nonce(key_bytes, 1)
+    get_encryption_key_with_nonce(key_bytes, nonce)
 }
 
 fn get_encryption_key_with_nonce(key: Vec<u8>, nonce: u32) -> Vec<u8> {


### PR DESCRIPTION
Use a non-hard-coded nonce seed when building the encryption key+nonce bundle.   fix `generate_encryption_key_nonce()` (around lines 1096–1102), generate 4 random bytes using the same `SystemRandom`, convert them into a `u32` (e.g., little-endian), and pass that value to `get_encryption_key_with_nonce(...)` instead of literal `1`. This keeps the existing data format and flow unchanged (still `u32` nonce + key bytes), avoids introducing new dependencies, and resolves the hard-coded cryptographic value. Also handle `rand.fill(...)` result for nonce bytes the same way existing code handles key generation (without changing function signatures/behavior).

- [O'Reilly Using Salts, Nonces, and Initialization Vectors](https://www.oreilly.com/library/view/secure-programming-cookbook/0596003943/ch04s09.html)
- [CWE-1204](https://cwe.mitre.org/data/definitions/1204.html)