### PR TITLE
Honor --dry-run when staging files

### DIFF
--- a/lore-revision/src/file/stage.rs
+++ b/lore-revision/src/file/stage.rs
@@ -417,9 +417,11 @@ pub async fn stage(
 
         if signature != current_revision {
             staged_revision = signature;
-            crate::instance::store_staged_anchor(&repository, signature)
-                .await
-                .forward::<StageError>("Failed to serialize staged anchor")?;
+            if !execution_context().globals().dry_run() {
+                crate::instance::store_staged_anchor(&repository, signature)
+                    .await
+                    .forward::<StageError>("Failed to serialize staged anchor")?;
+            }
         }
 
         event::LoreEvent::FileStageRevision(LoreFileStageRevisionEventData {
@@ -448,7 +450,7 @@ pub async fn stage(
             .await
             .forward::<StageError>("Failed to serialize staged revision state")?;
 
-        if signature != layer.current {
+        if signature != layer.current && !execution_context().globals().dry_run() {
             layer::store_layer_staged(
                 repository.clone(),
                 token,
@@ -673,9 +675,11 @@ pub async fn stage_merge(
         .serialize(repository.clone(), token)
         .await
         .forward::<StageError>("Failed to serialize staged revision state")?;
-    crate::instance::store_staged_anchor(&repository, signature)
-        .await
-        .forward::<StageError>("Failed to serialize staged anchor")?;
+    if !execution_context().globals().dry_run() {
+        crate::instance::store_staged_anchor(&repository, signature)
+            .await
+            .forward::<StageError>("Failed to serialize staged anchor")?;
+    }
 
     event::LoreEvent::FileStageRevision(LoreFileStageRevisionEventData {
         repository: repository.id,
@@ -1047,9 +1051,11 @@ pub async fn stage_move(
         .serialize(repository.clone(), token)
         .await
         .forward::<StageError>("Failed to serialize staged revision state")?;
-    crate::instance::store_staged_anchor(&repository, signature)
-        .await
-        .forward::<StageError>("Failed to serialize staged anchor")?;
+    if !execution_context().globals().dry_run() {
+        crate::instance::store_staged_anchor(&repository, signature)
+            .await
+            .forward::<StageError>("Failed to serialize staged anchor")?;
+    }
 
     event::LoreEvent::FileStageRevision(LoreFileStageRevisionEventData {
         repository: repository.id,

--- a/lore-revision/src/stage.rs
+++ b/lore-revision/src/stage.rs
@@ -2733,9 +2733,11 @@ pub(crate) async fn stage_from_parent_revision(
         .serialize(repository.clone(), token)
         .await
         .forward::<StageError>("Failed to serialize staged revision state")?;
-    crate::instance::store_staged_anchor(&repository, signature)
-        .await
-        .forward::<StageError>("Failed to serialize staged anchor")?;
+    if !execution_context().globals().dry_run() {
+        crate::instance::store_staged_anchor(&repository, signature)
+            .await
+            .forward::<StageError>("Failed to serialize staged anchor")?;
+    }
 
     event::LoreEvent::FileStageRevision(LoreFileStageRevisionEventData {
         repository: repository.id,
@@ -3089,9 +3091,11 @@ pub(crate) async fn stage_link_paths_from_parent_revision(
         .serialize(repository.clone(), token)
         .await
         .forward::<StageError>("Failed to serialize parent staged state")?;
-    crate::instance::store_staged_anchor(&repository, signature)
-        .await
-        .forward::<StageError>("Failed to store parent staged anchor")?;
+    if !execution_context().globals().dry_run() {
+        crate::instance::store_staged_anchor(&repository, signature)
+            .await
+            .forward::<StageError>("Failed to store parent staged anchor")?;
+    }
 
     Ok(())
 }

--- a/lore-revision/tests/stage.rs
+++ b/lore-revision/tests/stage.rs
@@ -15,12 +15,15 @@ mod tests {
     use lore_revision::commit;
     use lore_revision::commit::CommitOptions;
     use lore_revision::file;
+    use lore_revision::instance;
+    use lore_revision::interface::ExecutionContext;
     use lore_revision::interface::LoreArray;
     use lore_revision::interface::LoreString;
     use lore_revision::lore::RepositoryId;
     use lore_revision::lore_debug;
     use lore_revision::node;
     use lore_revision::node::NodeFlags;
+    use lore_revision::relay::EventDispatcher;
     use lore_revision::repository;
     use lore_revision::repository::RepositoryContext;
     use lore_revision::repository::RepositoryFormat;
@@ -30,6 +33,150 @@ mod tests {
     use lore_transport::ProtocolError;
 
     include!("helper.rs");
+
+    #[tokio::test]
+    async fn stage_dry_run_no_persist() {
+        let repository_id = RepositoryId::from(uuid::Uuid::now_v7());
+        let execution = setup_test_execution();
+
+        #[allow(clippy::disallowed_methods)]
+        runtime()
+            .spawn(LORE_CONTEXT.scope(execution.clone(), async move {
+                let tempdir = generate_tempdir();
+                let path = tempdir.to_path_buf();
+                std::fs::create_dir_all(path.as_path()).expect("Create directory failed");
+                let write_token = repository::RepositoryWriteToken::acquire(path.as_path()).await;
+                let repository = repository::create_local(
+                    path.as_path(),
+                    &write_token,
+                    repository_id,
+                    Context::from(uuid::Uuid::now_v7()),
+                    branch::DEFAULT_DEFAULT_NAME.to_string(),
+                    repository::RepositoryConfig::default(),
+                    false,
+                )
+                .await
+                .expect("Failed to initialize repository");
+
+                let file_path = path.as_path().join("test.file");
+                {
+                    let mut file = std::fs::File::options()
+                        .create(true)
+                        .truncate(true)
+                        .read(true)
+                        .write(true)
+                        .open(file_path.as_path())
+                        .expect("Failed to create test file");
+                    file.write_all(&[0, 1, 2, 3, 4])
+                        .expect("Failed to write test file");
+                }
+
+                let _ = file::stage::stage(
+                    repository.clone(),
+                    &write_token,
+                    LoreArray::from_vec(vec![LoreString::from(&path)]),
+                    StageOptions {
+                        case_change: stage::StageCaseChange::Error,
+                        node_flags: NodeFlags::NoFlags,
+                        file_id: None,
+                        no_children: false,
+                        scan: true,
+                    },
+                )
+                .await
+                .expect("Failed to stage initial file");
+
+                let options = CommitOptions {
+                    message: String::new(),
+                    link_messages: std::collections::HashMap::new(),
+                    link: None,
+                    layer_messages: std::collections::HashMap::new(),
+                    layer: None,
+                    stats: false,
+                };
+                let committed_signature =
+                    Box::pin(commit::commit(repository.clone(), &write_token, options))
+                        .await
+                        .expect("Failed to commit revision");
+
+                {
+                    let mut file = std::fs::File::options()
+                        .write(true)
+                        .truncate(true)
+                        .open(file_path.as_path())
+                        .expect("Failed to reopen test file");
+                    file.write_all(&[5, 6, 7, 8, 9])
+                        .expect("Failed to modify test file");
+                }
+
+                let dry_run_execution = std::sync::Arc::new(ExecutionContext::new_client(
+                    LoreGlobalArgs {
+                        dry_run: 1,
+                        ..Default::default()
+                    },
+                    EventDispatcher::no_dispatch(),
+                ));
+
+                LORE_CONTEXT
+                    .scope(
+                        dry_run_execution,
+                        file::stage::stage(
+                            repository.clone(),
+                            &write_token,
+                            LoreArray::from_vec(vec![LoreString::from(&path)]),
+                            StageOptions {
+                                case_change: stage::StageCaseChange::Error,
+                                node_flags: NodeFlags::NoFlags,
+                                file_id: None,
+                                no_children: false,
+                                scan: true,
+                            },
+                        ),
+                    )
+                    .await
+                    .expect("Dry-run stage failed");
+
+                let staged_revision = instance::load_staged_revision(&repository)
+                    .await
+                    .ok()
+                    .flatten();
+                assert!(
+                    staged_revision.is_none() || staged_revision == Some(committed_signature),
+                    "Dry-run stage should not persist a new staged anchor"
+                );
+
+                let signature = file::stage::stage(
+                    repository.clone(),
+                    &write_token,
+                    LoreArray::from_vec(vec![LoreString::from(&path)]),
+                    StageOptions {
+                        case_change: stage::StageCaseChange::Error,
+                        node_flags: NodeFlags::NoFlags,
+                        file_id: None,
+                        no_children: false,
+                        scan: true,
+                    },
+                )
+                .await
+                .expect("Real stage after dry-run failed");
+
+                assert_ne!(
+                    signature, committed_signature,
+                    "Real stage after dry-run should persist staged changes"
+                );
+
+                let staged_revision = instance::load_staged_revision(&repository)
+                    .await
+                    .ok()
+                    .flatten()
+                    .expect("Real stage should persist staged anchor");
+                assert_eq!(staged_revision, signature);
+
+                let _ = std::fs::remove_dir_all(path.as_path());
+            }))
+            .await
+            .expect("Test task failed");
+    }
 
     #[tokio::test]
     async fn stage_non_exist() {


### PR DESCRIPTION
## Summary

`lore stage --dry-run` computed staged state but still persisted the staged anchor, so a later real stage reported "No changes staged" and commit could pick up the preview state.

- Guard staged-anchor persistence with `globals.dry_run()` in `file/stage.rs` and `stage.rs`.
- Keep stage end/progress/revision events on dry-run so preview output is unchanged.

Fixes #125

## Test plan

- [x] `cargo +nightly fmt --all`
- [x] `cargo clippy -p lore-revision --all-targets -- -D warnings --no-deps`
- [x] `cargo test -p lore-revision --test stage stage_dry_run_no_persist`

## Evidence

```
$ cargo test -p lore-revision --test stage stage_dry_run_no_persist
running 1 test
test tests::stage_dry_run_no_persist ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
```

The test commits a baseline revision, modifies a tracked file, runs dry-run stage (no staged anchor persisted), then runs a real stage and verifies the staged anchor is written.
