### PR TITLE
lore-aws: Carry fragment metadata on the S3 object

### DIFF
--- a/docs/developing/decisions/00006-s3-storage-options-reconsidered.md
+++ b/docs/developing/decisions/00006-s3-storage-options-reconsidered.md
@@ -1,5 +1,5 @@
 ---
-status: accepted
+status: superseded by [ADR-00018](00018-fragment-metadata-on-s3-objects.md)
 date: 2024-05-19
 deciders: Mattias Jansson
 ---

--- a/docs/developing/decisions/00018-fragment-metadata-on-s3-objects.md
+++ b/docs/developing/decisions/00018-fragment-metadata-on-s3-objects.md
@@ -1,0 +1,286 @@
+---
+status: proposed
+date: 2026-08-03
+deciders: Mattias Jansson
+---
+
+# ADR-00018: Store fragment metadata as S3 object metadata
+
+## Context and Problem Statement
+
+[ADR-00006](00006-s3-storage-options-reconsidered.md) decided to store a fragment together with its
+payload, as a 16-byte preamble on the S3 object, so that the two could not get out of sync.
+[ADR-00008](00008-aws-store-fragment-associations.md) later moved fragment/repository/context
+associations into `DynamoDB`, because `ListObjects` was too slow for `query_immutable`. Following
+that, the fragment itself was moved into `DynamoDB` as well: with associations already there, a
+query could answer whether a fragment existed without touching S3, but reading what it was still
+cost an S3 request, and moving it removed that request. No ADR records this change, and ADR-00006
+has never been superseded.
+
+The consequence is that an S3 object holds one representation of some content while a separate
+`DynamoDB` record describes which representation that is. The S3 key is the *content* hash, but two
+writers may legitimately hold different valid representations of the same content — LZ4 and Zstd of
+the same bytes — and both address the same key. The object and the record are written independently
+and are required to agree. They can fail to:
+
+1. Two writers upload different representations to the same key and publish different fragments. The
+   interleaving that leaves one writer's fragment beside the other's payload is permanent and
+   requires no failure of any kind.
+2. A writer replaces the object and then fails to publish its fragment. The stored fragment then
+   describes bytes that are gone, and the affected partition cannot repair it, because its own
+   re-put sees a full match and does nothing.
+
+Either way the payload cannot be decompressed. It is reported as an internal size mismatch, no
+amount of retrying fixes it, and nothing detects it until a read fails.
+
+Separately, the same coupling wastes bandwidth. A put resolves to either a full match on the
+address-partition-context triplet or an upload — `lookup` short-circuits to `MatchNone` when a full
+match is requested, so the `MatchPartition` and `MatchHash` arms of `put` are unreachable. Content
+already durable in one partition is uploaded again when another partition needs it, even though the
+server has already established that the caller holds it.
+
+## Decision Drivers
+
+- A stored payload and the fragment describing it must not be able to disagree, under any
+  interleaving of concurrent writers and any partial failure.
+- Whether a hash exists must remain answerable without an S3 request. This is the reason the
+  fragment was moved into `DynamoDB`, and it is not up for negotiation.
+- Content already stored must be deduplicable across partitions and contexts, without a caller being
+  able to claim it on the strength of a hash alone.
+- Prefer correctness that follows from the storage layer's own guarantees over correctness that
+  depends on a multi-step protocol being executed correctly across crashes, races and partial
+  failures.
+- Do not increase AWS request volume on the hot paths.
+
+## Considered Options
+
+- Keep the fragment in `DynamoDB` and make the pair safe with a write protocol
+- Keep the fragment in `DynamoDB`, with a separate claim record marking the commit point
+- Store the fragment in the S3 object body, as ADR-00006 did
+- Store the fragment as S3 object metadata
+- Key S3 objects by representation hash rather than content hash
+- Normalize every payload to one canonical representation per hash
+
+## Decision Outcome
+
+Chosen option: "Store the fragment as S3 object metadata", because it is the only option that
+removes the disagreement rather than policing it, while preserving the S3-free existence check that
+motivated moving the fragment into `DynamoDB` in the first place.
+
+Object metadata is part of the object version. It cannot be changed without rewriting the object, and
+a `GetObject` returns headers and body from the same version. A full-object PUT is atomic, so a
+reader observes the whole previous object or the whole new one and never a mix. Two writers racing
+with different representations therefore both write complete, self-describing objects, and whichever
+lands last is read back whole. Last-writer-wins becomes safe, which is what removes the need for a
+protocol at all.
+
+The `DynamoDB` fragment state table replaces the fragment metadata table: the presence of a row
+means the hash exists, and the row additionally carries obliteration state. That keeps the existence
+probe a single `GetItem` with no S3 request, and makes publishing an idempotent set-a-bit with
+nothing for two writers to reconcile.
+
+It stays a separate table from the associations table rather than being folded in as a second sort
+key, even though merging would make the put probe one `BatchGetItem` instead of two `GetItem`s.
+Whether a fragment metadata table is configured is what selects the read path for objects written
+before this change, so its separate existence carries meaning beyond the rows it holds. Merging
+would erase that signal, and would also concentrate state-row traffic onto the same partition key as
+association traffic for popular hashes.
+
+### Consequences
+
+- Good, because a stored payload and its fragment cannot disagree. This follows from S3 object
+  atomicity rather than from code being correct, so it does not degrade under crashes or races.
+- Good, because it needs no S3 or `DynamoDB` feature beyond the plainest ones: `PutObject`,
+  `GetObject`, `HeadObject`, `DeleteObject`, and `GetItem`, `PutItem`, `DeleteItem`, `Query`. No
+  conditional S3 write, no ETag compare-and-set, no object-age heuristic, no transaction. The one
+  conditional `DynamoDB` write is a create guarded by `attribute_not_exists`, whose only job is to
+  avoid erasing an obliteration mark. Anything that made the pair safe while keeping them apart
+  would have to reach for more than this, and would then depend on those mechanisms behaving as
+  assumed under contention.
+- Neutral on code size. Production code in `lore-aws` grows by roughly 460 lines, mostly the
+  deduplication path and the read fallback for objects predating the change; `dynamodb.rs` is
+  untouched. This is not a simplification measured in lines, and should not be argued as one.
+- Good, because `get` drops a `DynamoDB` read: the fragment arrives on the `GetObject` response that
+  was already being made. `copy` drops one too.
+- Good, because cross-partition deduplication becomes possible at no additional request cost,
+  reusing the two probe reads a put already makes.
+- Good, because the bucket becomes self-describing. The fragment state table can be rebuilt from S3
+  alone, and `verify` can run against the bucket without `DynamoDB`.
+- Good, because `PayloadStoredDurable` is derived on read rather than persisted, so a durability
+  claim cannot outlive the object it describes or be supplied by a client.
+- Good, because `query` is answered from the state row and the association in parallel, with no S3
+  request at all. This matters more than it sounds: `query_immutable` is called once per fragment
+  stored on the ingress path and ADR-00008 names it the most frequently accessed path in the server,
+  so an S3 request here would have undone the change's whole purpose.
+- Neutral, because `query` consequently reports whether a payload is durable rather than what
+  representation is stored, which splits one trait method into two. Reading a representation moves
+  to `ImmutableStore::get_metadata`, which defaults to a `MatchFull` `query` and is overridden by
+  this store to spend a `HeadObject`. That is the only path here that spends an S3 request purely
+  on metadata, and it is reached by explicit metadata reads rather than by storing a fragment.
+- Good, because separating the two exposed that `store_fragment` was reporting the queried fragment
+  on its deduplicated path. It now reports the caller's own, with storage status merged in from the
+  query — both fragments describe the same content, and only the store knows the status. That is
+  the right split regardless of how any store answers.
+- Bad, because objects written before the change carry no fragment metadata and need a fallback read
+  from the old row, gated on configuration and retired only by an optional backfill.
+- Bad, because it does not address the case where a partition still references a hash whose object
+  S3 no longer has. That loss reads as an ordinary not-found, and re-putting the content does not
+  repair it: the reference makes the put a no-op, and a put from another partition attaches to the
+  same empty hash. The condition is detectable for free on `get` — an association plus an S3
+  not-found is the entire signal — and repairable by clearing the state row, which is only safe
+  because that row no longer carries a representation. Both are implemented: the loss is counted and
+  logged, and the row is cleared unless an obliteration holds the mark. Reconciling the whole
+  population rather than what happens to be read is left to the garbage collector.
+
+## Pros and Cons of the Options
+
+### Keep the fragment in `DynamoDB` and make the pair safe with a write protocol
+
+This option was implemented in full, reviewed adversarially over several rounds, and is the most
+informative of the alternatives because its difficulties are measured rather than predicted.
+
+The protocol makes the object write-once with `If-None-Match: *`, treats the resulting HTTP 412 as
+"someone else got there first", and then has to work out what that someone did. It re-reads the
+metadata to see whether they published; if not, it decides from `HeadObject` whether their upload is
+still in flight or was abandoned, reclaims an abandoned object with a single-winner
+`If-Match: <etag>` write, and publishes through a converging conditional `PutItem` with explicit
+write modes so that a losing writer stands down instead of overwriting the winner. Bounded retry
+loops sit around both the put and the publish.
+
+What that cost, concretely:
+
+- **Reconstructing a fragment for an abandoned object by probing codecs does not work.** The natural
+  repair — read the orphaned bytes, try each codec, keep the one that decompresses — was implemented
+  and then disproved by execution. `decompress_into` validates the result against `size_content`, and
+  Oodle takes the raw size as an *input* rather than discovering it, so a probe cannot distinguish
+  "wrong codec" from "wrong size". It was replaced by reclaiming the object outright.
+- **Telling an in-flight upload from a crashed one has no sound answer.** The implementation decides
+  by the object's age via `Last-Modified`, which is a heuristic: it must treat a missing or
+  future-dated timestamp as live, and the threshold trades a stalled writer against a merely slow
+  one. Re-reading the metadata with retries narrows the window but cannot close it.
+- **Convergence needs explicit write modes.** Because the row carries representation data that two
+  writers can legitimately disagree about, publishing needs `Exclusive` and `Displacing` modes and
+  `Superseded`/`Contended` outcomes so a race resolves to exactly one published fragment.
+- **Obliteration ordering is load-bearing and easy to get wrong.** The mark must be taken before the
+  association is deleted; the reverse order lets a put racing the obliteration re-associate the very
+  partition being obliterated. This was introduced as a regression during development and caught by
+  review rather than by tests, which is a fair indication of how legible the ordering is.
+- **A crashed obliteration leaves a mark nothing clears.** The hash stays readable but unwritable,
+  and resolving it requires a separate obliteration work table whose resumer must take over an
+  existing mark explicitly, since the ordinary path returns early when it sees one. That table, if
+  it retains completed items, also reconciles the one residue the chosen option leaves — an
+  obliteration racing a put — so it is one background job rather than two. This gap is accepted
+  rather than closed here.
+
+The result works. It was verified red-green against reproductions of both corruption cases, every
+guard was checked by reverting it, and it carries 96 tests. But it is roughly 2850 added lines
+whose correctness rests on all of the above holding simultaneously, and one of its steps —
+abandonment — is a heuristic by construction.
+
+- Good, because it changes no storage format, needs no migration, and rolls back cleanly.
+- Good, because it fixes the corruption, demonstrably.
+- Good, because it can ship as a rolling deployment with a mixed fleet.
+- Bad, because correctness depends on a multi-step protocol executing correctly across crashes,
+  races and partial failures, indefinitely, including in code not yet written.
+- Bad, because deciding whether an unpublished object is abandoned is a heuristic with no sound
+  resolution.
+- Bad, because it adds S3 requests on contended paths: `HeadObject` to classify, conditional writes
+  that can 412 and retry.
+- Bad, because the crashed-obliteration gap remains open.
+
+### Keep the fragment in `DynamoDB`, with a separate claim record marking the commit point
+
+Write a claim row before uploading and delete it after publishing, so a reader can tell a completed
+write from an interrupted one without guessing from timestamps.
+
+- Good, because it replaces the abandonment heuristic with a fact, closing the one hole the protocol
+  option cannot.
+- Bad, because it adds one `DynamoDB` write before and one delete after every put of new content,
+  on the hottest write path in the server, permanently, to serve an edge case.
+- Bad, because it still leaves two records describing one payload; it makes the window detectable
+  rather than absent.
+
+### Store the fragment in the S3 object body, as ADR-00006 did
+
+- Good, because it gives exactly the same atomicity as the chosen option: one object, written whole.
+- Bad, because every ranged read must offset by 16 bytes, permanently, in every caller.
+- Bad, because a metadata-only read must fetch a byte range and so transfers body bytes, which is
+  the cost that motivated moving the fragment into `DynamoDB`.
+- Bad, because the bucket stops being raw content addressable by hash, which forecloses serving
+  objects directly.
+- Neutral, because ADR-00006 noted it forced an empty sentinel object per association. That no
+  longer applies now associations live in `DynamoDB`.
+
+### Store the fragment as S3 object metadata
+
+One header, `x-amz-meta-lore-fragment: <flags>:<size_payload>:<size_content>` — for example
+`8:4096:16384`. One key rather than one per field, because a key name is spelled out in full on
+every request and every response, so three of them would cost several times what the values do.
+Flags in hex because it is a bit field; the sizes in decimal because they are magnitudes. Plain
+text rather than a packed encoding, so an object's shape is legible from `aws s3api head-object`
+with no lore tooling.
+
+Only flags that describe the payload travel there, on the test of whether they are the same answer
+for every reader of those bytes. `PayloadFragmented`, the compression codec and
+`PayloadRevisionState` pass it and are carried. Obliteration state does not — it changes while the
+bytes do not — and stays in `DynamoDB`. `PayloadStoredDurable` does not, being a fact about which
+store holds the payload, and is derived on read. `PayloadLocalCachePriority` does not either: it is
+a per-machine hint about what one host should keep, so it has no meaning on a globally shared
+object.
+
+- Good, because it has the atomicity of the body preamble with none of its costs: the body stays a
+  pure payload, so no offsets change.
+- Good, because `HeadObject` reads it without transferring a body, so a caller that wants a
+  representation with no payload can have one affordably — unlike a body preamble, which would have
+  to fetch a byte range.
+- Good, because the fragment rides the `GetObject` a payload read was already making, so `get` gets
+  cheaper rather than more expensive.
+- Neutral, because it caps at 2 KB and is US-ASCII. One short text value is far inside both, and the
+  cap is the reason to spend one key rather than three on it.
+- Bad, because a CDN in front of the bucket may strip `x-amz-meta-*`, which would matter if objects
+  were ever served directly.
+
+### Key S3 objects by representation hash rather than content hash
+
+Key each object by the hash of its stored bytes, and have the `DynamoDB` row point at whichever
+representation is current.
+
+- Good, because the object becomes immutable by construction: the key determines the bytes, so no
+  conditional write is needed for any reason.
+- Bad, because a read must consult `DynamoDB` to learn the key before it can start the S3 request,
+  turning two parallel round trips into two sequential ones on the hottest read path.
+- Bad, because unreferenced representations accumulate and require garbage collection across
+  billions of objects.
+- Bad, because obliteration must find and delete every representation of a hash, not one key.
+
+### Normalize every payload to one canonical representation per hash
+
+Recompress on ingest so that hash-to-bytes is a function and all writers produce identical objects.
+
+- Good, because concurrent writers write byte-identical objects, so the race disappears entirely.
+- Good, because the fragment becomes derivable and need not be stored at all.
+- Bad, because it puts recompression on the ingest path, which is CPU the server deliberately avoids
+  by accepting client-compressed payloads.
+- Bad, because it freezes the codec choice: changing it later means rewriting the entire population.
+
+## More Information
+
+The design, its behaviour under interruption and obliteration, the call-count comparison, and the
+migration are set out in the accompanying proposal,
+[Carry fragment metadata on the S3 object](../../proposals/2026-08-03-fragment-metadata-on-the-s3-object.md).
+
+The `DynamoDB` write-protocol option is not hypothetical; it exists as a reviewed implementation
+against the corruption it fixes. If this ADR is rejected, that is the fallback and it should ship.
+
+This decision should be revisited if any of the following changes: objects need to be served
+directly from S3 through a CDN that strips `x-amz-meta-*` headers; a metadata-only query becomes a hot path
+rather than an inspection one; or S3 gains a way to make object metadata a compare-and-set target,
+which would reopen options this ADR closes.
+
+This supersedes [ADR-00006](00006-s3-storage-options-reconsidered.md), which is marked accordingly.
+It agrees with that decision's principle and differs in mechanism: the fragment travels with its
+payload, as object metadata rather than a body preamble.
+
+The move of the fragment into `DynamoDB` between the two was never recorded in its own ADR. It does
+not need one — the reason for it is stated above, and superseding ADR-00006 leaves a single document
+describing where fragment metadata lives, how it got there, and why it is moving back.

--- a/docs/proposals/2026-08-03-fragment-metadata-on-the-s3-object.md
+++ b/docs/proposals/2026-08-03-fragment-metadata-on-the-s3-object.md
@@ -1,0 +1,734 @@
+---
+lep: 2026-08-03-fragment-metadata-on-the-s3-object
+title: Carry fragment metadata on the S3 object
+authors:
+  - Mattias Jansson
+status: Draft
+created: 2026-08-03
+updated: 2026-08-04
+discussion: https://github.com/EpicGames/lore/pull/157
+---
+
+# Carry fragment metadata on the S3 object
+
+## Summary
+
+Store the fragment describing a payload as S3 object metadata on the object holding that payload,
+instead of as a `DynamoDB` record keyed by content hash. In its place a **fragment state table**
+holds lifecycle state alone: the presence of a row means the hash exists, which keeps the existence
+check that cross-partition deduplication depends on a single `GetItem` with no S3 request. Because
+S3 object metadata is part of the object version, a reader always observes the fragment that was
+written with the bytes it is reading, and the two can no longer disagree.
+
+## Motivation
+
+The AWS store keys S3 objects by the *content* hash while the object holds a *representation* of
+that content. Two writers may legitimately hold different valid representations of the same content
+— LZ4 and Zstd of the same bytes — and both address the same S3 key. The fragment describing which
+representation is stored lives in a separate `DynamoDB` record, so the object and the record are
+two independently written things that are required to agree.
+
+They can fail to agree:
+
+1. **Concurrent cross-partition writers.** Two writers upload different representations to the same
+   key and publish different fragments. The interleaving that leaves writer A's fragment beside
+   writer B's payload is permanent and requires no failure.
+2. **A lost metadata write.** A writer replaces the object and then fails to publish its fragment.
+   The published fragment now describes bytes that are gone, and the bytes that are there are
+   described by nothing. A reader cannot use the payload: it decompresses with the codec the
+   fragment names, which is not the codec the bytes are in, and allocates against sizes that are not
+   theirs. The affected partition cannot repair it either, because its own re-put sees a full match
+   and does nothing.
+
+The result in both cases is the same: a stored payload that no reader can interpret, because the
+fragment it is described by is not about it. It surfaces as an internal size mismatch or a
+decompression failure, whichever the mismatched fields hit first. No amount of retrying fixes it —
+the writers involved all believe they succeeded — and nothing detects it until a read fails.
+
+Separately, the same coupling costs bandwidth that should not be spent. A put resolves to either a
+full match on the address-partition-context triplet or an upload — `lookup` short-circuits to
+`MatchNone` when a full match is requested, so the `MatchPartition` and `MatchHash` arms of `put`
+are unreachable. Content already durable in one partition is therefore uploaded again when another
+partition needs it, even though the server has already established that the caller holds it.
+
+What is needed is threefold:
+
+- A stored payload and the fragment describing it must be unable to disagree, under any
+  interleaving of concurrent writers and any partial failure.
+- Whether a hash exists must stay answerable without an S3 request. Deduplication that had to ask
+  S3 would defeat its own purpose.
+- Content already stored must be deduplicable across partitions and contexts, without a caller
+  being able to claim it on the strength of a hash alone.
+
+## Relationship to ADR-00006
+
+This is not a new idea. [ADR-00006](../developing/decisions/00006-s3-storage-options-reconsidered.md)
+decided in May 2024 to store the fragment together with its payload, and gave as its reason exactly
+the property this proposal is after: *"the fragment metadata is stored once, meaning there are no
+concerns about it getting out of sync with the stored payload."* It rejected the alternative of
+duplicating metadata partly because that would risk *"client errors if the metadata flags don't
+match what's stored in the payload object"* — which is the failure now occurring in production.
+
+**ADR-00006 is still accepted and has never been superseded**, and no decision record covers the
+change away from it:
+
+- [ADR-00004](../developing/decisions/00004-s3-storage-options.md) is marked superseded by 00006.
+- [ADR-00008](../developing/decisions/00008-aws-store-fragment-associations.md) introduced
+  `DynamoDB`, but only for fragment/repository/context **associations**, and only because
+  `ListObjects` was too slow for `query_immutable`. Its table is `hash` + `repository_context`. It
+  says nothing about fragment metadata.
+- No ADR describes a fragment metadata table at all.
+
+The reason is not in the log but is not in doubt either. Per the author of both ADRs: once
+ADR-00008 put associations in `DynamoDB`, a query could answer *whether* a fragment existed without
+touching S3, but reading *what* it was still meant an S3 request. Moving the fragment into
+`DynamoDB` as well removed that request. **S3 object metadata was not considered.**
+
+That reasoning was sound for the options on the table, and this proposal does not dispute the goal —
+it disputes that the goal requires the trade. The choice was framed as fragment-on-the-object-body,
+which costs an S3 request to read metadata alone, versus fragment-in-`DynamoDB`, which costs the
+guarantee that it matches the payload. Object metadata is not on that axis:
+
+- `get` — the fragment rides the `GetObject` already being made for the payload. No extra request,
+  and one fewer `DynamoDB` read than today.
+- `put` — reads no fragment at all, only the state row and the association. No extra request.
+- `query` — answered from the state row and the association, in parallel, with no S3 request. It is
+  called once per fragment stored on the ingress path, so this is the one place where paying an S3
+  request would have mattered most, and it does not.
+
+So the S3 traffic ADR-00008's follow-on was avoiding is still avoided everywhere it mattered, while
+the atomicity ADR-00006 wanted comes back. The mechanism differs from ADR-00006 in a second way that
+also helps: keeping the fragment out of the body means no offset arithmetic on ranged reads. Its
+noted downside — an empty sentinel object per association — is moot now that associations live in
+`DynamoDB`.
+
+[ADR-00018](../developing/decisions/00018-fragment-metadata-on-s3-objects.md) accompanies this
+proposal and supersedes ADR-00006. It carries the intervening history — the move into `DynamoDB` and
+why — so no separate record of that move is needed.
+
+## Goals / Non-Goals
+
+### Goals
+
+- Make it structurally impossible for a stored payload and the fragment describing it to disagree.
+- Keep "does this hash exist" answerable without an S3 request, so cross-partition deduplication
+  stays a `DynamoDB`-only decision on the hot path.
+- Need no S3 or `DynamoDB` feature beyond the plainest ones — no conditional S3 write, no ETag
+  compare-and-set, no object-age heuristic, no transaction — so that correctness does not rest on
+  those mechanisms behaving as assumed under contention.
+- Reduce the `DynamoDB` reads on `get`.
+
+### Non-Goals
+
+- Changing the S3 key scheme. Objects remain keyed by the bare hex content hash.
+- Changing the association table. It keeps recording which partition references which hash.
+- Preventing re-upload over an obliteration tombstone. The tombstone is retained so a future policy
+  can do this; this proposal deliberately allows the re-upload.
+- Detecting hash collisions in the store. That belongs at lore server ingress, which verifies
+  payload hashes on every ingest path.
+- Reclaiming orphaned payloads. See [Garbage collection](#garbage-collection).
+
+## Proposed Design
+
+### Where each piece of information lives
+
+| | Home | Why |
+| --- | --- | --- |
+| Payload bytes | S3 object body | — |
+| `flags` (payload bits), `size_payload`, `size_content` | S3 object metadata on that object | Describes the bytes; must never be separable from them |
+| Existence, obliteration state | `DynamoDB` fragment state table, PK `hash` | Must be answerable without S3; mutable, so cannot live on an immutable object |
+| Partition references | `DynamoDB` fragments table, PK `hash`, SK `repository‖context` | Access control and obliteration |
+
+The flags word is split by an explicit allowlist, `PAYLOAD_FLAGS`:
+
+- **On the object** — `PayloadFragmented`, the `PayloadCompressed` codec group and
+  `PayloadRevisionState`. These describe what the payload *is*, and are the same answer for every
+  reader of those bytes.
+- **In `DynamoDB`** — `PayloadObliterating`, `PayloadObliterated`. Lifecycle state that changes while
+  the bytes do not.
+- **Derived on read** — `PayloadStoredDurable`. This is a fact about *which store* holds the payload,
+  not about the payload. The AWS store now sets it on every fragment it returns rather than
+  persisting whatever a client sent, so the claim cannot outlive the object.
+- **Not carried on the object** — `PayloadLocalCachePriority`. A per-machine caching hint: it says
+  what one host should keep, which is not a property of the content and is not the same answer for
+  every reader, so it has no business on a globally shared object.
+- **Not persisted** — `PayloadDoNotReplicate`, already stripped by
+  `sanitise_fragment_behavior_flags`.
+
+The fragment is written as **one** header, `x-amz-meta-lore-fragment`, holding
+`<flags>:<size_payload>:<size_content>`:
+
+```text
+x-amz-meta-lore-fragment: 8:4096:16384
+```
+
+One key rather than one per field, because a key name is spelled out in full on every request and
+every response — three of them would cost several times what the values do, on every object and
+every read. Flags in hex because it is a bit field and hex is how bits are read; the sizes in
+decimal because they are magnitudes. Plain text rather than a packed encoding, so an object's shape
+stays legible from `aws s3api head-object` with no lore tooling.
+
+### Why this cannot tear
+
+S3 object metadata is part of the object version. It cannot be modified without rewriting the object,
+and a `GetObject` returns headers and body from the same version. A full-object PUT is atomic: a
+reader observes the whole previous object or the whole new one, never a mix.
+
+Therefore two writers racing with different representations both write complete, self-describing
+objects, and whichever lands last is read back whole. Last-writer-wins is *safe*, which is what
+removes the need for a protocol: no `If-None-Match`, no ETag compare-and-set, no abandonment
+heuristic, no reclaim path, no convergence.
+
+### Put
+
+```text
+              ┌──────────────────────────────────────────┐
+  probe       │  GetItem association  ‖  GetItem state   │   two DynamoDB reads, in parallel
+              └──────────────────────────────────────────┘
+                                 │
+        ┌────────────────────────┼────────────────────────┬─────────────────────┐
+        │                        │                        │                     │
+   state = Obliterating     row present,             row present,          no row, or
+        │                   associated               not associated        Obliterated
+        │                        │                        │                     │
+   SLOWDOWN                     OK                 payload supplied?        payload supplied?
+   (transient mark)          (nothing to do)        │           │            │         │
+                                                   yes         no           yes        no
+                                                    │           │            │         │
+                                            PutItem assoc.   ERROR      upload path   ERROR
+                                            (no S3 at all)  (payload    (below)      (payload
+                                                            required)               required)
+```
+
+The upload path:
+
+```text
+  PutObject (unconditional, metadata attached)
+        │
+  PutItem state row, conditional on attribute_not_exists(hash)
+        │
+        ├── created ──────────────────► continue
+        ├── exists, state = Stored ───► continue          (already published; nothing to reconcile)
+        ├── exists, state = Obliterating ─► SLOWDOWN      (leave the object unassociated)
+        └── exists, state = Obliterated ──► CAS Obliterated → Stored, revive
+                                             (lost the CAS? already Stored is success,
+                                              anything else is SLOWDOWN)
+        │
+  PutItem association
+```
+
+The conditional create has exactly one job: to avoid erasing an obliteration's mark. On the ordinary
+"already stored" path the condition fails, and that is fine — the row holds no representation, so
+the existing row is already correct and there is nothing to merge. Publishing is an idempotent
+set-a-bit.
+
+Reviving a tombstone tolerates losing its compare-and-set. Another writer reviving the same hash
+produced exactly the state this one wanted, and this one's bytes are already uploaded, so failing
+there would fail a put whose work is done. Only finding the hash back under an obliteration is a
+reason to stop, and that is a back-off because the mark is transient. The tolerance is confined to
+revival rather than put into the shared compare-and-set, which is also how an obliteration takes its
+mark — accepting "already in the target state" there would let two obliterations both believe they
+hold it.
+
+`force_write` skips the probe and goes straight to the upload path, which is now trivially safe.
+
+### Put under interruption
+
+Every step is individually idempotent:
+
+- **`PutObject`** — same key, same bytes, same metadata produces an identical object. A different
+  representation produces a different but equally valid object. S3 never leaves a partial one.
+- **State row create** — either it creates the row or it fails and reads back what is there. Both
+  outcomes end at `Stored`.
+- **Association write** — writing the same item again is a no-op.
+
+So the flow needs no compensation on failure and no journal of what it was doing. Retrying a put
+from the beginning converges from any interruption:
+
+| Interrupted after | Left behind | What a retry does | Residue |
+| --- | --- | --- | --- |
+| probe | nothing | full put | none |
+| `PutObject` | object, no row, no association | hash reads as unknown, so it re-uploads and publishes | none — the object is overwritten |
+| state row | object + row, no association | probe sees `Stored` + not associated + payload, so it writes the association only | none |
+| association | complete | returns `OK` | none |
+
+**The ordering rule is load-bearing, not cosmetic.** Writing the state row before the object would
+leave, on interruption, a hash that claims to exist with no bytes behind it — and that state is
+*unrepairable by retry*. The next put probes, sees the row present, takes the "already stored"
+branch, and writes only the association. It never uploads. Every reader of that hash then gets
+not-found for content the store believes it holds, permanently. Object-before-row inverts this: the
+leftover is a row-less object, which is invisible to every path and is overwritten by the next
+upload.
+
+The one case ordering cannot address is losing the object *after* the row exists — S3 durability
+loss, or the obliteration race below. That is the pre-existing "published but missing payload"
+condition. It is detectable (a `GetObject` not-found on a hash whose row says `Stored`) and warrants
+a counter and an alarm, since the affected partition cannot repair it by re-putting.
+
+**Orphaned objects.** Two paths leave an object nothing references: an interruption between upload
+and row, and a put that uploads and then backs off because an obliteration holds the hash. Neither
+is corruption — the object is well-formed and unreachable — but nothing reclaims it. This is the
+same gap as [Garbage collection](#garbage-collection).
+
+### Get
+
+```text
+  GetItem association  ‖  GetObject       one DynamoDB read, one S3 read, in parallel
+        │                     │
+   access check         body + metadata
+                              │
+                       fragment ← metadata      (same object version as the body)
+                              │
+                       size_payload == body.len() ?  ── no ──► ERROR (object damaged)
+```
+
+There is no `DynamoDB` metadata read on this path at all — one fewer round trip than today. The size
+check is now a self-consistency check on a single object rather than a comparison between two
+stores; it can only fail because the object itself is damaged, never because two records drifted.
+
+An obliterated hash needs no special case: obliteration deletes the object, so the `GetObject`
+returns not-found.
+
+### Query
+
+```text
+  GetItem association  ‖  GetItem state          no S3 request, ever
+        │                      │
+   match_made            Stored ──► match, PayloadStoredDurable derived
+                         obliteration ──► miss
+                         no row ──► miss
+```
+
+**Query must not reach S3.** `query_match_full` in `lore-storage`'s write path calls it once per
+fragment stored, and ADR-00008 identifies `query_immutable` as the most frequently accessed code
+path in the server. A `HeadObject` here would put an S3 request behind every already-present fragment
+of a push — the exact load this proposal exists to remove. The two probe reads run in parallel and
+answer on their own.
+
+The consequence is that `query` reports **whether a payload is there and durable, not what
+representation is stored**: the returned fragment carries the derived `PayloadStoredDurable` and no
+sizes. That is everything the ingress path reads — `stored_flags` looks only at flags — and it means
+an object predating the cut-over needs no fallback either, since `query` never wants its
+representation.
+
+Two callers are left owing something by this, and neither is resolved here:
+
+- Reading a representation without its payload needs its own way to ask, which is where the
+  `HeadObject` belongs — one request, on the one path that genuinely wants one. **Implemented** as
+  `ImmutableStore::get_metadata(partition, address)`, defaulting to a `MatchFull` `query` so every
+  store whose `query` already reports the representation is unaffected, and overridden by the AWS
+  store to add the `HeadObject`. Two callers switched to it: the `lore_storage_get_metadata`
+  command, and the server side of the remote metadata op in
+  `lore-server/src/protocol/storage/get.rs` — worth noting, because that second one means a remote
+  client's `GetMetadata` would otherwise have received sizeless fragments over the wire, not just a
+  local inspection command. Covered by `get_metadata_returns_the_representation_that_was_stored`,
+  `get_metadata_reads_a_preexisting_object_from_the_fragment_metadata_table` and
+  `get_metadata_reports_a_miss_for_an_unknown_address`.
+- `store_fragment` returned `query.fragment` as `StoreResult.fragment` on the deduplicated path,
+  which under this design would have reported zeroed sizes. **Fixed**: it now reports the caller's
+  own fragment, with the storage-status flags taken from the query. That split is the correct one
+  either way. Both fragments describe the same content — the address matched on its hash — so they
+  agree on `size_content`, and where they differ it is only over which representation happens to be
+  stored, which is not what the caller asked. Storage status is the opposite: it is the store's
+  answer and the caller cannot know it, which is the entire point of the short circuit.
+
+### Obliterate
+
+```text
+  read state ── absent, or already an obliteration ──► OK (idempotent)
+        │
+  CAS state Stored → Obliterating          take the mark, before touching the association
+        │
+  DeleteItem association                   ← the compliance obligation is discharged here
+        │
+  drain: wait max(dynamodb timeout, 100ms) ← let an in-flight put land its association
+        │
+  count associations for the hash
+        │
+        ├── any remain ──► CAS Obliterating → Stored, done  (payload survives; hash stays writable)
+        │
+        └── none ──► obliterate sub-fragments (if fragmented)
+                     DeleteObject
+                     CAS Obliterating → Obliterated         (tombstone)
+```
+
+The mark is taken *before* the association is deleted. The other order would let a put racing the
+obliteration re-associate the very partition being obliterated.
+
+Sub-fragment recursion moved after the reference count, so it is skipped entirely when other
+partitions still hold references. The parent payload is still present at that point, so its
+reference list can be read.
+
+#### Put racing obliteration
+
+Because the mark is taken first, the two flows can interleave in exactly three ways:
+
+1. **Put probes before the mark, uploads after it.** Its conditional create fails, it reads back
+   `Obliterating`, and it returns `SLOWDOWN` *without writing an association*. Compliance is
+   unaffected. The uploaded object is left unreferenced, and if the obliteration has already deleted
+   the payload, that upload resurrects it as an orphan.
+2. **Put probes after the mark.** It sees `Obliterating` at the probe and backs off having done
+   nothing.
+3. **Put passed its probe and races the association delete.** This is what the drain is for. If the
+   put's association lands before the count, it is counted, the mark is released, and the payload
+   survives — correct. If it lands after the count, the obliteration deletes the payload and
+   tombstones the hash, leaving that partition with an association to a hash whose object is gone.
+
+Case 3's residue is a narrowed window, not a closed one, and it is worth being explicit that no
+drain length closes it — nothing crashed, so nothing can be resumed; two correct operations simply
+interleaved badly. It is self-healing on the next put from that partition, which sees `Obliterated`,
+falls through to the upload path, revives the hash and re-associates. Reads before that fail as
+not-found, and the [obliteration work table](#the-obliteration-work-table) is what finds and repairs
+it without waiting for someone to notice.
+
+#### Obliteration under interruption
+
+The compliance obligation — removing the obliterated partition's reference — is discharged by a
+single atomic `DeleteItem`. Every step after it is cleanup. An obliteration interrupted at any point
+past that `DeleteItem` has therefore already met the requirement, and re-running it is safe: the
+state read at the top returns early for a hash already marked or tombstoned.
+
+Interruption *before* the `DeleteItem` but after the mark is the one bad case: the mark is left set
+with nothing to clear it. The hash stays readable — the object is untouched until after the count —
+but becomes unwritable, since every put now returns `SLOWDOWN`. This is a known gap, and it is the
+first of the three duties of the [obliteration work table](#the-obliteration-work-table) below. Note
+that resuming an obliteration requires taking over an existing mark explicitly, because `obliterate`
+deliberately returns early when it finds one.
+
+### The obliteration work table
+
+Recording each obliteration as a work item, and **keeping the item after the obliteration completes**,
+gives one background job three duties on one schedule:
+
+| Item | State found | Duty |
+| --- | --- | --- |
+| incomplete, stale | a mark with nothing advancing it | **resume** — the crashed-obliteration case above |
+| complete | `Obliterated` **and** associations remain | **reconcile** — the drain race in case 3 |
+| complete | no associations remain | drop the item |
+
+The reconcile predicate is exact rather than heuristic. A successful re-put moves the state back to
+`Stored` before it associates, so a tombstone coexisting with a reference means no revival happened
+and something is pointing at a payload that was destroyed. Detecting it costs one association count
+and one state read per completed item.
+
+It runs on a longer timer than the resume pass, and that delay is load-bearing rather than merely
+cautious: a legitimate revival is upload, then advance state, then associate, so sampling mid-sequence
+could momentarily observe `Obliterated` alongside the racing put's association. Waiting well past any
+in-flight put makes the observation stable.
+
+The reconcile pass can repair rather than only report, and this is the one repair in the design that
+is unconditionally safe: the payload is *provably* gone, because only the obliteration that wrote
+that state could have deleted it, so the association references nothing and removing it destroys
+nothing. It is also the fix that matters. The tombstone alone does not block recovery — a put over
+`Obliterated` already takes the upload path — but the dangling association makes `query` report a
+match, so the client believes it holds the content and never re-sends it. Clearing the association
+makes the next query a miss and the content comes back.
+
+Retention of completed items is therefore the mechanism, not bookkeeping: they must outlive the
+reconcile window.
+
+This is bounded work, which is what makes it affordable. It walks obliterations, not objects.
+
+### When the payload is gone but the reference remains
+
+This is the one failure the design does not remove, and it is worth stating plainly because it is
+both silent and self-perpetuating.
+
+**The condition.** A partition still references a hash and S3 no longer has the object. It arises
+from an obliteration interrupted between `DeleteObject` and the tombstone; from case 3 above, where
+a racing put's association lands after the reference count reached zero; from an out-of-band
+deletion; or from an S3 durability event.
+
+**Why it is silent.** `get` maps `NoSuchKey` to `AddressNotFound`, which is exactly what a hash that
+was never stored returns. Nothing separates "we never had this" from "we had this and lost it", so
+the loss surfaces as an ordinary miss and is invisible in aggregate.
+
+**Why it is self-perpetuating.** The obvious repair — have the client send the content again — is
+precisely the path deduplication short-circuits. A re-put from the same partition probes, finds the
+state row and its own association, and returns `OK` without uploading. A put from a *different*
+partition holding the payload takes the deduplicate branch and writes an association, attaching a
+second partition to a hash with no bytes. Re-putting therefore does not repair it, and can spread
+it.
+
+This is not new. The same shape exists on `main`: a published metadata row with no object, and a
+re-put that sees `MatchFull` and does nothing.
+
+**What can be done**, in increasing order of commitment:
+
+1. **Detect it.** An association that survived the access check, plus a not-found from S3, *is* the
+   condition — the read holds both facts already and needs no extra request to notice. S3 not-found
+   is definitive rather than transient, so there is nothing ambiguous to resolve. A counter and an
+   `error!` turn a silent miss into an alarmable one. *Implemented, on both reads that can observe
+   it: `get` and `get_metadata`. Doing it on only one would have made detection depend on which call
+   a client happened to make, and `get_metadata` is the cheaper one. The counter is
+   `store.immutable.missing_payload`.*
+
+   This is also why a failed `DynamoDB` read must never be reported as not-found. Repair acts on
+   that signal, so mapping a throttle to a miss would let overload be recorded as data loss and
+   clear a state row. See `is_dynamodb_overloaded`, which sorts timeouts, dispatch failures,
+   429s, 5xxs and throttling codes from real errors. Covered by
+   `a_failed_fragment_metadata_read_does_not_clear_the_state_row`.
+2. **Make it repairable, by clearing the state row on detection.** With the row gone the next put
+   finds no state, takes the upload path, and republishes. This is only safe because the row carries
+   no representation: deleting it discards nothing that the next write does not re-derive, which
+   would not have been true when the row held the fragment. The cost is a write on a read path, so
+   it wants to be a deliberate choice rather than a side effect. *Implemented, and skipped when an
+   obliteration holds the mark: removing a mark mid-obliteration would let a put republish
+   underneath it. Covered by `a_read_of_a_lost_payload_clears_its_state_so_a_put_can_restore_it` and
+   `a_read_of_a_lost_payload_leaves_an_obliteration_mark_alone`, and
+   `a_failed_repair_still_reports_the_lost_payload_as_not_found` for the best-effort part.*
+3. **Verify on the deduplicate branch.** A `HeadObject` before associating would stop the spread,
+   and is rejected — it puts an S3 request on the hot path to defend against a rare condition, which
+   is the trade this proposal exists to avoid.
+4. **Repair out of band.** For losses caused by an obliteration racing a put, the
+   [obliteration work table](#the-obliteration-work-table) finds every instance rather than only the
+   ones somebody happened to read, and does it by walking obliterations rather than objects. For
+   losses with any other cause — an S3 durability event, an out-of-band delete — nothing bounds the
+   search but the population itself, so that needs a sweep over S3 Inventory, which is the same
+   machinery as [Garbage collection](#garbage-collection) walked in the opposite direction and
+   belongs with it.
+
+1 and 2 are implemented; 4 is left to the obliteration work table and the GC sweeper. Both repair steps are best effort — a failure
+to clear the row leaves the hash exactly as it already was, and the alarm has been raised regardless.
+One residue remains: an obliteration that takes the mark between the state read and the delete has
+its mark cleared, so its later compare-and-set fails and logs. That is narrow, and it loses cleanup
+rather than corrupting anything.
+
+### Garbage collection
+
+Compliance requires only that the obliterated partition's reference is gone, which the
+`DeleteItem` above achieves. Deleting the payload is therefore garbage collection, not compliance —
+it is only correct to do when the reference count reaches zero.
+
+This proposal keeps that reclamation inline, as it is today. It is worth separating later: a
+background sweeper over zero-reference hashes can afford to be slow and conservative in a way that a
+synchronous obliterate cannot, and it shares a schedule with the
+[obliteration work table](#the-obliteration-work-table).
+
+### Call-count comparison
+
+| Operation | `main` | This proposal |
+| --- | --- | --- |
+| Put, new content | 1–3 DDB reads, 1 S3 PUT, 2 DDB writes | 2 DDB reads (parallel), 1 S3 PUT, 2 DDB writes |
+| Put, already associated | 1–3 DDB reads | 2 DDB reads (parallel) |
+| Put, dedup across partitions | not supported — re-uploads | 2 DDB reads, 1 DDB write, **no S3** |
+| Get | 2 DDB reads, 1 S3 GET | **1 DDB read**, 1 S3 GET (parallel) |
+| Query (per fragment, ingress) | 2 DDB reads | 2 DDB reads (parallel), **no S3** |
+| Copy | 2 DDB reads, 1 DDB write | **1 DDB read**, 1 DDB write |
+
+Cross-partition deduplication is new here, and costs no additional request: it reuses the same two
+probe reads the put already makes.
+
+## Compatibility
+
+- **Wire format** — N/A. `Fragment` is unchanged on the wire and in the public API.
+- **Client/server protocols** — N/A.
+- **On-disk format** — Changed for the AWS store. S3 objects gain fragment metadata, and the rows keyed
+  by hash change from a flattened `flags`/`size_payload`/`size_content` fragment to a single `state`
+  attribute. The key schema is unchanged, so no table needs to be recreated — the fragment state
+  table can be, and by default is, the same physical table that held fragment metadata, with the two
+  row shapes distinguished by shape. See [Migration Plan](#migration-plan).
+- **CLI and public API** — Which `DynamoDB` tables are used stays operator configuration and none of
+  those values change; the tables keep their identities and only what they hold differs. Two keys:
+  - `dynamodb_fragment_metadata_table`, optional, naming the table to read fragments from for
+    objects predating the cut-over. It **accepts `dynamodb_metadata_table` as an alias**, because
+    that is already what an existing configuration points at — a table holding fragment metadata,
+    which is exactly what it is read for afterwards.
+  - `dynamodb_fragment_state_table`, **required, and deliberately without an alias**. The role is
+    new, so which table serves it is a decision an operator makes rather than inherits. A
+    configuration that names neither fails to start rather than silently reusing whichever table
+    used to hold fragment metadata.
+
+  So an existing configuration must add one line, and adds it knowingly. In a migrating deployment
+  both keys normally name the same table, since the two row shapes share it and are told apart by
+  shape.
+
+## Non-Functional Considerations
+
+- **Concurrency** — The central claim. Concurrent writers with different representations converge on
+  whichever object landed last, always coherent, with no coordination. The only remaining ordered
+  step is object-before-row on the put path, and the only remaining compare-and-set is on the
+  obliteration state, which holds a single attribute. Covered by
+  `concurrent_writers_cannot_tear_the_fragment_from_its_payload`, which runs four writers with four
+  different representations over 64 randomized rounds and asserts the stored fragment describes the
+  stored bytes. The put flow is idempotent step by step, so it needs no journal and no compensation;
+  see [Put under interruption](#put-under-interruption). The one place that still needs a timing
+  window is the obliteration drain, and its residual race is self-healing rather than corrupting.
+- **Memory** — Unchanged. Metadata travels in HTTP headers, not in the payload buffer, so the read
+  path allocates exactly the payload.
+- **Statelessness** — Improved. `PayloadStoredDurable` is derived per store rather than persisted,
+  so no server writes down a durability claim another server will serve.
+- **Determinism** — Deduplication decisions are a pure function of the two probed rows.
+
+## Migration Plan
+
+The change is not backward compatible at the storage layer, and the population is large enough that
+rewriting it is not an option: objects written before this change carry no fragment metadata, and their
+fragments live in table rows this code no longer reads.
+
+### Prerequisite: no prefix-era objects
+
+lore once stored the fragment as a 16-byte `Fragment` prefix on the object body — the layout
+[ADR-00006](../developing/decisions/00006-s3-storage-options-reconsidered.md) chose — and `main`
+still carries a compatibility branch for it in `read_payload`.
+
+**This plan requires that no such objects remain in any live deployment**, which is the case: the
+prefix layout has no surviving deployments. That is a prerequisite rather than a conclusion, and it
+is what reduces the migration to two eras instead of three. It must be re-checked before Phase 1
+ships, because a reader under this plan interprets a bare object body as the whole payload — a
+prefix-era object would silently yield the payload with 16 bytes of `Fragment` glued to its front,
+sized wrong and failing to decompress.
+
+Two consequences follow. The dead compatibility branch in `read_payload` should simply be deleted
+rather than repaired — it never worked anyway, since it captures `buffer_size` before stripping the
+prefix and then compares the unstripped length against `size_payload`, so it always returns a size
+mismatch. And no phase below needs a third branch.
+
+Both remaining eras are therefore:
+
+1. **Table era** (current `main`) — bare object body, fragment in the metadata table row.
+2. **Object-metadata era** (this proposal) — bare object body, fragment in the object's user
+   metadata, `state` in the row.
+
+### Prerequisite: no mixed fleet
+
+**The rollout is a full stop followed by a full start.** Every server running the current code is
+taken down before any server running the new code comes up; the two versions are never alive
+together.
+
+This is what collapses the migration to a single release. The usual dual-read-then-dual-write
+staging exists only to keep a mixed fleet mutually intelligible: old servers must be able to read
+what new servers write, which forces new servers to keep writing the fragment to the table row, and
+that in turn means still publishing two records — so the tearing guarantee would not arrive until
+the final phase. With no old server alive to satisfy, none of that is needed. **Nothing is ever
+written to the old row shape, and the tearing guarantee holds from the first write after start-up.**
+
+The cost is the downtime and the loss of a rolling rollback: see [Rollback](#rollback).
+
+### Phase 1 — Cut over
+
+Deploy this proposal's code to the stopped fleet and start it. New content is written with the
+fragment on the object and `state` in the row.
+
+The existing population is not rewritten, so this single release must read both eras. Two pieces of
+read compatibility are required, and both are cheap:
+
+- **Fragment.** Two functions parse a fragment — `load`, reached from `get` and from obliteration's
+  sub-fragment recursion, and `head_fragment`, reached from `query`. The fallback belongs inside
+  those two, and every caller inherits it. `put` reads no fragment, only the state row and the
+  association, and `copy` resolves through `lookup` alone, so neither needs anything.
+
+  The trigger is `ObjectMetadataError::Absent` specifically — the object came back intact and
+  carries no lore metadata, which is exactly "this object predates the cut-over". On `Absent`, read
+  the fragment from the table row, which is still present and still authoritative for that object.
+  `Malformed` must **not** fall back: metadata that is present but unparsable means a damaged
+  object, and describing it from a table row would reintroduce the very mismatch this proposal
+  removes. A missing object stays a plain `AddressNotFound`.
+
+  The discriminator costs no extra request — it is the absence of headers on a response already
+  received. The fallback itself adds one sequential `GetItem` on a legacy `get`: the same three
+  requests `main` makes, serialized rather than parallel, and only for pre-cut-over objects.
+  Issuing that read speculatively in parallel would restore the latency at the price of a
+  `DynamoDB` read on every `get` for the whole transition, which is the wrong trade.
+
+  **The fallback is gated on configuration**, by the new optional
+  `dynamodb_fragment_metadata_table` setting. A deployment that has stored objects the old way
+  sets it — normally to the same value as `fragment_state_table_name`, since both row shapes live in that
+  table and are told apart by shape. A deployment created after the cut-over leaves it unset, and
+  then never issues the fallback read at all: it has declared that no object without metadata was
+  ever written, so one turning up is damaged rather than old, and is reported as such instead of
+  being described from a row that cannot be about it. The setting is also the migration's own
+  end-state marker — once a backfill completes, removing it retires the fallback.
+
+  *Implemented, and covered by `get_falls_back_to_the_legacy_row_for_an_object_with_no_metadata`,
+  `query_matches_a_preexisting_object_without_reading_s3`,
+  `get_refuses_an_object_with_no_metadata_when_no_legacy_table_is_configured` and
+  `get_does_not_fall_back_for_an_object_with_damaged_metadata`.*
+- **State.** None. The fragment state table is its own table and starts empty, so nothing reads a
+  table-era row as state and no tolerance is needed for their shape. A tombstone in the old table is
+  likewise invisible, which is only acceptable because no obliterated fragment exists there — if one
+  ever did, its hash would read as absent and become re-uploadable.
+
+**Nothing is migrated ahead of time; the population migrates itself as it is used.** The fragment
+state table starts empty and is its own table, so a hash stored before the cut-over has no state row
+and the put probe finds nothing. That is the intended path, not a gap: the put takes the upload
+branch, writes the object with its own metadata, creates the state row as `Stored`, and associates.
+The hash is fully migrated from then on, and every later put deduplicates against it.
+
+So migration is lazy and driven by traffic. Hot content converts on first write after cut-over; cold
+content converts whenever it is next written, or never — and never is fine, because the fallback
+read keeps it readable for as long as the fragment metadata table is configured. There is no
+backfill job, no window to coordinate, and no ordering requirement between deployment and data.
+
+The cost is bandwidth: content that is already durable is uploaded once more, the first time a
+client puts it after the cut-over. That is bounded, it happens at most once per hash, and it buys a
+self-describing object.
+
+### Phase 2 — Backfill (optional)
+
+The fallback can remain forever at the cost of carrying the dual-read branch. To retire it, backfill
+object metadata for the existing population.
+
+`CopyObject` with `MetadataDirective=REPLACE` rewrites an object's metadata without transferring the
+body through the caller, taking the fragment from the table-era row. It is a per-object S3 request
+against billions of objects, so it should be driven from an S3 Inventory manifest as a rate-limited
+background job, and it is only worth doing if the dual-read branch proves to be a real burden.
+
+An important interaction: `CopyObject` replaces the object version, so a backfill racing a
+concurrent put could reinstate an older representation. Backfill must therefore either take the
+obliteration-style mark for the hash, or condition the copy on the source ETag it read.
+
+### Rollback
+
+Collapsing the rollout buys the tearing guarantee immediately and pays for it here: **there is no
+clean rollback once the fleet has served writes.** Content written after cut-over is described only
+on its object, so the previous build — which reads the fragment exclusively from the table row —
+cannot read any of it. Reverting would strand every object written since start-up.
+
+Two options, to be decided before the cut-over rather than during an incident:
+
+- **Roll forward only.** Accept that the previous build is not a rollback target once writes begin,
+  and treat any defect as fix-forward. This is the simpler position and is defensible given the
+  narrow blast radius: the storage-layer change is confined to `lore-aws`, and the pre-cut-over
+  population stays readable throughout.
+- **Prepare a rollback build.** Keep a branch of the current code carrying only the dual-read
+  fragment fallback. It writes the old shape but reads both, so it can be deployed over a cut-over
+  fleet without stranding anything. This costs one extra build to maintain and validate, and it must
+  exist *before* the cut-over to be worth anything.
+
+Either way the window is bounded by how long the fleet serves writes before the change is trusted,
+so a short soak with writes disabled — reads only, exercising the dual-read path against the
+existing population — is worth doing first.
+
+## Security Considerations
+
+Cross-partition payload deduplication remains gated on the caller supplying the bytes. A caller that
+presents only a hash is refused (`Payload buffer required`) even when the payload is already
+durable, because a hash on its own is not evidence the caller holds the content; treating it as such
+would let any known hash be attached to a partition that never had it. This is a property of the
+deduplication mechanism and cannot be enforced at ingress, which does not know whether the upload
+will be skipped. It is covered by
+`put_without_a_payload_may_not_claim_stored_content`.
+
+Deriving `PayloadStoredDurable` rather than persisting it closes a smaller gap: a persisted
+durability flag could previously be supplied by a client and would survive the object it described.
+
+Obliteration's compliance obligation — removing the obliterated partition's reference — is
+discharged by a single `DeleteItem` that no longer depends on any subsequent step succeeding.
+
+S3 object metadata is not covered by the object ETag, so it cannot be used as a compare-and-set
+target. Nothing in this design does so.
+
+## Resolved
+
+- **Which flags travel on the object.** `PayloadRevisionState` does: it says what the payload *is*,
+  which is the same answer for every reader of those bytes. `PayloadLocalCachePriority` does not: it
+  is a per-machine hint about what one host should keep, so it has no meaning on a globally shared
+  object.
+- **The two `DynamoDB` tables stay separate.** Merging them — `PK=hash, SK=""` for state and
+  `SK=repository‖context` for associations — would turn the put probe into one `BatchGetItem`
+  instead of two `GetItem`s. It is rejected because the fragment metadata table's separate
+  existence is doing load-bearing work beyond holding rows: whether it is configured is what selects
+  the read path for objects predating the cut-over. Folding it into the associations table would
+  erase that signal, and would also concentrate state-row traffic onto the same partition key as
+  association traffic for popular hashes.

--- a/lore-aws/src/s3.rs
+++ b/lore-aws/src/s3.rs
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: 2026 Epic Games, Inc.
 // SPDX-License-Identifier: MIT
+use std::collections::HashMap;
 use std::ops::Range;
 use std::time::Duration;
 
@@ -190,12 +191,18 @@ impl S3Impl {
             .map_err(AwsError::AwsSdkError)
     }
 
+    /// Store an object, optionally attaching object metadata carried as `x-amz-meta-*` headers.
+    ///
+    /// Object metadata is part of the object version rather than a separate record, so a reader
+    /// always observes the metadata that was written with the bytes it is reading. Writing the
+    /// two together is what makes them impossible to tear apart.
     #[tracing::instrument(name = "S3Impl::put_object", skip_all)]
     pub async fn put_object<T>(
         &self,
         bucket: &str,
         key: &str,
         body: T,
+        metadata: Option<HashMap<String, String>>,
     ) -> Result<PutObjectOutput, AwsError<SdkError<PutObjectError>>>
     where
         T: Into<Vec<u8>> + 'static,
@@ -204,6 +211,7 @@ impl S3Impl {
             .put_object()
             .bucket(bucket)
             .key(key)
+            .set_metadata(metadata)
             .body(ByteStream::from(Into::<Vec<u8>>::into(body)))
             .send()
             .observe(

--- a/lore-aws/src/store/immutable_store.rs
+++ b/lore-aws/src/store/immutable_store.rs
@@ -6,14 +6,16 @@ use std::fmt::Formatter;
 use std::string::ToString;
 use std::sync::Arc;
 use std::sync::LazyLock;
+use std::time::Duration;
 
 use async_trait::async_trait;
-use aws_sdk_dynamodb::error::SdkError;
 use aws_sdk_dynamodb::operation::put_item::PutItemError;
 use aws_sdk_dynamodb::primitives::Blob;
 use aws_sdk_dynamodb::types::AttributeValue;
 use aws_sdk_dynamodb::types::Select;
 use aws_sdk_s3::operation::get_object::GetObjectError;
+use aws_sdk_s3::operation::head_object::HeadObjectError;
+use aws_smithy_types::error::metadata::ProvideErrorMetadata;
 use bytes::Bytes;
 use bytes::BytesMut;
 use lore_base::error::AddressNotFound;
@@ -44,6 +46,7 @@ use lore_telemetry::timer::TimedResult;
 use lore_telemetry::tracing::fields::ADDRESS;
 use lore_telemetry::tracing::fields::REPOSITORY_ID;
 use opentelemetry::KeyValue;
+use opentelemetry::metrics::Counter;
 use opentelemetry::metrics::Histogram;
 use serde::Deserialize;
 use serde::Serialize;
@@ -65,6 +68,9 @@ use crate::dynamodb::DynamoDbPutCondition;
 use crate::dynamodb::DynamoDbQuery;
 use crate::dynamodb::error::SdkError as DynamoDbSdkError;
 use crate::s3::S3;
+use crate::store::object_metadata::ObjectMetadataError;
+use crate::store::object_metadata::from_object_metadata;
+use crate::store::object_metadata::to_object_metadata;
 
 #[derive(Clone, PartialEq, Serialize, Deserialize)]
 struct FragmentsEntry {
@@ -104,26 +110,86 @@ impl FragmentsEntry {
     }
 }
 
+/// Where a payload is in its lifecycle.
+///
+/// This is the whole of what `DynamoDB` records about a payload. What the payload *is* — its
+/// compression, its sizes — lives on the S3 object itself and is never duplicated here, so the two
+/// cannot disagree. What `DynamoDB` adds is the ability to answer "does this hash exist, and may it
+/// be read" without an S3 request, which is the only reason the row exists at all.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum FragmentState {
+    /// The payload is stored and readable.
+    Stored,
+    /// An obliteration holds this hash. Transient: it is either cleared or advanced to
+    /// [`FragmentState::Obliterated`].
+    Obliterating,
+    /// The payload has been obliterated and its object deleted. A tombstone, kept so the
+    /// difference between "never stored" and "deliberately destroyed" survives.
+    Obliterated,
+}
+
+impl FragmentState {
+    fn from_bits(bits: u32) -> Self {
+        if bits & FragmentFlags::PayloadObliterated == FragmentFlags::PayloadObliterated {
+            Self::Obliterated
+        } else if bits & FragmentFlags::PayloadObliterating == FragmentFlags::PayloadObliterating {
+            Self::Obliterating
+        } else {
+            Self::Stored
+        }
+    }
+
+    fn bits(self) -> u32 {
+        match self {
+            Self::Stored => 0,
+            Self::Obliterating => FragmentFlags::PayloadObliterating.bits(),
+            Self::Obliterated => FragmentFlags::PayloadObliterated.bits(),
+        }
+    }
+
+    fn is_obliteration(self) -> bool {
+        self != Self::Stored
+    }
+}
+
+/// A row in the fragment state table. Presence of the row means the hash exists in some state.
+///
+/// The `state` field is what distinguishes a row written under this model from one written when
+/// fragments were stored in `DynamoDB`: those carry flattened `flags`/`size_payload`/`size_content`
+/// instead. A migration can tell the two apart by shape alone.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-struct FragmentMetadataEntry {
+struct FragmentStateEntry {
     hash: Hash,
     #[serde(skip_serializing_if = "Option::is_none")]
+    state: Option<u32>,
+}
+
+/// A row in the shape written before fragments moved onto the S3 object: the whole fragment,
+/// flattened alongside the hash.
+///
+/// Deserialization only. Nothing writes this shape any more.
+#[derive(Clone, Debug, Deserialize)]
+struct FragmentMetadataEntry {
+    #[allow(dead_code)]
+    hash: Hash,
     #[serde(flatten)]
     fragment: Option<Fragment>,
 }
 
-impl FragmentMetadataEntry {
-    fn new(hash: Hash) -> Self {
+impl FragmentStateEntry {
+    fn key(hash: Hash) -> Self {
+        Self { hash, state: None }
+    }
+
+    fn new(hash: Hash, state: FragmentState) -> Self {
         Self {
             hash,
-            fragment: None,
+            state: Some(state.bits()),
         }
     }
 
-    fn with_fragment(mut self, fragment: Fragment) -> Self {
-        self.fragment = Some(fragment);
-
-        self
+    fn state(&self) -> FragmentState {
+        FragmentState::from_bits(self.state.unwrap_or_default())
     }
 }
 
@@ -162,7 +228,16 @@ impl S3StoreSettings {
 #[derive(Clone, Debug, Deserialize)]
 pub struct DynamoDbImmutableStoreSettings {
     pub fragments_table_name: String,
-    pub metadata_table_name: String,
+    pub fragment_state_table_name: String,
+    /// Table holding fragments written before they moved onto the S3 object, read only when an
+    /// object turns out to carry no metadata of its own.
+    ///
+    /// Set this on a deployment that has stored objects the old way — normally to the same table as
+    /// `fragment_state_table_name`, since both row shapes share it and are told apart by shape. Leaving it
+    /// unset declares that no such object exists, which makes an object carrying no metadata what it
+    /// then is: damaged, rather than merely old.
+    #[serde(default)]
+    pub fragment_metadata_table_name: Option<String>,
     pub endpoint_url: Option<String>,
     pub region: Option<String>,
     pub slow_operation_threshold_millis: u64,
@@ -171,10 +246,11 @@ pub struct DynamoDbImmutableStoreSettings {
 }
 
 impl DynamoDbImmutableStoreSettings {
-    pub fn new(fragments_table_name: String, metadata_table_name: String) -> Self {
+    pub fn new(fragments_table_name: String, fragment_state_table_name: String) -> Self {
         Self {
             fragments_table_name,
-            metadata_table_name,
+            fragment_state_table_name,
+            fragment_metadata_table_name: None,
             endpoint_url: None,
             region: None,
             slow_operation_threshold_millis: u64::MAX,
@@ -184,6 +260,12 @@ impl DynamoDbImmutableStoreSettings {
 
     pub fn with_endpoint(mut self, endpoint_url: String) -> Self {
         self.endpoint_url = Some(endpoint_url);
+        self
+    }
+
+    /// Read fragments for objects predating the move onto the S3 object from `table_name`.
+    pub fn with_fragment_metadata_table(mut self, table_name: String) -> Self {
+        self.fragment_metadata_table_name = Some(table_name);
         self
     }
 }
@@ -295,34 +377,101 @@ impl DynamoDbQuery for FragmentsQuery {
     }
 }
 
+/// Write only if no row exists for this hash yet.
+///
+/// Publishing a payload uses this so that a concurrent obliteration's mark cannot be erased by a
+/// racing writer: the writer's create loses, it re-reads the row, and it sees the mark.
 #[derive(Debug, PartialEq)]
-struct UpdateMetadataCondition(Fragment);
+struct RowAbsent;
 
-impl DynamoDbPutCondition for UpdateMetadataCondition {
+impl DynamoDbPutCondition for RowAbsent {
     fn into_parts(self) -> ConditionParts {
         ConditionParts {
-            condition_expression: "#flags = :flags AND #size_payload = :size_payload AND #size_content = :size_content".to_string(),
-            expression_names: HashMap::from([
-                ("#flags".to_string(), "flags".to_string()),
-                ("#size_payload".to_string(), "size_payload".to_string()),
-                ("#size_content".to_string(), "size_content".to_string()),
-            ]),
-            expression_values: HashMap::from([
-                (
-                    ":flags".to_string(),
-                    AttributeValue::N(self.0.flags.to_string()),
-                ),
-                (
-                    ":size_payload".to_string(),
-                    AttributeValue::N(self.0.size_payload.to_string()),
-                ),
-                (
-                    ":size_content".to_string(),
-                    AttributeValue::N(self.0.size_content.to_string()),
-                ),
-            ]),
+            condition_expression: "attribute_not_exists(#hash)".to_string(),
+            expression_names: HashMap::from([("#hash".to_string(), "hash".to_string())]),
+            expression_values: HashMap::new(),
         }
     }
+}
+
+/// Write only if the row is still in the state the caller last observed.
+///
+/// Obliteration advances the row through its states with this, so two obliterations racing for the
+/// same hash cannot both believe they hold the mark.
+#[derive(Debug, PartialEq)]
+struct StateUnchanged(FragmentState);
+
+impl DynamoDbPutCondition for StateUnchanged {
+    fn into_parts(self) -> ConditionParts {
+        ConditionParts {
+            condition_expression: "#state = :state".to_string(),
+            expression_names: HashMap::from([("#state".to_string(), "state".to_string())]),
+            expression_values: HashMap::from([(
+                ":state".to_string(),
+                AttributeValue::N(self.0.bits().to_string()),
+            )]),
+        }
+    }
+}
+
+/// Counts reads that found a partition still referencing a hash whose payload S3 no longer has.
+///
+/// Non-zero means content has been lost. The read itself is reported as a plain not-found, which is
+/// indistinguishable from content that was never stored, so without this the loss is silent.
+const METRICS_MISSING_PAYLOAD_METRIC_NAME: &str = "store.immutable.missing_payload";
+
+/// Lower bound on the obliteration drain, regardless of how the `DynamoDB` timeout is configured.
+const MIN_OBLITERATION_DRAIN_MILLIS: u64 = 100;
+
+/// Whether a `DynamoDB` failure means "ask again" rather than "here is your answer".
+///
+/// The SDK signals overload in several shapes — a client-side timeout, a dispatch failure before the
+/// request reached the service, an HTTP 429 or 5xx, or a service error whose code names throttling —
+/// and they all mean the same thing to a caller: no answer was obtained. Everything else is a real
+/// failure and is reported as one.
+///
+/// Getting this wrong is not cosmetic. Reporting a failed read as not-found tells a caller the
+/// content is absent when we merely failed to look, and a not-found on a referenced hash is what
+/// [`AwsImmutableStore::report_missing_payload`] treats as lost data — so a throttle could be
+/// recorded as data loss and clear a state row.
+fn is_dynamodb_overloaded<E>(error: &AwsError<DynamoDbSdkError<E>>) -> bool
+where
+    E: ProvideErrorMetadata,
+{
+    let AwsError::AwsSdkError(sdk_error) = error else {
+        return false;
+    };
+
+    match sdk_error {
+        DynamoDbSdkError::TimeoutError(_) | DynamoDbSdkError::DispatchFailure(_) => true,
+        DynamoDbSdkError::ServiceError(err) => {
+            let status = err.raw().status().as_u16();
+
+            status == 429
+                || status >= 500
+                || matches!(
+                    err.err().code(),
+                    Some(
+                        "ThrottlingException"
+                            | "ProvisionedThroughputExceededException"
+                            | "RequestLimitExceeded"
+                            | "InternalServerError"
+                            | "ServiceUnavailable"
+                    )
+                )
+        }
+        _ => false,
+    }
+}
+
+/// Mark a fragment as durably stored.
+///
+/// Durability is a fact about this store, not about the payload, so it is derived on read rather
+/// than written down: an object present in the bucket is durable by definition. Persisting it would
+/// mean serving one store's answer for another, and would let the claim outlive the object.
+fn stored_durable(mut fragment: Fragment) -> Fragment {
+    fragment.flags |= FragmentFlags::PayloadStoredDurable.bits();
+    fragment
 }
 
 static STORE_ATTRIBUTES: LazyLock<[KeyValue; 1]> =
@@ -333,6 +482,9 @@ type BatchTaskResult = Result<(usize, StoreMatch), (usize, StoreError)>;
 struct GetS3objectContentsOutput {
     read: usize,
     bytes: BytesMut,
+    /// The fragment carried on the object, recovered from its object metadata. Arrives on the same
+    /// response as the bytes it describes, so the two are necessarily from the same object version.
+    fragment: Result<Fragment, ObjectMetadataError>,
 }
 
 pub struct AwsImmutableStore {
@@ -341,8 +493,16 @@ pub struct AwsImmutableStore {
     task_queue: TaskQueue<BatchTaskResult>,
     bucket: String,
     fragments_table_name: Arc<str>,
-    metadata_table_name: Arc<str>,
+    /// Table of [`FragmentStateEntry`] rows. Named "metadata" for historical reasons; it holds
+    /// lifecycle state only, never a fragment.
+    fragment_state_table_name: Arc<str>,
+    /// Set only where objects predating the move onto the S3 object may still exist. `None` is a
+    /// deployment that has never written one, and reads accordingly refuse to guess.
+    fragment_metadata_table_name: Option<Arc<str>>,
     force_write: bool,
+    /// How long to wait between removing an association and counting what remains, so a put that
+    /// had already passed its state probe has time to land its own association and be counted.
+    obliteration_drain: Duration,
     latency_histogram: Histogram<f64>,
     labels_get: LabelArray,
     labels_put: LabelArray,
@@ -351,6 +511,9 @@ pub struct AwsImmutableStore {
     labels_obliterate: LabelArray,
     labels_query: LabelArray,
     labels_copy: LabelArray,
+    labels_get_metadata: LabelArray,
+    missing_payload_counter: Counter<u64>,
+    labels_missing_payload: LabelArray,
 }
 
 impl AwsImmutableStore {
@@ -366,6 +529,9 @@ impl AwsImmutableStore {
         let labels_obliterate = provider.get_labels_for_operation_context("obliterate");
         let labels_query = provider.get_labels_for_operation_context("query");
         let labels_copy = provider.get_labels_for_operation_context("copy");
+        let labels_get_metadata = provider.get_labels_for_operation_context("get_metadata");
+        let missing_payload_counter = provider.counter(METRICS_MISSING_PAYLOAD_METRIC_NAME);
+        let labels_missing_payload = provider.get_labels_for_operation_context("missing_payload");
         Self {
             s3,
             dynamodb,
@@ -380,8 +546,21 @@ impl AwsImmutableStore {
             ),
             bucket: settings.s3.bucket.clone(),
             fragments_table_name: Arc::from(settings.dynamodb.fragments_table_name.clone()),
-            metadata_table_name: Arc::from(settings.dynamodb.metadata_table_name.clone()),
+            fragment_state_table_name: Arc::from(
+                settings.dynamodb.fragment_state_table_name.clone(),
+            ),
+            fragment_metadata_table_name: settings
+                .dynamodb
+                .fragment_metadata_table_name
+                .as_ref()
+                .map(|name| Arc::from(name.clone())),
             force_write: settings.force_write,
+            obliteration_drain: Duration::from_millis(
+                settings
+                    .dynamodb
+                    .timeout_millis
+                    .max(MIN_OBLITERATION_DRAIN_MILLIS),
+            ),
             latency_histogram,
             labels_get,
             labels_put,
@@ -390,6 +569,9 @@ impl AwsImmutableStore {
             labels_obliterate,
             labels_query,
             labels_copy,
+            labels_get_metadata,
+            missing_payload_counter,
+            labels_missing_payload,
         }
     }
 
@@ -705,128 +887,233 @@ impl AwsImmutableStore {
         })
     }
 
+    /// Resolve an address to the fragment stored for it, without transferring the payload.
+    ///
+    /// An obliterated hash needs no special case: obliteration deletes the object, so the head
+    /// returns not-found and the query reports a miss. Between an obliteration taking its mark and
+    /// deleting the association there is a window where a partition that still holds a reference
+    /// sees the fragment — which is accurate, since the payload survives for as long as any
+    /// reference to it does.
     async fn do_query(
         &self,
         repository: Context,
         address: Address,
         match_requested: StoreMatch,
-        hide_obliterates: bool,
     ) -> Result<StoreQueryResult, StoreError> {
-        let match_made = self.lookup(repository, address, match_requested).await?;
+        let (match_made, state) = tokio::join!(
+            self.lookup(repository, address, match_requested),
+            self.load_state(address.hash)
+        );
+
+        let match_made = match_made?;
+        let miss = Ok(StoreQueryResult {
+            fragment: Fragment::default(),
+            match_made: StoreMatch::MatchNone,
+        });
 
         if match_made == StoreMatch::MatchNone {
-            return Ok(StoreQueryResult {
-                fragment: Fragment::default(),
-                match_made,
-            });
+            return miss;
         }
 
-        let fragment = self.load_metadata(address.hash).await.map_err(|e| {
-            warn!(
-                "Load metadata failed for address: {address:?} in repository: {repository:?}: {e:?}"
-            );
-            StoreError::internal_with_context(e, "Failed to load metadata after fragment lookup")
-        })?;
-
-        if (fragment.flags & FragmentFlags::PayloadObliteration) != 0 && hide_obliterates {
-            debug!("Query found obliterated fragment at address {address}");
-            Ok(StoreQueryResult {
-                fragment: Fragment::default(),
-                match_made: StoreMatch::MatchNone,
-            })
-        } else {
-            Ok(StoreQueryResult {
-                fragment,
+        match state? {
+            Some(FragmentState::Stored) => Ok(StoreQueryResult {
+                fragment: stored_durable(Fragment::default()),
                 match_made,
-            })
+            }),
+            Some(FragmentState::Obliterating | FragmentState::Obliterated) => {
+                debug!("Query found obliterated fragment at address {address}");
+                miss
+            }
+            None => {
+                debug!("Query found an association at {address} with no stored payload");
+                miss
+            }
         }
     }
 
-    async fn write_metadata(
-        &self,
-        repository: Context,
-        address: Address,
-        fragment: Fragment,
-    ) -> Result<(), StoreError> {
-        let metadata = FragmentMetadataEntry::new(address.hash).with_fragment(fragment);
-        let item = serde_dynamo::to_item(&metadata).map_err(|e| {
-            warn!("Failed to serialize metadata entry for repository: {repository:?} and address: {address:?} to dynamo av map: {e:?}");
-            StoreError::internal_with_context(e, "Failed to serialize metadata for DynamoDB write")
+    /// Record that a payload exists, without disturbing an obliteration that may hold the hash.
+    ///
+    /// The create is conditional, so it can never overwrite a mark. Losing that condition is the
+    /// ordinary outcome for content that is already stored — the row carries no representation, so
+    /// there is nothing to reconcile and the existing row is already correct. The state it carries
+    /// is returned so the caller can tell "already published" from "an obliteration holds this".
+    async fn publish_state(&self, hash: Hash) -> Result<FragmentState, StoreError> {
+        let entry = FragmentStateEntry::new(hash, FragmentState::Stored);
+        let item = serde_dynamo::to_item(&entry).map_err(|e| {
+            warn!("Failed to serialize fragment state entry for {hash}: {e:?}");
+            StoreError::internal_with_context(e, "Failed to serialize fragment state for DynamoDB")
         })?;
 
-        self.dynamodb.put_item(&self.metadata_table_name, item).await.map_err(|e| {
-            warn!("Failed to save metadata entry for repository: {repository:?} and address: {address:?}: {e:?}");
-            if matches!(&e, AwsError::AwsSdkError(_)) {
-                StoreError::from(SlowDown)
-            } else {
-                StoreError::internal_with_context(e, "DynamoDB metadata write failed")
+        match self
+            .dynamodb
+            .put_item_conditional(&self.fragment_state_table_name, item, RowAbsent)
+            .await
+        {
+            Ok(_) => Ok(FragmentState::Stored),
+            Err(AwsError::AwsSdkError(DynamoDbSdkError::ServiceError(err)))
+                if err.err().is_conditional_check_failed_exception() =>
+            {
+                let PutItemError::ConditionalCheckFailedException(failure) = err.err() else {
+                    unreachable!()
+                };
+
+                Ok(failure
+                    .item()
+                    .and_then(|item| {
+                        serde_dynamo::from_item::<_, FragmentStateEntry>(item.to_owned())
+                            .inspect_err(|e| {
+                                warn!("Failed to parse fragment state from item {item:?}: {e}");
+                            })
+                            .ok()
+                    })
+                    .map_or(FragmentState::Stored, |entry| entry.state()))
             }
+            Err(e) => {
+                warn!("Failed to publish fragment state for {hash}: {e:?}");
+                if matches!(&e, AwsError::AwsSdkError(_)) {
+                    Err(StoreError::from(SlowDown))
+                } else {
+                    Err(StoreError::internal_with_context(
+                        e,
+                        "DynamoDB fragment state write failed",
+                    ))
+                }
+            }
+        }
+    }
+
+    /// Record, and make repairable, a hash that is still referenced but whose payload is gone.
+    ///
+    /// Reaching here means the access check found an association while S3 reported no object, so
+    /// the content was published once and has since been lost. The read is on its way back to the
+    /// caller as an ordinary not-found, which is indistinguishable from content that was never
+    /// stored, so this is the only point at which the difference is still known.
+    ///
+    /// Clearing the state row is what makes it repairable: with no row, the next put stops taking
+    /// the "already durable" branch and uploads instead. That is safe only because the row holds no
+    /// representation — there is nothing in it the next write does not re-derive.
+    ///
+    /// Both steps are best effort. Failing to clear the row leaves the hash exactly as it already
+    /// was, and the alarm has been raised regardless.
+    async fn report_missing_payload(&self, address: Address) {
+        self.missing_payload_counter
+            .add(1, &self.labels_missing_payload);
+        error!(
+            %address,
+            "Fragment is referenced by a partition but absent from S3; content for this hash has \
+             been lost. Clearing its state so the content can be stored again."
+        );
+
+        match self.load_state(address.hash).await {
+            Ok(Some(FragmentState::Stored)) => {
+                if let Err(error) = self.clear_state(address.hash).await {
+                    warn!(%address, ?error, "Failed to clear state for a lost payload");
+                }
+            }
+            Ok(state) => {
+                debug!(%address, ?state, "Leaving state alone for a lost payload");
+            }
+            Err(error) => {
+                warn!(%address, ?error, "Failed to read state for a lost payload");
+            }
+        }
+    }
+
+    /// Delete the state row for a hash, so the next put treats it as new content.
+    ///
+    /// Only called for a payload S3 has lost. An obliteration holding the mark is left alone by the
+    /// caller, since removing a mark mid-obliteration would let a put republish underneath it.
+    async fn clear_state(&self, hash: Hash) -> Result<(), StoreError> {
+        let item = serde_dynamo::to_item(FragmentStateEntry::key(hash)).map_err(|e| {
+            warn!("Failed to serialize fragment state key for {hash}: {e:?}");
+            StoreError::internal_with_context(e, "Failed to serialize fragment state for delete")
         })?;
+
+        self.dynamodb
+            .delete_item(&self.fragment_state_table_name, item)
+            .await
+            .map_err(|e| {
+                if matches!(&e, AwsError::AwsSdkError(_)) {
+                    StoreError::from(SlowDown)
+                } else {
+                    StoreError::internal_with_context(e, "DynamoDB fragment state delete failed")
+                }
+            })?;
 
         Ok(())
     }
 
-    async fn update_metadata(
+    /// Move a tombstoned hash back to stored, now that its payload has been uploaded again.
+    ///
+    /// Losing this race is not a failure. Another writer reviving the same tombstone produced
+    /// exactly the state this one wanted, and this one's bytes are already uploaded, so there is
+    /// nothing left to disagree about. Only finding the hash back under an obliteration is a reason
+    /// to stop, and that is a back-off rather than an error because the mark is transient.
+    ///
+    /// This tolerance belongs here rather than in [`AwsImmutableStore::advance_state`], which is
+    /// also how an obliteration takes its mark — treating "already in the target state" as success
+    /// there would let two obliterations both believe they hold it.
+    async fn revive_state(&self, hash: Hash) -> Result<(), StoreError> {
+        if self
+            .advance_state(hash, FragmentState::Obliterated, FragmentState::Stored)
+            .await
+            .is_ok()
+        {
+            return Ok(());
+        }
+
+        match self.load_state(hash).await? {
+            Some(FragmentState::Stored) => {
+                debug!(%hash, "Another writer revived this hash first");
+                Ok(())
+            }
+            state => {
+                info!(%hash, ?state, "Hash is no longer revivable, asking the caller to retry");
+                Err(StoreError::from(SlowDown))
+            }
+        }
+    }
+
+    /// Move the state row from one state to another, failing if it has moved underneath us.
+    ///
+    /// Obliteration uses this to take and release the mark. Because the row holds nothing but the
+    /// state, this compare-and-set is over a single attribute and two writers racing for the mark
+    /// cannot both win.
+    async fn advance_state(
         &self,
-        address: Address,
-        updated: Fragment,
-        expected: Fragment,
+        hash: Hash,
+        expected: FragmentState,
+        updated: FragmentState,
     ) -> Result<(), StoreError> {
-        let metadata = FragmentMetadataEntry::new(address.hash).with_fragment(updated);
-        let item = serde_dynamo::to_item(&metadata).map_err(|e| {
-            warn!("Failed to serialize metadata entry for fragment with address: {address}: {e:?}");
-            StoreError::internal_with_context(e, "Failed to serialize metadata for DynamoDB update")
+        let entry = FragmentStateEntry::new(hash, updated);
+        let item = serde_dynamo::to_item(&entry).map_err(|e| {
+            warn!("Failed to serialize fragment state entry for {hash}: {e:?}");
+            StoreError::internal_with_context(e, "Failed to serialize fragment state for DynamoDB")
         })?;
 
-        let result = self
+        match self
             .dynamodb
             .put_item_conditional(
-                &self.metadata_table_name,
+                &self.fragment_state_table_name,
                 item,
-                UpdateMetadataCondition(expected),
+                StateUnchanged(expected),
             )
-            .await;
-
-        match result {
+            .await
+        {
             Ok(_) => Ok(()),
             Err(AwsError::AwsSdkError(DynamoDbSdkError::ServiceError(err)))
                 if err.err().is_conditional_check_failed_exception() =>
             {
-                if let PutItemError::ConditionalCheckFailedException(e) = err.err() {
-                    match e.item() {
-                        Some(item) => {
-                            let entry: Option<FragmentMetadataEntry> =
-                                serde_dynamo::from_item(item.to_owned())
-                                    .inspect_err(|e| {
-                                        warn!("Failed to parse fragment from item: {item:?}: {e}");
-                                    })
-                                    .ok();
-
-                            warn!(
-                                "Failed to update metadata, expected metadata: {expected:?} did not match actual: {:?}",
-                                entry
-                            );
-                        }
-                        None => {
-                            warn!(
-                                "Failed to update metadata, no existing metadata found for {address}"
-                            );
-                        }
-                    }
-                    Err(StoreError::internal(
-                        "Failed to update metadata due to conflict",
-                    ))
-                } else {
-                    unreachable!()
-                }
+                warn!("Fragment state for {hash} was not {expected:?} when moving to {updated:?}");
+                Err(StoreError::internal(
+                    "Failed to update fragment state due to conflict",
+                ))
             }
             Err(e) => {
-                warn!(
-                    "DynamoDB conditional put failed while updating metadata for {address}: {e:?}"
-                );
+                warn!("DynamoDB conditional put failed while updating state for {hash}: {e:?}");
                 Err(StoreError::internal_with_context(
                     e,
-                    "DynamoDB conditional metadata update failed",
+                    "DynamoDB conditional fragment state update failed",
                 ))
             }
         }
@@ -933,7 +1220,12 @@ impl AwsImmutableStore {
         let hash = lore_revision::util::to_hex_str(address.hash.data(), &mut dst);
 
         self.s3
-            .put_object(self.bucket.as_str(), hash, payload.to_vec())
+            .put_object(
+                self.bucket.as_str(),
+                hash,
+                payload.to_vec(),
+                Some(to_object_metadata(&fragment)),
+            )
             .await
             .map(|_| ())
             .map_err(|e| {
@@ -945,12 +1237,20 @@ impl AwsImmutableStore {
                 }
             })?;
 
-        // Writing metadata is not tied to writing the payload to S3, which means that over time
-        // we'll likely wind up in a scenario where some fragments exist in S3, but their associated
-        // metadata does not exist in Dynamo. In this scenario, a later query and/or read for the
-        // fragment would treat it as not found, prompting clients to resend the fragment. This
-        // means that whenever we land in this scenario, we should be self-healing.
-        self.write_metadata(repository, address, fragment).await?;
+        match self.publish_state(address.hash).await? {
+            FragmentState::Stored => {}
+            FragmentState::Obliterating => {
+                info!(
+                    "Payload for {address} was uploaded while an obliteration holds the hash; \
+                     leaving it unassociated and asking the caller to retry"
+                );
+                return Err(StoreError::from(SlowDown));
+            }
+            FragmentState::Obliterated => {
+                info!("Payload for {address} revives a tombstoned hash");
+                self.revive_state(address.hash).await?;
+            }
+        }
 
         self.associate_fragment(repository, address).await?;
 
@@ -1011,73 +1311,149 @@ impl AwsImmutableStore {
         Ok(())
     }
 
-    /// Loads fragment metadata, with just size validation
-    async fn metadata_with_size_validation(&self, hash: Hash) -> Result<Fragment, StoreError> {
-        let metadata = self.load_metadata(hash).await?;
-        // Reject upfront before issuing the S3 GET: a corrupt metadata entry
-        // could declare a payload larger than the protocol threshold, which
-        // would then be happily extended into the in-memory buffer below.
-        lore_storage::validate_fragment_size(&metadata)?;
-        Ok(metadata)
-    }
+    /// Read a fragment without its payload, from the object's object metadata.
+    ///
+    /// This is the one path that spends an S3 request purely on metadata, and it spends the
+    /// cheapest one: `HeadObject` transfers no body. Reads that want the payload get the fragment
+    /// for free on the `GetObject` response instead.
+    async fn head_fragment(&self, hash: Hash) -> Result<Fragment, StoreError> {
+        let mut dst = [0u8; 64];
+        let output = self
+            .s3
+            .head_object(
+                self.bucket.as_str(),
+                lore_revision::util::to_hex_str(hash.data(), &mut dst),
+            )
+            .await
+            .map_err(|e| {
+                if let AwsError::AwsSdkError(sdk_error) = e {
+                    debug!(%hash, error = ?sdk_error, "head_fragment SDK error heading object");
+                    match sdk_error.into_service_error() {
+                        HeadObjectError::NotFound(_) => StoreError::from(AddressNotFound::from(
+                            Address::zero_context_hash(hash),
+                        )),
+                        _ => StoreError::from(SlowDown),
+                    }
+                } else {
+                    debug!(%hash, error = ?e, "head_fragment failed to head object");
+                    StoreError::internal_with_context(e, "S3 head object failed")
+                }
+            })?;
 
-    /// Loads fragment metadata, applying all validation
-    /// to ensure it is a valid fragment to load
-    async fn metadata_with_load_validation(&self, hash: Hash) -> Result<Fragment, StoreError> {
-        let metadata = self.metadata_with_size_validation(hash).await?;
-
-        if (metadata.flags & FragmentFlags::PayloadObliteration) != 0 {
-            return Err(StoreError::from(AddressNotFound::from(
-                Address::zero_context_hash(hash),
-            )));
+        let fragment = match from_object_metadata(output.metadata()) {
+            Ok(fragment) => fragment,
+            Err(ObjectMetadataError::Absent) => self.fragment_from_metadata_table(hash).await?,
+            Err(e) => {
+                warn!(%hash, "Stored object carries unusable fragment metadata: {e}");
+                return Err(StoreError::internal_with_context(
+                    e,
+                    "S3 object fragment metadata unusable",
+                ));
+            }
         };
 
-        Ok(metadata)
+        Ok(stored_durable(fragment))
     }
 
-    async fn load_metadata(&self, hash: Hash) -> Result<Fragment, StoreError> {
-        let item = serde_dynamo::to_item(FragmentMetadataEntry::new(hash)).map_err(|e| {
-            warn!("Failed to serialize fragment metadata entry for {hash}: {e:?}");
+    /// Read the lifecycle state of a hash. `None` means no row exists, so the hash is unknown.
+    ///
+    /// This is the cheap existence probe the whole design turns on: one strongly consistent
+    /// `GetItem` answers "is this payload durable" for every partition at once, with no S3 request
+    /// and no dependence on how many partitions reference it.
+    async fn load_state(&self, hash: Hash) -> Result<Option<FragmentState>, StoreError> {
+        let item = serde_dynamo::to_item(FragmentStateEntry::key(hash)).map_err(|e| {
+            warn!("Failed to serialize fragment state entry for {hash}: {e:?}");
             StoreError::internal_with_context(
                 e,
-                "Failed to serialize fragment entry for DynamoDB metadata load",
+                "Failed to serialize fragment entry for DynamoDB state load",
             )
         })?;
 
-        let metadata: FragmentMetadataEntry = if let Some(av_map) = self
+        let Some(av_map) = self
             .dynamodb
             .get_item(
-                &self.metadata_table_name,
+                &self.fragment_state_table_name,
                 item,
                 true, /* consistent read */
             )
             .await
             .map_err(|e| {
-                warn!(%hash, ?e, "Failed to get fragment metadata for hash");
-                if let AwsError::AwsSdkError(sdk_error) = e
-                    && let SdkError::TimeoutError(_) = sdk_error
-                {
+                warn!(%hash, ?e, "Failed to get fragment state for hash");
+                if is_dynamodb_overloaded(&e) {
                     StoreError::from(SlowDown)
                 } else {
-                    StoreError::from(AddressNotFound::from(Address::zero_context_hash(hash)))
+                    StoreError::internal_with_context(e, "DynamoDB fragment state read failed")
                 }
             })?
             .item
-        {
-            serde_dynamo::from_item(av_map).map_err(|e| {
-                warn!("Failed to deserialize fragment metadata: {e:?}");
-                StoreError::from(AddressNotFound::from(Address::zero_context_hash(hash)))
-            })
-        } else {
-            warn!("Failed to get metadata for fragment, no item found");
-            Err(StoreError::from(AddressNotFound::from(
-                Address::zero_context_hash(hash),
-            )))
-        }?;
+        else {
+            return Ok(None);
+        };
 
-        metadata.fragment.ok_or_else(|| {
-            warn!("No fragment found on metadata from store: {metadata:?}");
-            StoreError::internal("Fragment metadata entry missing fragment field")
+        let entry: FragmentStateEntry = serde_dynamo::from_item(av_map).map_err(|e| {
+            warn!("Failed to deserialize fragment state: {e:?}");
+            StoreError::from(AddressNotFound::from(Address::zero_context_hash(hash)))
+        })?;
+
+        Ok(Some(entry.state()))
+    }
+
+    /// Resolve the fragment for an object that carries none of its own.
+    ///
+    /// Reached only on [`ObjectMetadataError::Absent`] — an intact object with no lore metadata,
+    /// which is exactly what an object written before the fragment moved onto it looks like. A
+    /// `Malformed` object never arrives here: metadata that is present but unreadable means damage,
+    /// and describing damaged bytes from a separate record is the mismatch this design exists to
+    /// remove.
+    ///
+    /// With no legacy table configured there is nothing to fall back to, and nothing that should
+    /// be: the deployment has declared it never wrote such an object.
+    async fn fragment_from_metadata_table(&self, hash: Hash) -> Result<Fragment, StoreError> {
+        let Some(table_name) = self.fragment_metadata_table_name.as_ref() else {
+            warn!(
+                %hash,
+                "Stored object carries no fragment metadata and no fragment metadata table is \
+                 configured; treating it as damaged"
+            );
+            return Err(StoreError::internal(
+                "S3 object carries no fragment metadata",
+            ));
+        };
+
+        let item = serde_dynamo::to_item(FragmentStateEntry::key(hash)).map_err(|e| {
+            warn!("Failed to serialize legacy fragment key for {hash}: {e:?}");
+            StoreError::internal_with_context(
+                e,
+                "Failed to serialize fragment entry for legacy metadata load",
+            )
+        })?;
+
+        let entry = self
+            .dynamodb
+            .get_item(table_name, item, true /* consistent read */)
+            .await
+            .map_err(|e| {
+                warn!(%hash, ?e, "Failed to read fragment metadata table");
+                if is_dynamodb_overloaded(&e) {
+                    StoreError::from(SlowDown)
+                } else {
+                    StoreError::internal_with_context(e, "DynamoDB fragment metadata read failed")
+                }
+            })?
+            .item
+            .map(serde_dynamo::from_item::<_, FragmentMetadataEntry>)
+            .transpose()
+            .map_err(|e| {
+                warn!(%hash, "Failed to deserialize fragment metadata row: {e:?}");
+                StoreError::internal_with_context(e, "Fragment metadata row is unreadable")
+            })?;
+
+        entry.and_then(|entry| entry.fragment).ok_or_else(|| {
+            warn!(
+                %hash,
+                "Stored object carries no fragment metadata and no legacy row describes it"
+            );
+            StoreError::internal("S3 object carries no fragment metadata")
         })
     }
 
@@ -1109,6 +1485,8 @@ impl AwsImmutableStore {
                 }
             })?;
 
+        let fragment = from_object_metadata(output.metadata());
+
         let mut buffer = BytesMut::with_capacity(FRAGMENT_SIZE_THRESHOLD);
         let mut read = 0_usize;
         while let Some(bytes) = output.body.next().await {
@@ -1126,34 +1504,25 @@ impl AwsImmutableStore {
         Ok(GetS3objectContentsOutput {
             bytes: buffer,
             read,
+            fragment,
         })
     }
 
+    /// Check the object's own bytes against the fragment the same object declares.
+    ///
+    /// Both sides of this comparison come from one S3 response, so it is a self-consistency check
+    /// on a single object rather than a comparison between two stores. It cannot fail because two
+    /// records drifted apart; only because the object itself is damaged.
     fn read_payload(
-        &self,
-        mut s3_contents: GetS3objectContentsOutput,
+        s3_contents: GetS3objectContentsOutput,
         hash: Hash,
         fragment: Fragment,
     ) -> Result<Bytes, StoreError> {
         let payload_size = fragment.size_payload as usize;
         let buffer_size = s3_contents.bytes.len();
 
-        // This exists to work around an inconsistency that can occur as we switch from storing
-        // metadata prefixed to objects in S3 to storing metadata separately in Dynamo. If the
-        // amount of data we read does not match the expected size, we should fail the request.
-        // However, if it's off by exactly the size of fragment metadata, and we're in force-write
-        // mode, assume it's ok.
-        let buffer = if buffer_size > payload_size
-            && (buffer_size - payload_size) == size_of::<Fragment>()
-            && self.force_write
-        {
-            s3_contents.bytes.split_off(size_of::<Fragment>()).freeze()
-        } else {
-            s3_contents.bytes.freeze()
-        };
-
         if buffer_size == payload_size {
-            Ok(buffer)
+            Ok(s3_contents.bytes.freeze())
         } else {
             warn!(
                 "Wrong number of bytes read from payload, expected {payload_size} but got {buffer_size}, from a total of {} bytes read",
@@ -1165,33 +1534,110 @@ impl AwsImmutableStore {
         }
     }
 
+    /// Load a payload and the fragment describing it, in a single S3 request.
+    ///
+    /// There is no `DynamoDB` read here at all. The fragment arrives as object metadata on the very
+    /// response carrying the bytes, so it describes those bytes by construction — no second record
+    /// to consult, and nothing that can be stale with respect to what was read.
     async fn load(&self, hash: Hash) -> Result<(Fragment, Bytes), StoreError> {
-        // Run both futures concurrently. The select! loop breaks as soon as metadata resolves.
-        // If S3 finishes first its result is stashed, and we keep waiting for metadata.
-        let metadata_fut = self.metadata_with_load_validation(hash);
-        let s3_fut = self.get_s3_object_contents(hash);
-        tokio::pin!(metadata_fut, s3_fut);
-        let mut s3_result = None;
-        let metadata_result = loop {
-            tokio::select! {
-                result = &mut metadata_fut => break result,
-                result = &mut s3_fut, if s3_result.is_none() => {
-                    s3_result = Some(result);
-                }
+        let s3_contents = self.get_s3_object_contents(hash).await?;
+
+        let fragment = match s3_contents.fragment {
+            Ok(fragment) => fragment,
+            Err(ObjectMetadataError::Absent) => self.fragment_from_metadata_table(hash).await?,
+            Err(e) => {
+                warn!(%hash, "Stored object carries unusable fragment metadata: {e}");
+                return Err(StoreError::internal_with_context(
+                    e,
+                    "S3 object fragment metadata unusable",
+                ));
             }
         };
 
-        // If metadata failed, its error is returned here; s3_fut is dropped (canceled) on the
-        // early return. Metadata error takes priority over any S3 error.
-        let fragment = metadata_result?;
+        let fragment = stored_durable(fragment);
+        lore_storage::validate_fragment_size(&fragment)?;
 
-        let s3_contents = match s3_result {
-            Some(r) => r?,
-            None => s3_fut.await?,
+        let payload = Self::read_payload(s3_contents, hash, fragment)?;
+        Ok((fragment, payload))
+    }
+
+    /// Obliterate the fragments a fragmented payload points at, if it is one.
+    ///
+    /// Called once the mark is held and no association remains, so the parent payload is still
+    /// present to be read and nothing can be adding references beneath it.
+    async fn obliterate_sub_fragments(
+        self: Arc<Self>,
+        repository: Context,
+        address: Address,
+        stats: Arc<StoreObliterateStats>,
+    ) -> Result<(), StoreError> {
+        let (fragment, payload) = match self.load(address.hash).await {
+            Ok(loaded) => loaded,
+            Err(e) if e.is_address_not_found() => {
+                info!("Payload for {address} is already gone, no sub-fragments to obliterate");
+                return Ok(());
+            }
+            Err(e) => return Err(e),
         };
 
-        let payload = self.read_payload(s3_contents, hash, fragment)?;
-        Ok((fragment, payload))
+        if fragment.flags & FragmentFlags::PayloadFragmented == 0 {
+            return Ok(());
+        }
+
+        let payload = payload.to_aligned::<FragmentReference>();
+        let sub_fragments = payload.as_type_slice::<FragmentReference>();
+        info!(
+            "Fragment {address} has {} sub-fragments",
+            sub_fragments.len()
+        );
+
+        let span = tracing::Span::current();
+        let mut join_set = JoinSet::new();
+        for reference in sub_fragments.iter() {
+            let self_clone = self.clone();
+            let stats = stats.clone();
+            let sub_address = Address {
+                hash: reference.hash,
+                context: address.context,
+            };
+
+            info!("Spawning task to obliterate {sub_address}");
+            lore_base::lore_spawn!(
+                join_set,
+                async move {
+                    self_clone
+                        .obliterate(repository.into(), sub_address, stats)
+                        .await
+                        .map_err(|e| (sub_address, e))
+                }
+                .instrument(span.clone())
+            );
+        }
+
+        let mut failures = false;
+        while let Some(result) = join_set.join_next().await {
+            match result {
+                Err(e) => {
+                    failures = true;
+                    warn!("Failed to join task for fragment reference obliterate: {e:?}");
+                }
+                Ok(Err((sub_address, e))) => {
+                    failures = true;
+                    warn!("Obliteration failed for sub-fragment {sub_address}: {e:?}");
+                }
+                Ok(Ok(())) => {}
+            }
+        }
+
+        if failures {
+            warn!("Obliteration failed for at least one sub-fragment.");
+            return Err(StoreError::internal(format!(
+                "Failed to obliterate immutable {address}"
+            )));
+        }
+
+        info!("Done obliterating sub-fragments");
+        Ok(())
     }
 }
 
@@ -1251,13 +1697,47 @@ impl ImmutableStoreTrait for AwsImmutableStore {
     ) -> Result<StoreQueryResult, StoreError> {
         let repository: Context = partition.into();
         timed!(self.latency_histogram, &self.labels_query, {
-            self.do_query(
-                repository,
-                address,
-                match_requested,
-                true, /* hide obliterates */
-            )
-            .await
+            Box::pin(self.do_query(repository, address, match_requested)).await
+        })
+        .into()
+    }
+
+    /// Unlike [`AwsImmutableStore::query`], this reads the object to report the representation
+    /// actually stored, which costs a `HeadObject`. It transfers no body, and it is the only path
+    /// in this store that spends an S3 request purely on metadata.
+    #[lore_macro::lore_instrument]
+    #[tracing::instrument(name = "AwsImmutableStore::get_metadata" skip(self))]
+    async fn get_metadata(
+        self: Arc<Self>,
+        partition: Partition,
+        address: Address,
+    ) -> Result<StoreQueryResult, StoreError> {
+        let repository: Context = partition.into();
+        timed!(self.latency_histogram, &self.labels_get_metadata, {
+            let miss = StoreQueryResult {
+                fragment: Fragment::default(),
+                match_made: StoreMatch::MatchNone,
+            };
+
+            let match_made = Box::pin(self.do_query(repository, address, StoreMatch::MatchFull))
+                .await?
+                .match_made;
+
+            if match_made == StoreMatch::MatchNone {
+                return Ok(miss);
+            }
+
+            match self.head_fragment(address.hash).await {
+                Ok(fragment) => Ok(StoreQueryResult {
+                    fragment,
+                    match_made,
+                }),
+                Err(e) if e.is_address_not_found() => {
+                    self.report_missing_payload(address).await;
+                    Ok(miss)
+                }
+                Err(e) => Err(e),
+            }
         })
         .into()
     }
@@ -1293,11 +1773,19 @@ impl ImmutableStoreTrait for AwsImmutableStore {
                 exists_result?;
 
                 let load_output = match load_result {
-                    Some(r) => r?,
-                    None => load_fut.await?,
+                    Some(r) => r,
+                    None => load_fut.await,
                 };
 
-                Ok(load_output)
+                if load_output
+                    .as_ref()
+                    .err()
+                    .is_some_and(StoreError::is_address_not_found)
+                {
+                    self.report_missing_payload(address).await;
+                }
+
+                load_output
             })
             .into();
         let (fragment, payload) = result?;
@@ -1323,75 +1811,45 @@ impl ImmutableStoreTrait for AwsImmutableStore {
             lore_storage::validate_fragment_size(&fragment)?;
         }
         let repository: Context = partition.into();
-        timed!(
-            self.latency_histogram,
-            &self.labels_put,
-            {
-                let query = self.do_query(
-                    repository,
-                    address,
-                    StoreMatch::MatchFull,
-                    false, /* hide obliterates */
-                )
-                .await;
+        timed!(self.latency_histogram, &self.labels_put, {
+            let probe = if self.force_write {
+                (None, false)
+            } else {
+                let entry = FragmentsEntry::new(repository, address);
+                let (associated, state) =
+                    tokio::join!(self.exists_exact(&entry), self.load_state(address.hash));
+                (state?, associated?)
+            };
 
-                let match_made = if !self.force_write && query.is_ok() {
-                    let query = query?;
+            match probe {
+                (Some(FragmentState::Obliterating), _) => {
+                    info!(
+                        "Received request to put fragment at {address} that is in the process of \
+                         being obliterated"
+                    );
+                    Err(StoreError::from(SlowDown))
+                }
 
-                    if (query.fragment.flags & FragmentFlags::PayloadObliterating) == FragmentFlags::PayloadObliterating
-                    {
-                        info!("Received request to put fragment at {address} that is in the process of being obliterated");
-                        return Err(StoreError::internal(format!("Failed to obliterate immutable {address}")));
-                    }
+                (Some(FragmentState::Stored), true) => Ok(()),
 
-                    if query.match_made != StoreMatch::MatchNone
-                        && fragment.size_content != query.fragment.size_content
-                        && (query.fragment.flags & FragmentFlags::PayloadObliterated) != FragmentFlags::PayloadObliterated
-                    {
-                        return Err(StoreError::internal("Hash collision"));
-                    }
+                (Some(FragmentState::Stored), false) if payload.is_some() => {
+                    self.associate_fragment(repository, address).await
+                }
 
-                    query.match_made
-                } else {
-                    // If we're in this branch because the query failed, we should log the error.
-                    if let Err(e) = query {
-                        warn!("Query failed for address: {address:?} in repository: {repository}: {e:?}");
-                    }
+                (Some(FragmentState::Stored), false) => {
+                    Err(StoreError::internal("Payload buffer required"))
+                }
 
-                    StoreMatch::MatchNone
-                };
-
-                match match_made {
-                    // If the fragment exists with the same context, there's nothing to do.
-                    StoreMatch::MatchFull => Ok(()),
-
-                    // If we matched on hash + repo, then we need to associate the fragment with the new
-                    // context. Does not need the payload as it already exist in repository.
-                    StoreMatch::MatchPartition => {
-                        self.associate_fragment(repository, address).await
-                    }
-
-                    // If we were only able to match on hash, the payload must have been provided.
-                    // If so, associate the fragment.
-                    StoreMatch::MatchHash if payload.is_some() => {
-                        self.associate_fragment(repository, address).await
-                    }
-
-                    // If no match, the payload must have been provided. Write it to S3 and store fragment.
-                    StoreMatch::MatchNone if payload.is_some() => {
-                        self.write_payload(repository, address, fragment, payload.unwrap())
+                _ => match payload {
+                    Some(payload) => {
+                        self.write_payload(repository, address, fragment, payload)
                             .await
                     }
-
-                    // If we were only able to match on hash, or were not able to match at all, and no
-                    // payload was provided, that's an error.
-                    StoreMatch::MatchHash | StoreMatch::MatchNone => {
-                        Err(StoreError::internal("Payload buffer required"))
-                    }
-                }
+                    None => Err(StoreError::internal("Payload buffer required")),
+                },
             }
-        )
-            .into()
+        })
+        .into()
     }
 
     #[lore_macro::lore_instrument]
@@ -1408,87 +1866,28 @@ impl ImmutableStoreTrait for AwsImmutableStore {
             // expect this to be invoked, the log output in this method is intentionally very verbose.
             let span = tracing::Span::current();
 
-            let original_metadata = self
-                .metadata_with_size_validation(address.hash)
+            let Some(state) = self
+                .load_state(address.hash)
                 .instrument(span.clone())
-                .await?;
-
-            info!("Original metadata: {original_metadata:?}");
-
-            // Acquire the lock on the fragment.
-            let updated_metadata = if original_metadata.flags & FragmentFlags::PayloadObliteration == 0
-            {
-                let mut updated_metadata = original_metadata;
-                updated_metadata.flags |= FragmentFlags::PayloadObliterating;
-
-                self.update_metadata(address, updated_metadata, original_metadata)
-                    .instrument(span.clone())
-                    .await?;
-                info!("Acquired obliteration lock, updated metadata: {updated_metadata:?}");
-                updated_metadata
-            } else {
-                info!("Fragment metadata indicates fragment is already being (or has previously been) obliterated");
+                .await?
+            else {
+                info!("No fragment state for {address}, nothing to obliterate");
                 return Ok(());
             };
 
-            if updated_metadata.flags & FragmentFlags::PayloadFragmented != 0 {
-                info!("Fragment is fragmented");
-                // There's no reason we couldn't use the `updated_metadata` here, since `read_payload`
-                // only cares about the size fields (which haven't changed), but it feels wrong given it
-                // doesn't explicitly match the metadata for what's currently in S3.
-                let payload = self
-                    .read_payload(self.get_s3_object_contents(address.hash).await?, address.hash, original_metadata)?
-                    .to_aligned::<FragmentReference>();
-
-                let sub_fragments = payload.as_type_slice::<FragmentReference>();
-                info!("Fragment has {} sub-fragments", sub_fragments.len());
-
-                let mut join_set = JoinSet::new();
-                for reference in sub_fragments.iter() {
-                    let self_clone = self.clone();
-                    let stats = stats.clone();
-                    let address = Address {
-                        hash: reference.hash,
-                        context: address.context,
-                    };
-
-                    info!("Spawning task to obliterate {address}");
-                    lore_base::lore_spawn!(
-                        join_set,
-                        async move {
-                            self_clone
-                                .obliterate(repository.into(), address, stats)
-                                .await
-                                .map_err(|e| (address, e))
-                        }
-                        .instrument(span.clone())
-                    );
-                }
-
-                let mut failures = false;
-                while let Some(result) = join_set.join_next().await {
-                    if let Err(e) = result {
-                        failures = true;
-                        warn!("Failed to join task for fragment reference obliterate: {e:?}");
-                        continue;
-                    }
-
-                    // We wouldn't reach this if the result is an `Err`, so this unwrap is guaranteed
-                    // not to panic.
-                    let result = result.unwrap();
-                    if let Err(e) = result {
-                        failures = true;
-                        warn!("Obliteration failed for sub-fragment {address}: {e:?}");
-                    }
-                }
-
-                if failures {
-                    warn!("Obliteration failed for at least one sub-fragment.");
-                    return Err(StoreError::internal(format!("Failed to obliterate immutable {address}")));
-                }
-
-                info!("Done obliterating sub-fragments");
+            if state.is_obliteration() {
+                info!("Fragment {address} is already being, or has already been, obliterated");
+                return Ok(());
             }
+
+            self.advance_state(
+                address.hash,
+                FragmentState::Stored,
+                FragmentState::Obliterating,
+            )
+            .instrument(span.clone())
+            .await?;
+            info!("Acquired obliteration mark for {address}");
 
             self.delete_association(repository, address)
                 .instrument(span.clone())
@@ -1497,28 +1896,32 @@ impl ImmutableStoreTrait for AwsImmutableStore {
                 .num_fragments
                 .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
 
-            // TODO(jcohen): Assuming we always lock the fragment regardless of the association count
-            //  then this process of re-checking the count after removing the association should
-            //  theoretically not be necessary since no one else should have been able to add a new
-            //  fragment association while we maintain the lock.
-            info!("Association deleted, re-checking for other association...");
-            let remain_associated = self
+            tokio::time::sleep(self.obliteration_drain).await;
+
+            info!("Association deleted, re-checking for other associations...");
+            if self
                 .has_associations(address.hash)
                 .instrument(span.clone())
-                .await?;
-
-            // If the association count is still >= 1 after we deleted, other references remain, so
-            // there's nothing left to do...
-            if remain_associated {
-                info!("Fragment still associated, nothing more to do");
+                .await?
+            {
+                info!("Fragment still associated, releasing the obliteration mark");
                 return self
-                    .update_metadata(address, original_metadata, updated_metadata)
+                    .advance_state(
+                        address.hash,
+                        FragmentState::Obliterating,
+                        FragmentState::Stored,
+                    )
                     .instrument(span.clone())
                     .await
                     .inspect_err(|e| {
-                        warn!("Failed to reset metadata back to original state: {e:?}");
+                        warn!("Failed to release the obliteration mark: {e:?}");
                     });
             }
+
+            self.clone()
+                .obliterate_sub_fragments(repository, address, stats.clone())
+                .instrument(span.clone())
+                .await?;
 
             self.delete_payload(address.hash)
                 .instrument(span.clone())
@@ -1528,21 +1931,17 @@ impl ImmutableStoreTrait for AwsImmutableStore {
                 .num_payloads
                 .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
 
-            let mut obliterated_metadata = updated_metadata;
-            obliterated_metadata.flags = FragmentFlags::PayloadObliterated.bits();
-            obliterated_metadata.size_payload = 0;
-            obliterated_metadata.size_content = 0;
-
-            // Final metadata update to clear out the sizes and set the flags to `Obliterated`.
-            self.update_metadata(address, obliterated_metadata, updated_metadata)
-                .await
-                .inspect_err(|e| {
-                    // At this point we've already deleted the underlying payload, so there's not any
-                    // point in trying to revert the metadata, that fragment is just well and truly
-                    // broken.
-                    warn!("Failed to finalize obliterate for {address}: {e:?}");
-                })
-        }).into()
+            self.advance_state(
+                address.hash,
+                FragmentState::Obliterating,
+                FragmentState::Obliterated,
+            )
+            .await
+            .inspect_err(|e| {
+                warn!("Failed to finalize obliterate for {address}: {e:?}");
+            })
+        })
+        .into()
     }
 
     #[lore_macro::lore_instrument]
@@ -1566,16 +1965,11 @@ impl ImmutableStoreTrait for AwsImmutableStore {
             context: destination_context,
         };
         timed!(self.latency_histogram, &self.labels_copy, {
-            let query = self
-                .do_query(
-                    source_repository,
-                    source_address,
-                    StoreMatch::MatchFull,
-                    false,
-                )
+            let match_made = self
+                .lookup(source_repository, source_address, StoreMatch::MatchFull)
                 .await?;
 
-            if query.match_made != StoreMatch::MatchFull {
+            if match_made != StoreMatch::MatchFull {
                 return Err(StoreError::from(AddressNotFound::from(source_address)));
             }
 
@@ -1642,6 +2036,8 @@ impl InstrumentProvider for AwsImmutableStoreInstrumentProvider {
 #[cfg(test)]
 mod test {
     use std::collections::HashMap;
+    use std::collections::HashSet;
+    use std::sync::Mutex;
     use std::sync::atomic::Ordering;
 
     use aws_sdk_dynamodb::operation::delete_item::DeleteItemError;
@@ -1659,1275 +2055,31 @@ mod test {
     use aws_sdk_s3::operation::delete_object::DeleteObjectError;
     use aws_sdk_s3::operation::delete_object::DeleteObjectOutput;
     use aws_sdk_s3::operation::get_object::GetObjectOutput;
+    use aws_sdk_s3::operation::head_object::HeadObjectOutput;
     use aws_sdk_s3::operation::list_object_versions::ListObjectVersionsError;
     use aws_sdk_s3::operation::list_object_versions::ListObjectVersionsOutput;
     use aws_sdk_s3::operation::put_object::PutObjectOutput;
     use aws_sdk_s3::primitives::SdkBody;
-    use aws_sdk_s3::types::ObjectVersion;
+    use aws_sdk_s3::types::error::NoSuchKey;
+    use aws_sdk_s3::types::error::NotFound;
     use aws_smithy_runtime_api::client::orchestrator::HttpResponse;
     use aws_smithy_runtime_api::client::result::SdkError;
     use aws_smithy_runtime_api::client::result::ServiceError;
-    use aws_smithy_runtime_api::client::result::TimeoutError;
     use lore_base::runtime::LORE_CONTEXT;
     use lore_base::types::FragmentFlags;
-    use lore_revision::fragment;
     use lore_storage::ImmutableStore;
-    use mockall::predicate::eq;
-    use rand::Rng;
     use rand::random;
-    use tracing_test::traced_test;
     use zerocopy::IntoBytes;
 
     use super::*;
     use crate::dynamodb::MockDynamoDb;
     use crate::s3::MockS3Impl;
-    use crate::store::address_with_random_context;
+    use crate::store::object_metadata::PAYLOAD_FLAGS;
     use crate::store::setup_execution;
 
     const BUCKET: &str = "test-bucket";
     const FRAGMENTS_TABLE_NAME: &str = "fragments";
-    const METADATA_TABLE_NAME: &str = "metadata";
-
-    fn mock_lookup_fragments(
-        dynamodb_mock: &mut MockDynamoDb,
-        fragment_entry: FragmentsEntry,
-        starting_match: StoreMatch,
-        expected_match: StoreMatch,
-    ) {
-        let mut store_match = Some(starting_match);
-
-        while store_match.is_some() {
-            let m = store_match.unwrap();
-            if m == StoreMatch::MatchNone {
-                return;
-            }
-
-            let matched = m == expected_match;
-
-            match m {
-                StoreMatch::MatchFull => {
-                    let av_map: HashMap<String, AttributeValue> =
-                        serde_dynamo::to_item(fragment_entry.clone()).unwrap();
-                    let item = if matched { Some(av_map.clone()) } else { None };
-
-                    dynamodb_mock
-                        .expect_get_item()
-                        .with(
-                            eq(Arc::<str>::from(FRAGMENTS_TABLE_NAME)),
-                            eq(av_map),
-                            eq(true),
-                        )
-                        .return_once(move |_, _, _| {
-                            Ok(GetItemOutput::builder().set_item(item).build())
-                        });
-                }
-                StoreMatch::MatchPartition => {
-                    dynamodb_mock
-                        .expect_query_single()
-                        .with(
-                            eq(Arc::<str>::from(FRAGMENTS_TABLE_NAME)),
-                            eq(FragmentsQuery::Repository(
-                                fragment_entry.hash,
-                                Context::from(
-                                    &fragment_entry.repository_context[..size_of::<Context>()],
-                                ),
-                            )),
-                        )
-                        .return_once(move |_, _| {
-                            Ok(QueryOutput::builder()
-                                .count(if matched { 1 } else { 0 })
-                                .build())
-                        });
-                }
-                StoreMatch::MatchHash => {
-                    dynamodb_mock
-                        .expect_query_single()
-                        .with(
-                            eq(Arc::<str>::from(FRAGMENTS_TABLE_NAME)),
-                            eq(FragmentsQuery::Hash(fragment_entry.hash)),
-                        )
-                        .return_once(move |_, _| {
-                            Ok(QueryOutput::builder()
-                                .count(if matched { 1 } else { 0 })
-                                .build())
-                        });
-                }
-                StoreMatch::MatchNone => unreachable!(),
-            }
-
-            if matched {
-                break;
-            } else {
-                store_match = store_match.unwrap().prev();
-            }
-        }
-    }
-
-    fn mock_associate_fragment(dynamodb_mock: &mut MockDynamoDb, entry: &FragmentsEntry) {
-        let item: HashMap<String, AttributeValue> = serde_dynamo::to_item(entry).unwrap();
-
-        dynamodb_mock
-            .expect_put_item()
-            .with(eq(Arc::<str>::from(FRAGMENTS_TABLE_NAME)), eq(item.clone()))
-            .return_once(move |_, _| {
-                Ok(PutItemOutput::builder().set_attributes(Some(item)).build())
-            });
-    }
-
-    async fn initialize_immutable_store(s3: S3, dynamodb: DynamoDb) -> AwsImmutableStore {
-        let settings = AwsImmutableStoreSettings {
-            s3: S3StoreSettings::new(BUCKET.to_string()),
-            dynamodb: DynamoDbImmutableStoreSettings::new(
-                FRAGMENTS_TABLE_NAME.to_string(),
-                METADATA_TABLE_NAME.to_string(),
-            ),
-            force_write: false,
-            batch_exist_submission_limit: 1000,
-        };
-
-        let execution = setup_execution("test".to_string());
-        LORE_CONTEXT
-            .scope(execution.clone(), async move {
-                AwsImmutableStore::new(s3, dynamodb, &settings)
-            })
-            .await
-    }
-
-    #[tokio::test]
-    async fn test_exists_batch_full_match() {
-        let repository = random::<Context>();
-
-        let mut rng = rand::rng();
-
-        #[allow(clippy::type_complexity)]
-        let fragments: Vec<(
-            FragmentsEntry,
-            HashMap<String, AttributeValue>,
-            StoreMatch,
-            Option<HashMap<String, AttributeValue>>,
-        )> = (1..=20)
-            .map(|_| {
-                let address = random::<Address>();
-                let found: bool = rng.random();
-
-                let entry = FragmentsEntry::new(repository, address);
-                let av_map: HashMap<String, AttributeValue> =
-                    serde_dynamo::to_item(entry.clone()).unwrap();
-
-                let (mock_match, mock_item) = if found {
-                    (StoreMatch::MatchFull, Some(av_map.clone()))
-                } else {
-                    (StoreMatch::MatchNone, None)
-                };
-
-                (entry, av_map, mock_match, mock_item)
-            })
-            .collect();
-
-        let addresses: Vec<Address> = fragments
-            .iter()
-            .map(|f| Into::<Address>::into(&f.0))
-            .collect();
-        let items: Vec<HashMap<String, AttributeValue>> =
-            fragments.iter().map(|f| f.1.clone()).collect();
-        let matches: Vec<StoreMatch> = fragments.iter().map(|f| f.2).collect();
-        let response_items: Vec<HashMap<String, AttributeValue>> =
-            fragments.iter().filter_map(|f| f.3.clone()).collect();
-
-        let s3mock = MockS3Impl::default();
-        let mut dynamodb_mock = MockDynamoDb::default();
-
-        dynamodb_mock
-            .expect_batch_get_item()
-            .with(
-                eq(Arc::<str>::from(FRAGMENTS_TABLE_NAME)),
-                eq(items),
-                eq(true),
-            )
-            .return_once(move |_, _, _| Ok(response_items));
-
-        let store = initialize_immutable_store(s3mock, dynamodb_mock).await;
-        let store = Arc::new(store);
-
-        let result = store
-            .clone()
-            .exist_batch(
-                repository.into(),
-                addresses.as_slice(),
-                StoreMatch::MatchFull,
-            )
-            .await
-            .expect("exist batch failed");
-
-        assert_eq!(matches, result);
-    }
-
-    #[tokio::test]
-    async fn test_query_immutable_not_found() {
-        let repository = random::<Context>();
-        let address = random::<Address>();
-
-        let s3mock = MockS3Impl::default();
-        let mut dynamodb_mock = MockDynamoDb::default();
-
-        mock_lookup_fragments(
-            &mut dynamodb_mock,
-            FragmentsEntry::new(repository, address),
-            StoreMatch::MatchFull,
-            StoreMatch::MatchNone,
-        );
-
-        let store = initialize_immutable_store(s3mock, dynamodb_mock).await;
-        let store = Arc::new(store);
-
-        let result = store
-            .clone()
-            .query(repository.into(), address, StoreMatch::MatchFull)
-            .await
-            .expect("query immutable failed");
-
-        assert_eq!(
-            StoreQueryResult {
-                fragment: Fragment::default(),
-                match_made: StoreMatch::MatchNone
-            },
-            result
-        );
-    }
-
-    #[tokio::test]
-    async fn test_query_immutable_found() {
-        let repository = random::<Context>();
-        let (fragment, address, _) = fragment::generate_random();
-
-        let s3mock = MockS3Impl::default();
-        let mut dynamodb_mock = MockDynamoDb::default();
-
-        mock_lookup_fragments(
-            &mut dynamodb_mock,
-            FragmentsEntry::new(repository, address),
-            StoreMatch::MatchFull,
-            StoreMatch::MatchFull,
-        );
-
-        let metadata_entry = FragmentMetadataEntry::new(address.hash);
-        let av_map: HashMap<String, AttributeValue> =
-            serde_dynamo::to_item(metadata_entry.clone()).unwrap();
-        let full_entry = metadata_entry.with_fragment(fragment);
-        let full_entry_av_map = serde_dynamo::to_item(full_entry.clone()).unwrap();
-
-        dynamodb_mock
-            .expect_get_item()
-            .with(
-                eq(Arc::<str>::from(METADATA_TABLE_NAME)),
-                eq(av_map),
-                eq(true),
-            )
-            .return_once(move |_, _, _| {
-                Ok(GetItemOutput::builder()
-                    .set_item(Some(full_entry_av_map))
-                    .build())
-            });
-
-        let store = initialize_immutable_store(s3mock, dynamodb_mock).await;
-        let store = Arc::new(store);
-
-        let result = store
-            .clone()
-            .query(repository.into(), address, StoreMatch::MatchFull)
-            .await
-            .unwrap();
-
-        assert_eq!(
-            StoreQueryResult {
-                fragment,
-                match_made: StoreMatch::MatchFull
-            },
-            result
-        );
-    }
-
-    #[tokio::test]
-    async fn test_query_immutable_obliterating() {
-        let repository = random::<Context>();
-        let (mut fragment, address, _) = fragment::generate_random();
-        fragment.flags |= FragmentFlags::PayloadStoredDurable | FragmentFlags::PayloadObliterating;
-
-        let s3mock = MockS3Impl::default();
-        let mut dynamodb_mock = MockDynamoDb::default();
-
-        mock_lookup_fragments(
-            &mut dynamodb_mock,
-            FragmentsEntry::new(repository, address),
-            StoreMatch::MatchFull,
-            StoreMatch::MatchFull,
-        );
-
-        let metadata_entry = FragmentMetadataEntry::new(address.hash);
-        let av_map: HashMap<String, AttributeValue> =
-            serde_dynamo::to_item(metadata_entry.clone()).unwrap();
-        let full_entry = metadata_entry.with_fragment(fragment);
-        let full_entry_av_map = serde_dynamo::to_item(full_entry.clone()).unwrap();
-
-        dynamodb_mock
-            .expect_get_item()
-            .with(
-                eq(Arc::<str>::from(METADATA_TABLE_NAME)),
-                eq(av_map),
-                eq(true),
-            )
-            .return_once(move |_, _, _| {
-                Ok(GetItemOutput::builder()
-                    .set_item(Some(full_entry_av_map))
-                    .build())
-            });
-
-        let store = initialize_immutable_store(s3mock, dynamodb_mock).await;
-        let store = Arc::new(store);
-
-        let result = store
-            .clone()
-            .query(repository.into(), address, StoreMatch::MatchFull)
-            .await
-            .unwrap();
-
-        assert_eq!(
-            StoreQueryResult {
-                fragment: Fragment::default(),
-                match_made: StoreMatch::MatchNone
-            },
-            result
-        );
-    }
-
-    #[tokio::test]
-    async fn test_query_immutable_partial_match() {
-        let repository = random::<Context>();
-        let (fragment, address, _) = fragment::generate_random();
-
-        let s3mock = MockS3Impl::default();
-        let mut dynamodb_mock = MockDynamoDb::default();
-
-        mock_lookup_fragments(
-            &mut dynamodb_mock,
-            FragmentsEntry::new(repository, address),
-            StoreMatch::MatchPartition,
-            StoreMatch::MatchPartition,
-        );
-
-        let metadata_entry = FragmentMetadataEntry::new(address.hash);
-        let av_map: HashMap<String, AttributeValue> =
-            serde_dynamo::to_item(metadata_entry.clone()).unwrap();
-        let full_entry = metadata_entry.with_fragment(fragment);
-        let full_entry_av_map = serde_dynamo::to_item(full_entry.clone()).unwrap();
-
-        dynamodb_mock
-            .expect_get_item()
-            .with(
-                eq(Arc::<str>::from(METADATA_TABLE_NAME)),
-                eq(av_map),
-                eq(true),
-            )
-            .return_once(move |_, _, _| {
-                Ok(GetItemOutput::builder()
-                    .set_item(Some(full_entry_av_map))
-                    .build())
-            });
-
-        let store = initialize_immutable_store(s3mock, dynamodb_mock).await;
-        let store = Arc::new(store);
-
-        let other_address = address_with_random_context(address);
-
-        let result = store
-            .clone()
-            .query(repository.into(), other_address, StoreMatch::MatchPartition)
-            .await
-            .unwrap();
-
-        assert_eq!(
-            StoreQueryResult {
-                fragment,
-                match_made: StoreMatch::MatchPartition
-            },
-            result
-        );
-    }
-
-    #[tokio::test]
-    async fn test_query_lower_specificity_match() {
-        let repository = random::<Context>();
-        let (fragment, address, _) = fragment::generate_random();
-
-        let other_address = address_with_random_context(address);
-
-        let s3mock = MockS3Impl::default();
-        let mut dynamodb_mock = MockDynamoDb::default();
-
-        mock_lookup_fragments(
-            &mut dynamodb_mock,
-            FragmentsEntry::new(repository, other_address),
-            StoreMatch::MatchPartition,
-            StoreMatch::MatchHash,
-        );
-
-        let metadata_entry = FragmentMetadataEntry::new(address.hash);
-        let av_map: HashMap<String, AttributeValue> =
-            serde_dynamo::to_item(metadata_entry.clone()).unwrap();
-        let full_entry = metadata_entry.with_fragment(fragment);
-        let full_entry_av_map = serde_dynamo::to_item(full_entry.clone()).unwrap();
-
-        dynamodb_mock
-            .expect_get_item()
-            .with(
-                eq(Arc::<str>::from(METADATA_TABLE_NAME)),
-                eq(av_map),
-                eq(true),
-            )
-            .return_once(move |_, _, _| {
-                Ok(GetItemOutput::builder()
-                    .set_item(Some(full_entry_av_map))
-                    .build())
-            });
-
-        let store = initialize_immutable_store(s3mock, dynamodb_mock).await;
-        let store = Arc::new(store);
-
-        let result = store
-            .clone()
-            .query(repository.into(), other_address, StoreMatch::MatchPartition)
-            .await
-            .unwrap();
-
-        assert_eq!(
-            StoreQueryResult {
-                fragment,
-                match_made: StoreMatch::MatchHash
-            },
-            result
-        );
-    }
-
-    #[tokio::test]
-    async fn test_put_immutable() {
-        let repository = random::<Context>();
-        let (fragment, address, payload) = fragment::generate_random();
-
-        let mut s3mock = MockS3Impl::default();
-        let mut dynamodb_mock = MockDynamoDb::default();
-
-        let entry = FragmentsEntry::new(repository, address);
-
-        // Mock the list objects calls that `put_immutable` makes when querying for an object.
-        mock_lookup_fragments(
-            &mut dynamodb_mock,
-            entry.clone(),
-            StoreMatch::MatchFull,
-            StoreMatch::MatchNone,
-        );
-
-        let item: HashMap<String, AttributeValue> =
-            serde_dynamo::to_item(FragmentMetadataEntry::new(address.hash).with_fragment(fragment))
-                .unwrap();
-
-        dynamodb_mock
-            .expect_put_item()
-            .with(eq(Arc::<str>::from(METADATA_TABLE_NAME)), eq(item.clone()))
-            .return_once(move |_, _| {
-                Ok(PutItemOutput::builder().set_attributes(Some(item)).build())
-            });
-
-        mock_associate_fragment(&mut dynamodb_mock, &entry);
-
-        s3mock
-            .expect_put_object()
-            .with(
-                eq(BUCKET),
-                eq(address.hash.to_string()),
-                eq(payload.to_vec()),
-            )
-            .return_once(move |_, _, _: Vec<u8>| Ok(PutObjectOutput::builder().build()));
-
-        let store = initialize_immutable_store(s3mock, dynamodb_mock).await;
-        let store = Arc::new(store);
-
-        store
-            .clone()
-            .put(repository.into(), address, fragment, Some(payload), false)
-            .await
-            .expect("failed to write to store");
-    }
-
-    #[tokio::test]
-    #[ignore] // Partial puts are not currently supported
-    async fn test_put_immutable_partial() {
-        let repository = random::<Context>();
-        let (fragment, address, payload) = fragment::generate_random();
-
-        let s3mock = MockS3Impl::default();
-        let mut dynamodb_mock = MockDynamoDb::default();
-
-        let entry = FragmentsEntry::new(repository, address);
-
-        // Mock the list objects calls that `put_immutable` makes when querying for an object.
-        mock_lookup_fragments(
-            &mut dynamodb_mock,
-            entry.clone(),
-            StoreMatch::MatchFull,
-            StoreMatch::MatchPartition,
-        );
-
-        let metadata_entry = FragmentMetadataEntry::new(address.hash);
-        let av_map: HashMap<String, AttributeValue> =
-            serde_dynamo::to_item(metadata_entry.clone()).unwrap();
-        let full_entry = metadata_entry.with_fragment(fragment);
-        let full_entry_av_map = serde_dynamo::to_item(full_entry.clone()).unwrap();
-
-        dynamodb_mock
-            .expect_get_item()
-            .with(
-                eq(Arc::<str>::from(METADATA_TABLE_NAME)),
-                eq(av_map),
-                eq(true),
-            )
-            .return_once(move |_, _, _| {
-                Ok(GetItemOutput::builder()
-                    .set_item(Some(full_entry_av_map))
-                    .build())
-            });
-
-        mock_associate_fragment(&mut dynamodb_mock, &entry);
-
-        let store = initialize_immutable_store(s3mock, dynamodb_mock).await;
-        let store = Arc::new(store);
-
-        store
-            .clone()
-            .put(repository.into(), address, fragment, Some(payload), false)
-            .await
-            .expect("failed to write to store");
-    }
-
-    #[tokio::test]
-    async fn test_put_immutable_obliterating() {
-        let repository = random::<Context>();
-        let (mut fragment, address, payload) = fragment::generate_random();
-        fragment.flags = FragmentFlags::PayloadObliterating.bits();
-
-        let s3mock = MockS3Impl::default();
-        let mut dynamodb_mock = MockDynamoDb::default();
-
-        let entry = FragmentsEntry::new(repository, address);
-
-        // Mock the list objects calls that `put_immutable` makes when querying for an object.
-        mock_lookup_fragments(
-            &mut dynamodb_mock,
-            entry.clone(),
-            StoreMatch::MatchFull,
-            StoreMatch::MatchFull,
-        );
-
-        let metadata_entry = FragmentMetadataEntry::new(address.hash);
-        let av_map: HashMap<String, AttributeValue> =
-            serde_dynamo::to_item(metadata_entry.clone()).unwrap();
-        let full_entry = metadata_entry.with_fragment(fragment);
-        let full_entry_av_map = serde_dynamo::to_item(full_entry.clone()).unwrap();
-
-        dynamodb_mock
-            .expect_get_item()
-            .with(
-                eq(Arc::<str>::from(METADATA_TABLE_NAME)),
-                eq(av_map),
-                eq(true),
-            )
-            .return_once(move |_, _, _| {
-                Ok(GetItemOutput::builder()
-                    .set_item(Some(full_entry_av_map))
-                    .build())
-            });
-
-        let store = initialize_immutable_store(s3mock, dynamodb_mock).await;
-        let store = Arc::new(store);
-
-        assert!(
-            store
-                .put(repository.into(), address, fragment, Some(payload), false)
-                .await
-                .expect_err("expected put to fail")
-                .is_internal()
-        );
-    }
-
-    #[tokio::test]
-    async fn test_put_immutable_obliterated() {
-        let repository = random::<Context>();
-        let (fragment, address, payload) = fragment::generate_random();
-
-        let mut s3mock = MockS3Impl::default();
-        let mut dynamodb_mock = MockDynamoDb::default();
-
-        let entry = FragmentsEntry::new(repository, address);
-
-        // Mock the list objects calls that `put_immutable` makes when querying for an object.
-        mock_lookup_fragments(
-            &mut dynamodb_mock,
-            entry.clone(),
-            StoreMatch::MatchFull,
-            StoreMatch::MatchHash,
-        );
-
-        let obliterated_fragment = Fragment {
-            flags: FragmentFlags::PayloadObliterated.bits(),
-            size_payload: 0,
-            size_content: 0,
-        };
-
-        let metadata_entry = FragmentMetadataEntry::new(address.hash);
-        let av_map: HashMap<String, AttributeValue> =
-            serde_dynamo::to_item(metadata_entry.clone()).unwrap();
-        let full_entry = metadata_entry.with_fragment(obliterated_fragment);
-        let full_entry_av_map = serde_dynamo::to_item(full_entry.clone()).unwrap();
-
-        dynamodb_mock
-            .expect_get_item()
-            .with(
-                eq(Arc::<str>::from(METADATA_TABLE_NAME)),
-                eq(av_map),
-                eq(true),
-            )
-            .return_once(move |_, _, _| {
-                Ok(GetItemOutput::builder()
-                    .set_item(Some(full_entry_av_map))
-                    .build())
-            });
-
-        let item: HashMap<String, AttributeValue> =
-            serde_dynamo::to_item(FragmentMetadataEntry::new(address.hash).with_fragment(fragment))
-                .unwrap();
-
-        dynamodb_mock
-            .expect_put_item()
-            .with(eq(Arc::<str>::from(METADATA_TABLE_NAME)), eq(item.clone()))
-            .return_once(move |_, _| {
-                Ok(PutItemOutput::builder().set_attributes(Some(item)).build())
-            });
-
-        mock_associate_fragment(&mut dynamodb_mock, &entry);
-
-        s3mock
-            .expect_put_object()
-            .with(
-                eq(BUCKET),
-                eq(address.hash.to_string()),
-                eq(payload.to_vec()),
-            )
-            .return_once(move |_, _, _: Vec<u8>| Ok(PutObjectOutput::builder().build()));
-
-        let store = initialize_immutable_store(s3mock, dynamodb_mock).await;
-        let store = Arc::new(store);
-
-        store
-            .put(repository.into(), address, fragment, Some(payload), false)
-            .await
-            .expect("failed to write to store");
-    }
-
-    #[tokio::test]
-    #[ignore] // Partial puts are not currently supported
-    async fn test_put_immutable_partial_hash_collision() {
-        let repository = random::<Context>();
-        let (fragment, address, payload) = fragment::generate_random();
-
-        let s3mock = MockS3Impl::default();
-        let mut dynamodb_mock = MockDynamoDb::default();
-
-        let entry = FragmentsEntry::new(repository, address);
-
-        // Mock the list objects calls that `put` makes when querying for an object.
-        mock_lookup_fragments(
-            &mut dynamodb_mock,
-            entry,
-            StoreMatch::MatchFull,
-            StoreMatch::MatchPartition,
-        );
-
-        let mut different_fragment = fragment;
-        different_fragment.size_content *= 2;
-
-        let metadata_entry = FragmentMetadataEntry::new(address.hash);
-        let av_map: HashMap<String, AttributeValue> =
-            serde_dynamo::to_item(metadata_entry.clone()).unwrap();
-        let full_entry = metadata_entry.with_fragment(different_fragment);
-        let full_entry_av_map = serde_dynamo::to_item(full_entry.clone()).unwrap();
-
-        dynamodb_mock
-            .expect_get_item()
-            .with(
-                eq(Arc::<str>::from(METADATA_TABLE_NAME)),
-                eq(av_map),
-                eq(true),
-            )
-            .return_once(move |_, _, _| {
-                Ok(GetItemOutput::builder()
-                    .set_item(Some(full_entry_av_map))
-                    .build())
-            });
-
-        let store = initialize_immutable_store(s3mock, dynamodb_mock).await;
-        let store = Arc::new(store);
-
-        assert!(
-            store
-                .put(repository.into(), address, fragment, Some(payload), false)
-                .await
-                .err()
-                .unwrap()
-                .is_internal()
-        );
-    }
-
-    #[tokio::test]
-    async fn test_put_immutable_payload_required() {
-        let repository = random::<Context>();
-        let (fragment, address, _) = fragment::generate_random();
-
-        let s3mock = MockS3Impl::default();
-        let mut dynamodb_mock = MockDynamoDb::default();
-
-        let entry = FragmentsEntry::new(repository, address);
-
-        // Mock the list objects calls that `put_immutable` makes when querying for an object.
-        mock_lookup_fragments(
-            &mut dynamodb_mock,
-            entry,
-            StoreMatch::MatchFull,
-            StoreMatch::MatchHash,
-        );
-
-        let metadata_entry = FragmentMetadataEntry::new(address.hash);
-        let av_map: HashMap<String, AttributeValue> =
-            serde_dynamo::to_item(metadata_entry.clone()).unwrap();
-        let full_entry = metadata_entry.with_fragment(fragment);
-        let full_entry_av_map = serde_dynamo::to_item(full_entry.clone()).unwrap();
-
-        dynamodb_mock
-            .expect_get_item()
-            .with(
-                eq(Arc::<str>::from(METADATA_TABLE_NAME)),
-                eq(av_map),
-                eq(true),
-            )
-            .return_once(move |_, _, _| {
-                Ok(GetItemOutput::builder()
-                    .set_item(Some(full_entry_av_map))
-                    .build())
-            });
-
-        let store = initialize_immutable_store(s3mock, dynamodb_mock).await;
-        let store = Arc::new(store);
-
-        assert!(
-            store
-                .put(repository.into(), address, fragment, None, false)
-                .await
-                .expect_err("should have returned an error")
-                .is_internal()
-        );
-    }
-
-    #[tokio::test]
-    async fn test_put_immutable_extra_data() {
-        let repository = random::<Context>();
-        let (fragment, address, payload) = fragment::generate_random();
-
-        let mut s3mock = MockS3Impl::default();
-        let mut dynamodb_mock = MockDynamoDb::default();
-
-        let entry = FragmentsEntry::new(repository, address);
-
-        // Mock the list objects calls that `put_immutable` makes when querying for an object.
-        mock_lookup_fragments(
-            &mut dynamodb_mock,
-            entry.clone(),
-            StoreMatch::MatchFull,
-            StoreMatch::MatchNone,
-        );
-
-        let item: HashMap<String, AttributeValue> =
-            serde_dynamo::to_item(FragmentMetadataEntry::new(address.hash).with_fragment(fragment))
-                .unwrap();
-
-        dynamodb_mock
-            .expect_put_item()
-            .with(eq(Arc::<str>::from(METADATA_TABLE_NAME)), eq(item.clone()))
-            .return_once(move |_, _| {
-                Ok(PutItemOutput::builder().set_attributes(Some(item)).build())
-            });
-
-        mock_associate_fragment(&mut dynamodb_mock, &entry);
-
-        let mut body = vec![];
-        body.extend_from_slice(payload.as_ref());
-
-        let real_len = body.len();
-
-        let extra = random::<[u8; 32]>();
-        body.extend_from_slice(extra.as_slice());
-
-        // Ensure we only write bytes equal to the actual payload size, regardless of how much extra
-        // was sent.
-        let expected = body[..real_len].to_vec();
-        s3mock
-            .expect_put_object()
-            .with(eq(BUCKET), eq(address.hash.to_string()), eq(expected))
-            .return_once(move |_, _, _: Vec<u8>| Ok(PutObjectOutput::builder().build()));
-
-        let store = initialize_immutable_store(s3mock, dynamodb_mock).await;
-        let store = Arc::new(store);
-
-        store
-            .put(repository.into(), address, fragment, Some(payload), false)
-            .await
-            .expect("failed to write to store");
-    }
-
-    #[tokio::test]
-    async fn test_put_immutable_not_enough_data() {
-        let repository = random::<Context>();
-        let (fragment, address, payload) = fragment::generate_random();
-
-        let s3mock = MockS3Impl::default();
-        let mut dynamodb_mock = MockDynamoDb::default();
-
-        let entry = FragmentsEntry::new(repository, address);
-
-        // Mock the list objects calls that `put_immutable` makes when querying for an object.
-        mock_lookup_fragments(
-            &mut dynamodb_mock,
-            entry.clone(),
-            StoreMatch::MatchFull,
-            StoreMatch::MatchNone,
-        );
-
-        mock_associate_fragment(&mut dynamodb_mock, &entry);
-
-        let mut body = vec![];
-        body.extend_from_slice(fragment.as_bytes());
-
-        let truncated_payload = Bytes::copy_from_slice(&payload[..payload.len() - 1]);
-
-        body.extend_from_slice(truncated_payload.as_ref());
-
-        let store = initialize_immutable_store(s3mock, dynamodb_mock).await;
-        let store = Arc::new(store);
-
-        assert!(
-            store
-                .put(
-                    repository.into(),
-                    address,
-                    fragment,
-                    Some(truncated_payload),
-                    false
-                )
-                .await
-                .expect_err("should have failed")
-                .is_internal()
-        );
-    }
-
-    #[tokio::test]
-    async fn test_get_immutable() {
-        let repository = random::<Context>();
-        let (fragment, address, payload) = fragment::generate_random();
-
-        let mut s3mock = MockS3Impl::default();
-        let mut dynamodb_mock = MockDynamoDb::default();
-
-        let entry = FragmentsEntry::new(repository, address);
-
-        // Mock the list objects calls that `put_immutable` makes when querying for an object.
-        mock_lookup_fragments(
-            &mut dynamodb_mock,
-            entry.clone(),
-            StoreMatch::MatchHash,
-            StoreMatch::MatchHash,
-        );
-
-        let metadata_entry = FragmentMetadataEntry::new(address.hash);
-        let av_map: HashMap<String, AttributeValue> =
-            serde_dynamo::to_item(metadata_entry.clone()).unwrap();
-        let full_entry_av_map =
-            serde_dynamo::to_item(metadata_entry.with_fragment(fragment)).unwrap();
-
-        dynamodb_mock
-            .expect_get_item()
-            .with(
-                eq(Arc::<str>::from(METADATA_TABLE_NAME)),
-                eq(av_map),
-                eq(true),
-            )
-            .return_once(move |_, _, _| {
-                Ok(GetItemOutput::builder()
-                    .set_item(Some(full_entry_av_map))
-                    .build())
-            });
-
-        let mut s3payload = vec![];
-        s3payload.extend_from_slice(payload.as_ref());
-
-        s3mock
-            .expect_get_object()
-            .with(eq(BUCKET), eq(address.hash.to_string()), eq(None))
-            .return_once(move |_, _, _| {
-                Ok(GetObjectOutput::builder()
-                    .set_body(Some(s3payload.into()))
-                    .build())
-            });
-
-        let store = initialize_immutable_store(s3mock, dynamodb_mock).await;
-        let store = Arc::new(store);
-
-        let (result_fragment, result_buffer) = store
-            .get(repository.into(), address, StoreMatch::MatchHash)
-            .await
-            .expect("failed to get from store");
-
-        assert_eq!(fragment, result_fragment);
-
-        assert_eq!(payload.as_ref(), result_buffer.as_ref());
-    }
-
-    #[tokio::test]
-    async fn test_get_immutable_not_found() {
-        let repository = random::<Context>();
-        let (fragment, address, payload) = fragment::generate_random();
-
-        let mut s3mock = MockS3Impl::default();
-        let mut dynamodb_mock = MockDynamoDb::default();
-
-        let entry = FragmentsEntry::new(repository, address);
-
-        // Mock the list objects calls that `put_immutable` makes when querying for an object.
-        mock_lookup_fragments(
-            &mut dynamodb_mock,
-            entry.clone(),
-            StoreMatch::MatchHash,
-            StoreMatch::MatchNone,
-        );
-
-        // `load` runs concurrently with `ensure_exists` in `get`, and its two internal
-        // futures (`load_metadata` and `get_s3_object_contents`) also race each other.
-        // Depending on select! polling order either or both may be called before being
-        // cancelled by the `ensure_exists` error, so these expectations are optional.
-        {
-            let metadata_entry = FragmentMetadataEntry::new(address.hash);
-            let av_map: HashMap<String, AttributeValue> =
-                serde_dynamo::to_item(metadata_entry.clone()).unwrap();
-            let full_entry_av_map =
-                serde_dynamo::to_item(metadata_entry.with_fragment(fragment)).unwrap();
-            dynamodb_mock
-                .expect_get_item()
-                .with(
-                    eq(Arc::<str>::from(METADATA_TABLE_NAME)),
-                    eq(av_map),
-                    eq(true),
-                )
-                .times(..=1)
-                .return_once(move |_, _, _| {
-                    Ok(GetItemOutput::builder()
-                        .set_item(Some(full_entry_av_map))
-                        .build())
-                });
-
-            let mut s3payload = vec![];
-            s3payload.extend_from_slice(payload.as_ref());
-            s3mock
-                .expect_get_object()
-                .with(eq(BUCKET), eq(address.hash.to_string()), eq(None))
-                .times(..=1)
-                .return_once(move |_, _, _| {
-                    Ok(GetObjectOutput::builder()
-                        .set_body(Some(s3payload.into()))
-                        .build())
-                });
-        }
-
-        let store = initialize_immutable_store(s3mock, dynamodb_mock).await;
-        let store = Arc::new(store);
-
-        assert!(
-            store
-                .get(repository.into(), address, StoreMatch::MatchHash,)
-                .await
-                .expect_err("should have returned an error")
-                .is_address_not_found()
-        );
-    }
-
-    #[tokio::test]
-    async fn test_get_immutable_obliterated() {
-        let (_, address, payload) = fragment::generate_random();
-        let repository = random::<Context>();
-        let fragment = Fragment {
-            flags: FragmentFlags::PayloadObliterating.bits(),
-            size_payload: 0,
-            size_content: 0,
-        };
-
-        let mut s3mock = MockS3Impl::default();
-        let mut dynamodb_mock = MockDynamoDb::default();
-
-        let entry = FragmentsEntry::new(repository, address);
-
-        // Mock the list objects calls that `get` makes when querying for an object.
-        mock_lookup_fragments(
-            &mut dynamodb_mock,
-            entry.clone(),
-            StoreMatch::MatchHash,
-            StoreMatch::MatchHash,
-        );
-
-        // the store will opportunistically try to get the data
-        // from s3, but because the metadata shows it is obliterated
-        // it will not load, even if s3 says it is there
-        {
-            let mut s3payload = vec![];
-            s3payload.extend_from_slice(payload.as_ref());
-
-            s3mock.expect_get_object().return_once(|_, _, _| {
-                Ok(GetObjectOutput::builder()
-                    .set_body(Some(s3payload.into()))
-                    .build())
-            });
-        }
-
-        let metadata_entry = FragmentMetadataEntry::new(address.hash);
-        let av_map: HashMap<String, AttributeValue> =
-            serde_dynamo::to_item(metadata_entry.clone()).unwrap();
-        let full_entry_av_map =
-            serde_dynamo::to_item(metadata_entry.with_fragment(fragment)).unwrap();
-
-        dynamodb_mock
-            .expect_get_item()
-            .with(
-                eq(Arc::<str>::from(METADATA_TABLE_NAME)),
-                eq(av_map),
-                eq(true),
-            )
-            .return_once(move |_, _, _| {
-                Ok(GetItemOutput::builder()
-                    .set_item(Some(full_entry_av_map))
-                    .build())
-            });
-
-        let store = initialize_immutable_store(s3mock, dynamodb_mock).await;
-        let store = Arc::new(store);
-
-        let err = store
-            .get(repository.into(), address, StoreMatch::MatchHash)
-            .await
-            .expect_err("should have returned an error");
-
-        assert!(err.is_address_not_found());
-    }
-
-    #[allow(dead_code)]
-    async fn test_get_immutable_partial_match() {
-        let repository = random::<Context>();
-        let (fragment, address, payload) = fragment::generate_random();
-
-        let mut s3mock = MockS3Impl::default();
-        let mut dynamodb_mock = DynamoDb::default();
-
-        let entry = FragmentsEntry::new(repository, address);
-
-        // Mock the list objects calls that `put_immutable` makes when querying for an object.
-        mock_lookup_fragments(
-            &mut dynamodb_mock,
-            entry.clone(),
-            StoreMatch::MatchFull,
-            StoreMatch::MatchPartition,
-        );
-
-        let mut s3payload = vec![];
-        s3payload.extend_from_slice(fragment.as_bytes());
-        s3payload.extend_from_slice(payload.as_ref());
-
-        s3mock
-            .expect_get_object()
-            .with(eq(BUCKET), eq(address.hash.to_string()), eq(None))
-            .return_once(move |_, _, _| {
-                Ok(GetObjectOutput::builder()
-                    .set_body(Some(s3payload.into()))
-                    .build())
-            });
-
-        let store = initialize_immutable_store(s3mock, dynamodb_mock).await;
-        let store = Arc::new(store);
-
-        let (result_fragment, result_buffer) = store
-            .get(repository.into(), address, StoreMatch::MatchPartition)
-            .await
-            .expect("failed to get from store");
-
-        assert_eq!(fragment, result_fragment);
-
-        assert_eq!(payload.as_ref(), result_buffer.as_ref());
-    }
-
-    #[tokio::test]
-    async fn test_get_immutable_payload_size_mismatch() {
-        let repository = random::<Context>();
-        let (fragment, address, payload) = fragment::generate_random();
-
-        let mut s3mock = MockS3Impl::default();
-        let mut dynamodb_mock = MockDynamoDb::default();
-
-        let entry = FragmentsEntry::new(repository, address);
-
-        // Mock the list objects calls that `put_immutable` makes when querying for an object.
-        mock_lookup_fragments(
-            &mut dynamodb_mock,
-            entry.clone(),
-            StoreMatch::MatchHash,
-            StoreMatch::MatchHash,
-        );
-
-        let metadata_entry = FragmentMetadataEntry::new(address.hash);
-        let av_map: HashMap<String, AttributeValue> =
-            serde_dynamo::to_item(metadata_entry.clone()).unwrap();
-        let full_entry_av_map =
-            serde_dynamo::to_item(metadata_entry.with_fragment(fragment)).unwrap();
-
-        dynamodb_mock
-            .expect_get_item()
-            .with(
-                eq(Arc::<str>::from(METADATA_TABLE_NAME)),
-                eq(av_map),
-                eq(true),
-            )
-            .return_once(move |_, _, _| {
-                Ok(GetItemOutput::builder()
-                    .set_item(Some(full_entry_av_map))
-                    .build())
-            });
-
-        let mut s3payload = vec![];
-        s3payload.extend_from_slice(&payload.as_ref()[..16]);
-
-        s3mock
-            .expect_get_object()
-            .with(eq(BUCKET), eq(address.hash.to_string()), eq(None))
-            .return_once(move |_, _, _| {
-                Ok(GetObjectOutput::builder()
-                    .set_body(Some(s3payload.into()))
-                    .build())
-            });
-
-        let store = initialize_immutable_store(s3mock, dynamodb_mock).await;
-        let store = Arc::new(store);
-
-        assert!(
-            store
-                .get(repository.into(), address, StoreMatch::MatchHash,)
-                .await
-                .expect_err("Request did not fail as expected")
-                .is_internal()
-        );
-    }
-
-    fn mock_load_fragment_metadata(
-        dynamodb_mock: &mut MockDynamoDb,
-        extra_flags: Option<FragmentFlags>,
-        fail: bool,
-    ) -> (Fragment, Address) {
-        let (mut fragment, address, _payload) = fragment::generate_random();
-
-        fragment.flags |= FragmentFlags::PayloadStoredDurable;
-        if let Some(extra_flags) = extra_flags {
-            fragment.flags |= extra_flags;
-        }
-
-        let metadata_entry = FragmentMetadataEntry::new(address.hash);
-        let av_map: HashMap<String, AttributeValue> =
-            serde_dynamo::to_item(metadata_entry.clone()).unwrap();
-        let full_entry_av_map =
-            serde_dynamo::to_item(metadata_entry.with_fragment(fragment)).unwrap();
-
-        // Mock loading the fragment metadata
-        dynamodb_mock
-            .expect_get_item()
-            .with(
-                eq(Arc::<str>::from(METADATA_TABLE_NAME)),
-                eq(av_map),
-                eq(true),
-            )
-            .return_once(move |_, _, _| {
-                if fail {
-                    Ok(GetItemOutput::builder().set_item(None).build())
-                } else {
-                    Ok(GetItemOutput::builder()
-                        .set_item(Some(full_entry_av_map))
-                        .build())
-                }
-            });
-
-        (fragment, address)
-    }
-
-    #[tokio::test]
-    async fn test_obliterate_already_obliterating() {
-        let repository = random::<Context>();
-
-        let s3mock = MockS3Impl::default();
-        let mut dynamodb_mock = MockDynamoDb::default();
-
-        let (_fragment, address) = mock_load_fragment_metadata(
-            &mut dynamodb_mock,
-            Some(FragmentFlags::PayloadObliterating),
-            false, /* fail */
-        );
-
-        let store = initialize_immutable_store(s3mock, dynamodb_mock).await;
-
-        let stats = Default::default();
-        Arc::new(store)
-            .obliterate(repository.into(), address, stats)
-            .await
-            .expect("obliterate failed");
-    }
-
-    #[tokio::test]
-    async fn test_obliterate_already_obliterated() {
-        let repository = random::<Context>();
-
-        let s3mock = MockS3Impl::default();
-        let mut dynamodb_mock = MockDynamoDb::default();
-
-        let (_fragment, address) = mock_load_fragment_metadata(
-            &mut dynamodb_mock,
-            Some(FragmentFlags::PayloadObliterated),
-            false, /* fail */
-        );
-
-        let store = initialize_immutable_store(s3mock, dynamodb_mock).await;
-
-        let stats = Default::default();
-        Arc::new(store)
-            .obliterate(repository.into(), address, stats)
-            .await
-            .expect("obliterate failed");
-    }
-
-    #[derive(Clone, Copy)]
-    enum MockLockMode {
-        Finalize,
-        Revert,
-        AcquireFail,
-        FinalizeFail,
-        None,
-    }
+    const FRAGMENT_STATE_TABLE_NAME: &str = "fragment-state";
 
     fn aws_error<E>(error: E, status: u16) -> AwsError<SdkError<E, HttpResponse>> {
         AwsError::AwsSdkError(SdkError::ServiceError(
@@ -2941,1092 +2093,2127 @@ mod test {
         ))
     }
 
-    fn mock_acquire_obliterate_lock(
-        dynamodb_mock: &mut MockDynamoDb,
-        fragment: Fragment,
-        hash: Hash,
-        lock_mode: MockLockMode,
-        in_sequence: bool,
-    ) {
-        let mut updated_metadata = fragment;
-        updated_metadata.flags |= FragmentFlags::PayloadObliterating;
-        let item: HashMap<String, AttributeValue> =
-            serde_dynamo::to_item(FragmentMetadataEntry::new(hash).with_fragment(updated_metadata))
-                .expect("failed to serialize");
+    fn blob(item: &HashMap<String, AttributeValue>, key: &str) -> Vec<u8> {
+        item.get(key)
+            .and_then(|value| value.as_b().ok())
+            .map(|value| value.as_ref().to_vec())
+            .unwrap_or_default()
+    }
 
-        let mut seq = mockall::Sequence::default();
+    /// An in-memory stand-in for the bucket and the two tables.
+    ///
+    /// The tests are written against behaviour rather than a call sequence: they put and get
+    /// through the real store and assert on what ends up stored. That is what lets the concurrency
+    /// test exist at all — a mock programmed with an expected order of calls cannot express
+    /// "any interleaving, and the result must still be coherent".
+    /// A stored object: its body, and the object metadata written with it.
+    type StoredObject = (Vec<u8>, HashMap<String, String>);
 
-        // Mock the metadata updates to acquire the lock
-        let mut expectation = dynamodb_mock.expect_put_item_conditional().times(1);
+    /// An operation the fake can be told to fail, so error paths are reachable.
+    #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+    enum Fault {
+        StateRead,
+        StateReadTimeout,
+        StateReadBroken,
+        StateWrite,
+        StateDelete,
+        AssociationWrite,
+        AssociationDelete,
+        AssociationCount,
+        ObjectDelete,
+        ObjectList,
+    }
 
-        if in_sequence {
-            expectation = expectation.in_sequence(&mut seq);
+    #[derive(Default)]
+    struct Storage {
+        faults: HashSet<Fault>,
+        race_state: Option<(Hash, FragmentState)>,
+        object_reads: usize,
+        objects: HashMap<Vec<u8>, StoredObject>,
+        associations: HashMap<(Vec<u8>, Vec<u8>), HashMap<String, AttributeValue>>,
+        state: HashMap<Vec<u8>, HashMap<String, AttributeValue>>,
+    }
+
+    #[derive(Clone, Default)]
+    struct Fake(Arc<Mutex<Storage>>);
+
+    impl Fake {
+        fn lock(&self) -> std::sync::MutexGuard<'_, Storage> {
+            self.0.lock().unwrap()
         }
 
-        expectation
-            .with(
-                eq(Arc::<str>::from(METADATA_TABLE_NAME)),
-                eq(item.clone()),
-                eq(UpdateMetadataCondition(fragment)),
-            )
-            .return_once(move |_, _, _| {
-                if matches!(lock_mode, MockLockMode::AcquireFail) {
-                    Err(aws_error(
-                        PutItemError::ConditionalCheckFailedException(
-                            ConditionalCheckFailedException::builder()
-                                .set_item(Some(item))
-                                .build(),
-                        ),
-                        400u16,
-                    ))
+        /// Make `fault` fail from now on. Latched rather than one-shot, so a retrying caller sees a
+        /// persistent failure rather than one that heals underneath it.
+        fn fail(&self, fault: Fault) {
+            self.lock().faults.insert(fault);
+        }
+
+        /// Move `hash` into `state` at the moment its payload is uploaded, so a put reaches its
+        /// publish step having probed before an obliteration and uploaded after it. That window
+        /// cannot be hit by ordering calls from the outside.
+        fn obliterate_during_upload(&self, hash: Hash, state: FragmentState) {
+            self.lock().race_state = Some((hash, state));
+        }
+
+        fn failing(&self, fault: Fault) -> bool {
+            self.lock().faults.contains(&fault)
+        }
+
+        fn object_reads(&self) -> usize {
+            self.lock().object_reads
+        }
+
+        fn object(&self, hash: Hash) -> Option<StoredObject> {
+            self.lock()
+                .objects
+                .get(&hash.to_string().into_bytes())
+                .cloned()
+        }
+
+        fn stored_fragment(&self, hash: Hash) -> Option<Fragment> {
+            self.object(hash)
+                .map(|(_, metadata)| from_object_metadata(Some(&metadata)).unwrap())
+        }
+
+        fn state_of(&self, hash: Hash) -> Option<FragmentState> {
+            self.lock()
+                .state
+                .get(hash.data().as_slice())
+                .map(|item| serde_dynamo::from_item::<_, FragmentStateEntry>(item.clone()).unwrap())
+                .map(|entry| entry.state())
+        }
+
+        fn association_count(&self, hash: Hash) -> usize {
+            self.lock()
+                .associations
+                .keys()
+                .filter(|(stored, _)| stored == hash.data())
+                .count()
+        }
+
+        fn set_state(&self, hash: Hash, state: FragmentState) {
+            let item = serde_dynamo::to_item(FragmentStateEntry::new(hash, state)).unwrap();
+            self.lock().state.insert(hash.data().to_vec(), item);
+        }
+
+        /// Write a row in the shape used before fragments moved onto the object: no `state`, and a
+        /// whole flattened fragment whose `flags` also carry the obliteration bits.
+        fn set_fragment_metadata_row(&self, hash: Hash, fragment: Fragment) {
+            let item = HashMap::from([
+                (
+                    "hash".to_owned(),
+                    AttributeValue::B(Blob::new(hash.data().to_vec())),
+                ),
+                (
+                    "flags".to_owned(),
+                    AttributeValue::N(fragment.flags.to_string()),
+                ),
+                (
+                    "size_payload".to_owned(),
+                    AttributeValue::N(fragment.size_payload.to_string()),
+                ),
+                (
+                    "size_content".to_owned(),
+                    AttributeValue::N(fragment.size_content.to_string()),
+                ),
+            ]);
+
+            self.lock().state.insert(hash.data().to_vec(), item);
+        }
+
+        /// Delete an object while leaving every reference to it in place, as an obliteration
+        /// interrupted before its tombstone or an S3 durability event would.
+        fn lose_object(&self, hash: Hash) {
+            self.lock().objects.remove(&hash.to_string().into_bytes());
+        }
+
+        /// Store an object the way one was stored before the fragment moved onto it: bare bytes,
+        /// no fragment metadata.
+        fn put_object_without_metadata(&self, hash: Hash, body: &[u8]) {
+            self.lock().objects.insert(
+                hash.to_string().into_bytes(),
+                (body.to_vec(), HashMap::new()),
+            );
+        }
+
+        /// Store an object whose metadata is present but unreadable.
+        fn put_object_with_damaged_metadata(&self, hash: Hash, body: &[u8]) {
+            let mut metadata = HashMap::new();
+            metadata.insert("lore-fragment".to_owned(), "not:a:fragment".to_owned());
+
+            self.lock()
+                .objects
+                .insert(hash.to_string().into_bytes(), (body.to_vec(), metadata));
+        }
+
+        fn add_association(&self, repository: Context, address: Address) {
+            let entry = FragmentsEntry::new(repository, address);
+            let item: HashMap<String, AttributeValue> = serde_dynamo::to_item(&entry).unwrap();
+            self.lock().associations.insert(
+                (
+                    entry.hash.data().to_vec(),
+                    entry.repository_context.to_vec(),
+                ),
+                item,
+            );
+        }
+    }
+
+    /// Wire the fake into the generated mocks.
+    ///
+    /// Every expectation is unbounded and stateful, so a test asserts on the resulting storage
+    /// rather than on how many times something was called.
+    fn wire(fake: &Fake) -> (MockS3Impl, MockDynamoDb) {
+        let mut s3 = MockS3Impl::default();
+        let mut dynamodb = MockDynamoDb::default();
+
+        let f = fake.clone();
+        s3.expect_put_object::<Vec<u8>>()
+            .returning(move |_, key, body, metadata| {
+                let mut storage = f.lock();
+                storage.objects.insert(
+                    key.as_bytes().to_vec(),
+                    (body, metadata.unwrap_or_default()),
+                );
+
+                if let Some((hash, state)) = storage.race_state.take() {
+                    let item = serde_dynamo::to_item(FragmentStateEntry::new(hash, state)).unwrap();
+                    storage.state.insert(hash.data().to_vec(), item);
+                }
+
+                Ok(PutObjectOutput::builder().build())
+            });
+
+        let f = fake.clone();
+        s3.expect_get_object().returning(move |_, key, _| {
+            let mut storage = f.lock();
+            storage.object_reads += 1;
+            match storage.objects.get(key.as_bytes()) {
+                Some((body, metadata)) => Ok(GetObjectOutput::builder()
+                    .set_body(Some(body.clone().into()))
+                    .set_metadata(Some(metadata.clone()))
+                    .build()),
+                None => Err(aws_error(
+                    GetObjectError::NoSuchKey(NoSuchKey::builder().build()),
+                    404,
+                )),
+            }
+        });
+
+        let f = fake.clone();
+        s3.expect_head_object().returning(move |_, key| {
+            let mut storage = f.lock();
+            storage.object_reads += 1;
+            match storage.objects.get(key.as_bytes()) {
+                Some((_, metadata)) => Ok(HeadObjectOutput::builder()
+                    .set_metadata(Some(metadata.clone()))
+                    .build()),
+                None => Err(aws_error(
+                    HeadObjectError::NotFound(NotFound::builder().build()),
+                    404,
+                )),
+            }
+        });
+
+        let f = fake.clone();
+        s3.expect_delete_object().returning(move |_, key, _| {
+            if f.failing(Fault::ObjectDelete) {
+                return Err(aws_error(
+                    DeleteObjectError::generic(ErrorMetadata::builder().code("500").build()),
+                    500,
+                ));
+            }
+
+            f.lock().objects.remove(key.as_bytes());
+            Ok(DeleteObjectOutput::builder().build())
+        });
+
+        let f = fake.clone();
+        s3.expect_list_versions().returning(move |_, _| {
+            if f.failing(Fault::ObjectList) {
+                return Err(aws_error(
+                    ListObjectVersionsError::generic(ErrorMetadata::builder().code("500").build()),
+                    500,
+                ));
+            }
+
+            Ok(ListObjectVersionsOutput::builder().build())
+        });
+
+        let f = fake.clone();
+        dynamodb
+            .expect_get_item()
+            .returning(move |table, item, _| {
+                if &**table == FRAGMENT_STATE_TABLE_NAME {
+                    if f.failing(Fault::StateReadTimeout) {
+                        return Err(AwsError::AwsSdkError(SdkError::timeout_error(Box::new(
+                            std::io::Error::other("injected timeout"),
+                        ))));
+                    }
+                    if f.failing(Fault::StateReadBroken) {
+                        return Err(aws_error(
+                            GetItemError::ResourceNotFoundException(
+                                ResourceNotFoundException::builder().build(),
+                            ),
+                            400,
+                        ));
+                    }
+                    if f.failing(Fault::StateRead) {
+                        return Err(throughput_exceeded(
+                            GetItemError::ProvisionedThroughputExceededException(
+                                throttling_exception(),
+                            ),
+                        ));
+                    }
+                }
+
+                let storage = f.lock();
+                let found = if &**table == FRAGMENT_STATE_TABLE_NAME {
+                    storage.state.get(&blob(&item, "hash")).cloned()
                 } else {
+                    storage
+                        .associations
+                        .get(&(blob(&item, "hash"), blob(&item, "repository_context")))
+                        .cloned()
+                };
+
+                Ok(GetItemOutput::builder().set_item(found).build())
+            });
+
+        let f = fake.clone();
+        dynamodb
+            .expect_batch_get_item()
+            .returning(move |_, keys, _| {
+                let storage = f.lock();
+
+                Ok(keys
+                    .iter()
+                    .filter_map(|key| {
+                        storage
+                            .associations
+                            .get(&(blob(key, "hash"), blob(key, "repository_context")))
+                            .cloned()
+                    })
+                    .collect())
+            });
+
+        let f = fake.clone();
+        dynamodb.expect_put_item().returning(move |table, item| {
+            if &**table == FRAGMENTS_TABLE_NAME && f.failing(Fault::AssociationWrite) {
+                return Err(throughput_exceeded(
+                    PutItemError::ProvisionedThroughputExceededException(throttling_exception()),
+                ));
+            }
+
+            let mut storage = f.lock();
+            if &**table == FRAGMENT_STATE_TABLE_NAME {
+                storage.state.insert(blob(&item, "hash"), item);
+            } else {
+                storage.associations.insert(
+                    (blob(&item, "hash"), blob(&item, "repository_context")),
+                    item,
+                );
+            }
+            Ok(PutItemOutput::builder().build())
+        });
+
+        let f = fake.clone();
+        dynamodb
+            .expect_put_item_conditional::<RowAbsent>()
+            .returning(move |_, item, _| {
+                let mut storage = f.lock();
+                let key = blob(&item, "hash");
+
+                if let Some(existing) = storage.state.get(&key) {
+                    return Err(conditional_check_failed(existing.clone()));
+                }
+
+                storage.state.insert(key, item);
+                Ok(PutItemOutput::builder().build())
+            });
+
+        let f = fake.clone();
+        dynamodb
+            .expect_put_item_conditional::<StateUnchanged>()
+            .returning(move |_, item, condition| {
+                if f.failing(Fault::StateWrite) {
+                    return Err(throughput_exceeded(
+                        PutItemError::ProvisionedThroughputExceededException(
+                            throttling_exception(),
+                        ),
+                    ));
+                }
+
+                let mut storage = f.lock();
+                let key = blob(&item, "hash");
+
+                let current = storage.state.get(&key).map(|existing| {
+                    serde_dynamo::from_item::<_, FragmentStateEntry>(existing.clone())
+                        .unwrap()
+                        .state()
+                });
+
+                if current == Some(condition.0) {
+                    storage.state.insert(key, item);
                     Ok(PutItemOutput::builder().build())
-                }
-            });
-
-        match lock_mode {
-            MockLockMode::Finalize | MockLockMode::FinalizeFail => {
-                let mut final_metadata = updated_metadata;
-                final_metadata.flags = FragmentFlags::PayloadObliterated.bits();
-                final_metadata.size_content = 0;
-                final_metadata.size_payload = 0;
-                let item: HashMap<String, AttributeValue> = serde_dynamo::to_item(
-                    FragmentMetadataEntry::new(hash).with_fragment(final_metadata),
-                )
-                .expect("failed to serialize");
-
-                // And a second one that releases the lock
-                let mut expectation = dynamodb_mock.expect_put_item_conditional().times(1);
-
-                if in_sequence {
-                    expectation = expectation.in_sequence(&mut seq);
-                }
-
-                expectation
-                    .with(
-                        eq(Arc::<str>::from(METADATA_TABLE_NAME)),
-                        eq(item.clone()),
-                        eq(UpdateMetadataCondition(updated_metadata)),
-                    )
-                    .return_once(move |_, _, _| {
-                        if matches!(lock_mode, MockLockMode::Finalize) {
-                            Ok(PutItemOutput::builder().build())
-                        } else {
-                            Err(aws_error(
-                                PutItemError::ConditionalCheckFailedException(
-                                    ConditionalCheckFailedException::builder()
-                                        .set_item(Some(item))
-                                        .build(),
-                                ),
-                                400u16,
-                            ))
-                        }
-                    });
-            }
-            MockLockMode::Revert => {
-                let item: HashMap<String, AttributeValue> =
-                    serde_dynamo::to_item(FragmentMetadataEntry::new(hash).with_fragment(fragment))
-                        .expect("failed to serialize");
-
-                // And a second one that releases the lock
-                let mut expectation = dynamodb_mock.expect_put_item_conditional().times(1);
-
-                if in_sequence {
-                    expectation = expectation.in_sequence(&mut seq);
-                }
-
-                expectation
-                    .with(
-                        eq(Arc::<str>::from(METADATA_TABLE_NAME)),
-                        eq(item),
-                        eq(UpdateMetadataCondition(updated_metadata)),
-                    )
-                    .return_once(move |_, _, _| Ok(PutItemOutput::builder().build()));
-            }
-            MockLockMode::None | MockLockMode::AcquireFail => {}
-        }
-    }
-
-    fn mock_count_associations(
-        dynamodb_mock: &mut MockDynamoDb,
-        hash: Hash,
-        count: i32,
-        fail: bool,
-    ) {
-        dynamodb_mock
-            .expect_query_single()
-            .times(1)
-            .with(
-                eq(Arc::<str>::from(FRAGMENTS_TABLE_NAME)),
-                eq(FragmentsQuery::HashCount(hash)),
-            )
-            .return_once(move |_, _| {
-                if fail {
-                    Err(aws_error(
-                        QueryError::ProvisionedThroughputExceededException(
-                            ProvisionedThroughputExceededException::builder().build(),
-                        ),
-                        503u16,
-                    ))
                 } else {
-                    Ok(QueryOutput::builder().count(count).build())
-                }
-            });
-    }
-
-    fn mock_remove_association(
-        dynamodb_mock: &mut MockDynamoDb,
-        repository: Context,
-        address: Address,
-        fail: bool,
-    ) {
-        let entry = FragmentsEntry::new(repository, address);
-        let item: HashMap<String, AttributeValue> =
-            serde_dynamo::to_item(entry).expect("failed to serialize fragments entry");
-
-        dynamodb_mock
-            .expect_delete_item()
-            .with(eq(Arc::<str>::from(FRAGMENTS_TABLE_NAME)), eq(item))
-            .return_once(move |_, _| {
-                if fail {
-                    Err(aws_error(
-                        DeleteItemError::ProvisionedThroughputExceededException(
-                            ProvisionedThroughputExceededException::builder().build(),
-                        ),
-                        503u16,
+                    Err(conditional_check_failed(
+                        storage.state.get(&key).cloned().unwrap_or_default(),
                     ))
-                } else {
-                    Ok(DeleteItemOutput::builder().build())
                 }
             });
-    }
 
-    fn mock_list_versions(
-        s3mock: &mut MockS3Impl,
-        hash: Hash,
-        version: Option<String>,
-        fail: bool,
-    ) {
-        s3mock
-            .expect_list_versions()
-            .with(eq(BUCKET), eq(hash.to_string()))
-            .return_once(move |_, _| {
-                if fail {
-                    Err(aws_error(
-                        ListObjectVersionsError::generic(ErrorMetadata::builder().build()),
-                        500u16,
-                    ))
-                } else {
-                    let versions = if version.is_some() {
-                        Some(vec![
-                            ObjectVersion::builder().set_version_id(version).build(),
-                        ])
-                    } else {
-                        None
-                    };
-                    Ok(ListObjectVersionsOutput::builder()
-                        .set_versions(versions)
-                        .build())
-                }
-            });
-    }
-
-    fn mock_delete_payload(
-        s3mock: &mut MockS3Impl,
-        hash: Hash,
-        version: Option<String>,
-        fail: bool,
-    ) {
-        s3mock
-            .expect_delete_object()
-            .with(eq(BUCKET), eq(hash.to_string()), eq(version))
-            .return_once(move |_, _, _| {
-                if fail {
-                    Err(aws_error(
-                        DeleteObjectError::generic(ErrorMetadata::builder().build()),
-                        500u16,
-                    ))
-                } else {
-                    Ok(DeleteObjectOutput::builder().build())
-                }
-            });
-    }
-
-    #[tokio::test]
-    #[traced_test]
-    async fn test_obliterate_single_fragment() {
-        let repository = random::<Context>();
-
-        let mut s3mock = MockS3Impl::default();
-        let mut dynamodb_mock = MockDynamoDb::default();
-
-        let (fragment, address) =
-            mock_load_fragment_metadata(&mut dynamodb_mock, None, false /* fail */);
-
-        mock_acquire_obliterate_lock(
-            &mut dynamodb_mock,
-            fragment,
-            address.hash,
-            MockLockMode::Finalize,
-            true, /* in sequence */
-        );
-
-        // Mock the association count, this is currently done twice (for now), the first time we
-        // return 1, the second 0.
-        mock_count_associations(&mut dynamodb_mock, address.hash, 0, false /* fail */);
-
-        mock_remove_association(
-            &mut dynamodb_mock,
-            repository,
-            address,
-            false, /* fail */
-        );
-
-        let version_id = Some("some-version".to_string());
-        mock_list_versions(&mut s3mock, address.hash, version_id.clone(), false);
-
-        mock_delete_payload(&mut s3mock, address.hash, version_id, false /* fail */);
-
-        let store = initialize_immutable_store(s3mock, dynamodb_mock).await;
-
-        let stats: Arc<StoreObliterateStats> = Default::default();
-        Arc::new(store)
-            .obliterate(repository.into(), address, stats.clone())
-            .await
-            .expect("obliterate failed");
-
-        // The rest of the necessary assertions are handled by expectations on the Dynamo and S3
-        // mocks.
-        assert_eq!(stats.num_fragments.load(Ordering::Relaxed), 1);
-        assert_eq!(stats.num_payloads.load(Ordering::Relaxed), 1);
-    }
-
-    #[tokio::test]
-    #[traced_test]
-    async fn test_obliterate_single_fragment_multiple_associations() {
-        let repository = random::<Context>();
-
-        let s3mock = MockS3Impl::default();
-        let mut dynamodb_mock = MockDynamoDb::default();
-
-        let (fragment, address) =
-            mock_load_fragment_metadata(&mut dynamodb_mock, None, false /* fail */);
-
-        mock_acquire_obliterate_lock(
-            &mut dynamodb_mock,
-            fragment,
-            address.hash,
-            MockLockMode::Revert,
-            true, /* in sequence */
-        );
-
-        // Mock the association count, this is currently done twice (for now), the first time we
-        // return 2, the second 1.
-        mock_count_associations(&mut dynamodb_mock, address.hash, 1, false /* fail */);
-
-        mock_remove_association(
-            &mut dynamodb_mock,
-            repository,
-            address,
-            false, /* fail */
-        );
-
-        let store = initialize_immutable_store(s3mock, dynamodb_mock).await;
-
-        let stats: Arc<StoreObliterateStats> = Default::default();
-        Arc::new(store)
-            .obliterate(repository.into(), address, stats.clone())
-            .await
-            .expect("obliterate failed");
-
-        // The rest of the necessary assertions are handled by expectations on the Dynamo and S3
-        // mocks.
-        assert_eq!(stats.num_fragments.load(Ordering::Relaxed), 1);
-        assert_eq!(stats.num_payloads.load(Ordering::Relaxed), 0);
-    }
-
-    #[tokio::test]
-    #[traced_test]
-    async fn test_obliterate_single_fragment_metadata_load_fails() {
-        let repository = random::<Context>();
-
-        let s3mock = MockS3Impl::default();
-        let mut dynamodb_mock = MockDynamoDb::default();
-
-        let (_fragment, address) =
-            mock_load_fragment_metadata(&mut dynamodb_mock, None, true /* fail */);
-
-        let store = initialize_immutable_store(s3mock, dynamodb_mock).await;
-
-        let stats: Arc<StoreObliterateStats> = Default::default();
-        assert!(
-            Arc::new(store)
-                .obliterate(repository.into(), address, stats.clone())
-                .await
-                .unwrap_err()
-                .is_address_not_found()
-        );
-
-        // The rest of the necessary assertions are handled by expectations on the Dynamo and S3
-        // mocks.
-        assert_eq!(stats.num_fragments.load(Ordering::Relaxed), 0);
-        assert_eq!(stats.num_payloads.load(Ordering::Relaxed), 0);
-    }
-
-    #[tokio::test]
-    async fn test_load_metadata_sdk_timeout_returns_slow_down() {
-        let (_fragment, address, _payload) = fragment::generate_random();
-
-        let s3mock = MockS3Impl::default();
-        let mut dynamodb_mock = MockDynamoDb::default();
-
-        let metadata_entry = FragmentMetadataEntry::new(address.hash);
-        let av_map: HashMap<String, AttributeValue> =
-            serde_dynamo::to_item(metadata_entry).unwrap();
-
-        #[derive(Debug, thiserror::Error)]
-        #[error("stub")]
-        struct StubError;
-
-        dynamodb_mock
-            .expect_get_item()
-            .with(
-                eq(Arc::<str>::from(METADATA_TABLE_NAME)),
-                eq(av_map),
-                eq(true),
-            )
-            .return_once(move |_, _, _| {
-                Err(AwsError::AwsSdkError(SdkError::TimeoutError(
-                    TimeoutError::builder().source(Box::new(StubError)).build(),
-                )))
-            });
-
-        let store = initialize_immutable_store(s3mock, dynamodb_mock).await;
-
-        assert!(
-            store
-                .load_metadata(address.hash)
-                .await
-                .unwrap_err()
-                .is_slow_down()
-        );
-    }
-
-    #[tokio::test]
-    async fn test_load_metadata_sdk_service_error_returns_address_not_found() {
-        let (_fragment, address, _payload) = fragment::generate_random();
-
-        let s3mock = MockS3Impl::default();
-        let mut dynamodb_mock = MockDynamoDb::default();
-
-        let metadata_entry = FragmentMetadataEntry::new(address.hash);
-        let av_map: HashMap<String, AttributeValue> =
-            serde_dynamo::to_item(metadata_entry).unwrap();
-
-        dynamodb_mock
-            .expect_get_item()
-            .with(
-                eq(Arc::<str>::from(METADATA_TABLE_NAME)),
-                eq(av_map),
-                eq(true),
-            )
-            .return_once(move |_, _, _| {
-                Err(aws_error(
-                    GetItemError::ResourceNotFoundException(
-                        ResourceNotFoundException::builder()
-                            .message("Table not found")
-                            .build(),
-                    ),
-                    400u16,
-                ))
-            });
-
-        let store = initialize_immutable_store(s3mock, dynamodb_mock).await;
-
-        assert!(
-            store
-                .load_metadata(address.hash)
-                .await
-                .unwrap_err()
-                .is_address_not_found()
-        );
-    }
-
-    #[tokio::test]
-    #[traced_test]
-    async fn test_obliterate_single_fragment_acquire_lock_fails() {
-        let repository = random::<Context>();
-
-        let s3mock = MockS3Impl::default();
-        let mut dynamodb_mock = MockDynamoDb::default();
-
-        let (fragment, address) =
-            mock_load_fragment_metadata(&mut dynamodb_mock, None, false /* fail */);
-
-        mock_acquire_obliterate_lock(
-            &mut dynamodb_mock,
-            fragment,
-            address.hash,
-            MockLockMode::AcquireFail,
-            true, /* in sequence */
-        );
-
-        let store = initialize_immutable_store(s3mock, dynamodb_mock).await;
-
-        let stats: Arc<StoreObliterateStats> = Default::default();
-        assert!(
-            Arc::new(store)
-                .obliterate(repository.into(), address, stats.clone())
-                .await
-                .unwrap_err()
-                .is_internal(),
-        );
-
-        // The rest of the necessary assertions are handled by expectations on the Dynamo and S3
-        // mocks.
-        assert_eq!(stats.num_fragments.load(Ordering::Relaxed), 0);
-        assert_eq!(stats.num_payloads.load(Ordering::Relaxed), 0);
-    }
-
-    #[tokio::test]
-    #[traced_test]
-    async fn test_obliterate_single_fragment_count_associations_fails() {
-        let repository = random::<Context>();
-
-        let s3mock = MockS3Impl::default();
-        let mut dynamodb_mock = MockDynamoDb::default();
-
-        let (fragment, address) =
-            mock_load_fragment_metadata(&mut dynamodb_mock, None, false /* fail */);
-
-        mock_acquire_obliterate_lock(
-            &mut dynamodb_mock,
-            fragment,
-            address.hash,
-            MockLockMode::None,
-            true, /* in sequence */
-        );
-
-        mock_remove_association(&mut dynamodb_mock, repository, address, false);
-
-        mock_count_associations(&mut dynamodb_mock, address.hash, 0, true /* fail */);
-
-        let store = initialize_immutable_store(s3mock, dynamodb_mock).await;
-
-        let stats: Arc<StoreObliterateStats> = Default::default();
-        assert!(
-            Arc::new(store)
-                .obliterate(repository.into(), address, stats.clone())
-                .await
-                .unwrap_err()
-                .is_slow_down()
-        );
-
-        // The rest of the necessary assertions are handled by expectations on the Dynamo and S3
-        // mocks.
-        assert_eq!(stats.num_fragments.load(Ordering::Relaxed), 1);
-        assert_eq!(stats.num_payloads.load(Ordering::Relaxed), 0);
-    }
-
-    #[tokio::test]
-    #[traced_test]
-    async fn test_obliterate_single_fragment_remove_fragment_association_fails() {
-        let repository = random::<Context>();
-
-        let s3mock = MockS3Impl::default();
-        let mut dynamodb_mock = MockDynamoDb::default();
-
-        let (fragment, address) =
-            mock_load_fragment_metadata(&mut dynamodb_mock, None, false /* fail */);
-
-        mock_acquire_obliterate_lock(
-            &mut dynamodb_mock,
-            fragment,
-            address.hash,
-            MockLockMode::None,
-            true, /* in sequence */
-        );
-
-        mock_remove_association(
-            &mut dynamodb_mock,
-            repository,
-            address,
-            true, /* fail */
-        );
-
-        let store = initialize_immutable_store(s3mock, dynamodb_mock).await;
-
-        let stats: Arc<StoreObliterateStats> = Default::default();
-        assert!(
-            Arc::new(store)
-                .obliterate(repository.into(), address, stats.clone())
-                .await
-                .unwrap_err()
-                .is_slow_down()
-        );
-
-        // The rest of the necessary assertions are handled by expectations on the Dynamo and S3
-        // mocks.
-        assert_eq!(stats.num_fragments.load(Ordering::Relaxed), 0);
-        assert_eq!(stats.num_payloads.load(Ordering::Relaxed), 0);
-    }
-
-    // Delete payload fails
-    #[tokio::test]
-    #[traced_test]
-    async fn test_obliterate_single_fragment_delete_payload_fails() {
-        let repository = random::<Context>();
-
-        let mut s3mock = MockS3Impl::default();
-        let mut dynamodb_mock = MockDynamoDb::default();
-
-        let (fragment, address) =
-            mock_load_fragment_metadata(&mut dynamodb_mock, None, false /* fail */);
-
-        mock_acquire_obliterate_lock(
-            &mut dynamodb_mock,
-            fragment,
-            address.hash,
-            MockLockMode::None,
-            true, /* in sequence */
-        );
-
-        // Mock the association count, this is currently done twice (for now), the first time we
-        // return 1, the second 0.
-        mock_count_associations(&mut dynamodb_mock, address.hash, 0, false /* fail */);
-
-        mock_remove_association(
-            &mut dynamodb_mock,
-            repository,
-            address,
-            false, /* fail */
-        );
-
-        let version_id = Some("some-version".to_string());
-        mock_list_versions(&mut s3mock, address.hash, version_id.clone(), false);
-
-        mock_delete_payload(&mut s3mock, address.hash, version_id, true /* fail */);
-
-        let store = initialize_immutable_store(s3mock, dynamodb_mock).await;
-
-        let stats: Arc<StoreObliterateStats> = Default::default();
-        assert!(
-            Arc::new(store)
-                .obliterate(repository.into(), address, stats.clone())
-                .await
-                .unwrap_err()
-                .is_slow_down()
-        );
-
-        // The rest of the necessary assertions are handled by expectations on the Dynamo and S3
-        // mocks.
-        assert_eq!(stats.num_fragments.load(Ordering::Relaxed), 1);
-        assert_eq!(stats.num_payloads.load(Ordering::Relaxed), 0);
-    }
-
-    #[tokio::test]
-    #[traced_test]
-    async fn test_obliterate_single_fragment_delete_payload_fails_to_list_versions() {
-        let repository = random::<Context>();
-
-        let mut s3mock = MockS3Impl::default();
-        let mut dynamodb_mock = MockDynamoDb::default();
-
-        let (fragment, address) =
-            mock_load_fragment_metadata(&mut dynamodb_mock, None, false /* fail */);
-
-        mock_acquire_obliterate_lock(
-            &mut dynamodb_mock,
-            fragment,
-            address.hash,
-            MockLockMode::None,
-            true, /* in sequence */
-        );
-
-        // Mock the association count, this is currently done twice (for now), the first time we
-        // return 1, the second 0.
-        mock_count_associations(&mut dynamodb_mock, address.hash, 0, false /* fail */);
-
-        mock_remove_association(
-            &mut dynamodb_mock,
-            repository,
-            address,
-            false, /* fail */
-        );
-
-        let version_id = Some("some-version".to_string());
-        mock_list_versions(&mut s3mock, address.hash, version_id.clone(), true);
-
-        let store = initialize_immutable_store(s3mock, dynamodb_mock).await;
-
-        let stats: Arc<StoreObliterateStats> = Default::default();
-        assert!(
-            Arc::new(store)
-                .obliterate(repository.into(), address, stats.clone())
-                .await
-                .unwrap_err()
-                .is_slow_down()
-        );
-
-        // The rest of the necessary assertions are handled by expectations on the Dynamo and S3
-        // mocks.
-        assert_eq!(stats.num_fragments.load(Ordering::Relaxed), 1);
-        assert_eq!(stats.num_payloads.load(Ordering::Relaxed), 0);
-    }
-
-    // Finalize metadata fails
-    #[tokio::test]
-    #[traced_test]
-    async fn test_obliterate_single_fragment_finalize_metadata_fails() {
-        let repository = random::<Context>();
-
-        let mut s3mock = MockS3Impl::default();
-        let mut dynamodb_mock = MockDynamoDb::default();
-
-        let (fragment, address) =
-            mock_load_fragment_metadata(&mut dynamodb_mock, None, false /* fail */);
-
-        mock_acquire_obliterate_lock(
-            &mut dynamodb_mock,
-            fragment,
-            address.hash,
-            MockLockMode::FinalizeFail,
-            true, /* in sequence */
-        );
-
-        // Mock the association count, this is currently done twice (for now), the first time we
-        // return 1, the second 0.
-        mock_count_associations(&mut dynamodb_mock, address.hash, 0, false /* fail */);
-
-        mock_remove_association(
-            &mut dynamodb_mock,
-            repository,
-            address,
-            false, /* fail */
-        );
-
-        let version_id = Some("some-version".to_string());
-        mock_list_versions(&mut s3mock, address.hash, version_id.clone(), false);
-
-        mock_delete_payload(&mut s3mock, address.hash, version_id, false /* fail */);
-
-        let store = initialize_immutable_store(s3mock, dynamodb_mock).await;
-
-        let stats: Arc<StoreObliterateStats> = Default::default();
-        assert!(
-            Arc::new(store)
-                .obliterate(repository.into(), address, stats.clone())
-                .await
-                .unwrap_err()
-                .is_internal()
-        );
-
-        // The rest of the necessary assertions are handled by expectations on the Dynamo and S3
-        // mocks.
-        assert_eq!(stats.num_fragments.load(Ordering::Relaxed), 1);
-        assert_eq!(stats.num_payloads.load(Ordering::Relaxed), 1);
-    }
-
-    #[tokio::test]
-    #[traced_test]
-    async fn test_obliterate_fragment_is_fragmented() {
-        let repository = random::<Context>();
-
-        let mut s3mock = MockS3Impl::default();
-        let mut dynamodb_mock = MockDynamoDb::default();
-
-        // Build the fragment list payload
-        let address = random::<Address>();
-        let context = address.context;
-
-        let mut payload = BytesMut::new();
-        const SUB_FRAGMENT_COUNT: u64 = 5;
-        const SUB_FRAGMENT_SIZE: u64 = 32;
-
-        for i in 0..SUB_FRAGMENT_COUNT {
-            let (fragment, mut address) =
-                mock_load_fragment_metadata(&mut dynamodb_mock, None, false /* fail */);
-            address.context = context;
-
-            mock_acquire_obliterate_lock(
-                &mut dynamodb_mock,
-                fragment,
-                address.hash,
-                MockLockMode::Finalize,
-                // We do not mock the expectations in sequence because order of obliterates for each
-                // sub-fragment is non-deterministic.
-                false, /* in sequence */
-            );
-
-            // Mock the association count, this is currently done twice (for now), the first time we
-            // return 1, the second 0.
-            mock_count_associations(&mut dynamodb_mock, address.hash, 0, false /* fail */);
-
-            mock_remove_association(
-                &mut dynamodb_mock,
-                repository,
-                address,
-                false, /* fail */
-            );
-
-            let version_id = Some("some-version".to_string());
-            mock_list_versions(&mut s3mock, address.hash, version_id.clone(), false);
-
-            mock_delete_payload(&mut s3mock, address.hash, version_id, false /* fail */);
-
-            let reference = FragmentReference {
-                hash: address.hash,
-                offset_content: i * SUB_FRAGMENT_SIZE,
+        let f = fake.clone();
+        dynamodb.expect_delete_item().returning(move |table, item| {
+            let fault = if &**table == FRAGMENT_STATE_TABLE_NAME {
+                Fault::StateDelete
+            } else {
+                Fault::AssociationDelete
             };
-            payload.extend_from_slice(reference.as_bytes());
+            if f.failing(fault) {
+                return Err(throughput_exceeded(
+                    DeleteItemError::ProvisionedThroughputExceededException(throttling_exception()),
+                ));
+            }
+
+            let mut storage = f.lock();
+            if &**table == FRAGMENT_STATE_TABLE_NAME {
+                storage.state.remove(&blob(&item, "hash"));
+            } else {
+                storage
+                    .associations
+                    .remove(&(blob(&item, "hash"), blob(&item, "repository_context")));
+            }
+            Ok(DeleteItemOutput::builder().build())
+        });
+
+        let f = fake.clone();
+        dynamodb.expect_query_single().returning(move |_, query| {
+            if f.failing(Fault::AssociationCount) {
+                return Err(throughput_exceeded(
+                    QueryError::ProvisionedThroughputExceededException(throttling_exception()),
+                ));
+            }
+
+            let storage = f.lock();
+            let count = match query {
+                FragmentsQuery::Hash(hash) | FragmentsQuery::HashCount(hash) => storage
+                    .associations
+                    .keys()
+                    .filter(|(stored, _)| stored == hash.data())
+                    .count(),
+                FragmentsQuery::Repository(hash, repository) => storage
+                    .associations
+                    .keys()
+                    .filter(|(stored, repository_context)| {
+                        stored == hash.data() && repository_context.starts_with(repository.data())
+                    })
+                    .count(),
+            };
+
+            Ok(QueryOutput::builder()
+                .count(i32::try_from(count).unwrap())
+                .build())
+        });
+
+        (s3, dynamodb)
+    }
+
+    /// A throttling exception carrying the error code a real response would, which is what the
+    /// classifier reads — a builder-constructed exception has no metadata at all.
+    fn throttling_exception() -> ProvisionedThroughputExceededException {
+        ProvisionedThroughputExceededException::builder()
+            .meta(
+                ErrorMetadata::builder()
+                    .code("ProvisionedThroughputExceededException")
+                    .build(),
+            )
+            .build()
+    }
+
+    fn throughput_exceeded<E>(error: E) -> AwsError<SdkError<E, HttpResponse>> {
+        aws_error(error, 400)
+    }
+
+    fn conditional_check_failed(
+        item: HashMap<String, AttributeValue>,
+    ) -> AwsError<SdkError<PutItemError, HttpResponse>> {
+        aws_error(
+            PutItemError::ConditionalCheckFailedException(
+                ConditionalCheckFailedException::builder()
+                    .set_item(Some(item))
+                    .build(),
+            ),
+            400,
+        )
+    }
+
+    async fn store_with(
+        fake: &Fake,
+        force_write: bool,
+        fragment_metadata: bool,
+    ) -> Arc<AwsImmutableStore> {
+        let (s3, dynamodb) = wire(fake);
+        let mut dynamodb_settings = DynamoDbImmutableStoreSettings::new(
+            FRAGMENTS_TABLE_NAME.to_string(),
+            FRAGMENT_STATE_TABLE_NAME.to_string(),
+        );
+        dynamodb_settings.timeout_millis = 1;
+
+        if fragment_metadata {
+            dynamodb_settings = dynamodb_settings
+                .with_fragment_metadata_table(FRAGMENT_STATE_TABLE_NAME.to_string());
         }
 
-        let fragment = Fragment {
-            flags: (FragmentFlags::PayloadStoredDurable | FragmentFlags::PayloadFragmented).bits(),
-            size_payload: payload.len() as u32,
-            size_content: SUB_FRAGMENT_SIZE * SUB_FRAGMENT_COUNT,
+        let settings = AwsImmutableStoreSettings {
+            s3: S3StoreSettings::new(BUCKET.to_string()),
+            dynamodb: dynamodb_settings,
+            force_write,
+            batch_exist_submission_limit: 1000,
         };
 
-        let metadata_entry = FragmentMetadataEntry::new(address.hash);
-        let av_map: HashMap<String, AttributeValue> =
-            serde_dynamo::to_item(metadata_entry.clone()).unwrap();
-        let full_entry_av_map =
-            serde_dynamo::to_item(metadata_entry.with_fragment(fragment)).unwrap();
-
-        // Mock loading the fragment metadata
-        dynamodb_mock
-            .expect_get_item()
-            .times(1)
-            .with(
-                eq(Arc::<str>::from(METADATA_TABLE_NAME)),
-                eq(av_map),
-                eq(true),
-            )
-            .return_once(move |_, _, _| {
-                Ok(GetItemOutput::builder()
-                    .set_item(Some(full_entry_av_map))
-                    .build())
-            });
-
-        // Mock reading the payload to get the sub-fragments
-        s3mock
-            .expect_get_object()
-            .with(eq(BUCKET), eq(format!("{}", address.hash)), eq(None))
-            .return_once(move |_, _, _| {
-                Ok(GetObjectOutput::builder()
-                    .body(payload.to_vec().into())
-                    .build())
-            });
-
-        mock_acquire_obliterate_lock(
-            &mut dynamodb_mock,
-            fragment,
-            address.hash,
-            MockLockMode::Finalize,
-            // We do not mock the expectations in sequence because order of obliterates for each
-            // sub-fragment is non-deterministic.
-            false, /* in sequence */
-        );
-
-        // Mock the association count, this is currently done twice (for now), the first time we
-        // return 1, the second 0.
-        mock_count_associations(&mut dynamodb_mock, address.hash, 0, false /* fail */);
-
-        mock_remove_association(
-            &mut dynamodb_mock,
-            repository,
-            address,
-            false, /* fail */
-        );
-
-        let version_id = Some("some-version".to_string());
-        mock_list_versions(&mut s3mock, address.hash, version_id.clone(), false);
-
-        mock_delete_payload(&mut s3mock, address.hash, version_id, false /* fail */);
-
-        let store = initialize_immutable_store(s3mock, dynamodb_mock).await;
-
-        let stats: Arc<StoreObliterateStats> = Default::default();
-        Arc::new(store)
-            .obliterate(repository.into(), address, stats.clone())
+        let execution = setup_execution("test".to_string());
+        LORE_CONTEXT
+            .scope(execution, async move {
+                Arc::new(AwsImmutableStore::new(s3, dynamodb, &settings))
+            })
             .await
-            .expect("obliterate failed");
+    }
 
-        // The rest of the necessary assertions are handled by expectations on the Dynamo and S3
-        // mocks.
-        assert_eq!(
-            stats.num_fragments.load(Ordering::Relaxed),
-            (SUB_FRAGMENT_COUNT + 1) as usize
-        );
-        assert_eq!(
-            stats.num_payloads.load(Ordering::Relaxed),
-            (SUB_FRAGMENT_COUNT + 1) as usize
-        );
+    async fn store(fake: &Fake) -> Arc<AwsImmutableStore> {
+        store_with(fake, false, false).await
+    }
+
+    /// A store on a deployment that may still hold objects written before fragments moved onto
+    /// them, and so is configured to read the rows describing those.
+    async fn migrated_store(fake: &Fake) -> Arc<AwsImmutableStore> {
+        store_with(fake, false, true).await
+    }
+
+    /// A payload and the fragment that correctly describes it.
+    fn representation(
+        codec: FragmentFlags,
+        size_payload: usize,
+        size_content: u64,
+    ) -> (Fragment, Bytes) {
+        let payload = Bytes::from(vec![codec.bits() as u8; size_payload]);
+        let fragment = Fragment {
+            flags: codec.bits(),
+            size_payload: u32::try_from(size_payload).unwrap(),
+            size_content,
+        };
+
+        (fragment, payload)
     }
 
     #[tokio::test]
-    #[traced_test]
-    async fn test_obliterate_fragment_is_fragmented_obliterate_subfragment_fails() {
-        let repository = random::<Context>();
+    async fn put_stores_the_fragment_on_the_object() {
+        let fake = Fake::default();
+        let address = Address {
+            hash: random(),
+            context: random(),
+        };
+        let repository: Context = random();
+        let (fragment, payload) = representation(FragmentFlags::PayloadCompressedZstd, 64, 256);
 
-        let mut s3mock = MockS3Impl::default();
-        let mut dynamodb_mock = MockDynamoDb::default();
-
-        // Build the fragment list payload
-        let address = random::<Address>();
-        let context = address.context;
-
-        let mut payload = BytesMut::new();
-        const SUB_FRAGMENT_COUNT: u64 = 2;
-        const SUB_FRAGMENT_SIZE: u64 = 32;
-
-        for i in 0..SUB_FRAGMENT_COUNT {
-            let (fragment, mut address) =
-                mock_load_fragment_metadata(&mut dynamodb_mock, None, false /* fail */);
-            address.context = context;
-
-            mock_acquire_obliterate_lock(
-                &mut dynamodb_mock,
+        store(&fake)
+            .await
+            .put(
+                repository.into(),
+                address,
                 fragment,
-                address.hash,
-                if i == 0 {
-                    MockLockMode::Finalize
-                } else {
-                    MockLockMode::None
+                Some(payload.clone()),
+                false,
+            )
+            .await
+            .expect("put should succeed");
+
+        assert_eq!(fake.stored_fragment(address.hash), Some(fragment));
+        assert_eq!(fake.object(address.hash).unwrap().0, payload.as_ref());
+        assert_eq!(fake.state_of(address.hash), Some(FragmentState::Stored));
+        assert_eq!(fake.association_count(address.hash), 1);
+    }
+
+    #[tokio::test]
+    async fn put_of_an_already_associated_fragment_writes_nothing() {
+        let fake = Fake::default();
+        let address = Address {
+            hash: random(),
+            context: random(),
+        };
+        let repository: Context = random();
+        let (fragment, payload) = representation(FragmentFlags::PayloadCompressedZstd, 64, 256);
+
+        let store = store(&fake).await;
+        store
+            .clone()
+            .put(
+                repository.into(),
+                address,
+                fragment,
+                Some(payload.clone()),
+                false,
+            )
+            .await
+            .expect("first put should succeed");
+
+        let (other, other_payload) = representation(FragmentFlags::PayloadCompressedLZ4, 96, 256);
+        store
+            .put(
+                repository.into(),
+                address,
+                other,
+                Some(other_payload),
+                false,
+            )
+            .await
+            .expect("second put should succeed");
+
+        assert_eq!(
+            fake.stored_fragment(address.hash),
+            Some(fragment),
+            "an already associated put must not re-upload"
+        );
+        assert_eq!(fake.object(address.hash).unwrap().0, payload.as_ref());
+    }
+
+    #[tokio::test]
+    async fn put_deduplicates_across_partitions_without_uploading() {
+        let fake = Fake::default();
+        let hash: Hash = random();
+        let first = Address {
+            hash,
+            context: random(),
+        };
+        let second = Address {
+            hash,
+            context: random(),
+        };
+        let (fragment, payload) = representation(FragmentFlags::PayloadCompressedZstd, 64, 256);
+
+        let store = store(&fake).await;
+        store
+            .clone()
+            .put(
+                random::<Context>().into(),
+                first,
+                fragment,
+                Some(payload.clone()),
+                false,
+            )
+            .await
+            .expect("first put should succeed");
+
+        let (other, other_payload) = representation(FragmentFlags::PayloadCompressedLZ4, 96, 256);
+        store
+            .put(
+                random::<Context>().into(),
+                second,
+                other,
+                Some(other_payload),
+                false,
+            )
+            .await
+            .expect("cross-partition put should succeed");
+
+        assert_eq!(
+            fake.stored_fragment(hash),
+            Some(fragment),
+            "deduplication must leave the stored representation alone"
+        );
+        assert_eq!(fake.association_count(hash), 2);
+    }
+
+    #[tokio::test]
+    async fn put_without_a_payload_may_not_claim_stored_content() {
+        let fake = Fake::default();
+        let hash: Hash = random();
+        let (fragment, payload) = representation(FragmentFlags::PayloadCompressedZstd, 64, 256);
+
+        let store = store(&fake).await;
+        store
+            .clone()
+            .put(
+                random::<Context>().into(),
+                Address {
+                    hash,
+                    context: random(),
                 },
-                // We do not mock the expectations in sequence because order of obliterates for each
-                // sub-fragment is non-deterministic.
-                false, /* in sequence */
-            );
+                fragment,
+                Some(payload),
+                false,
+            )
+            .await
+            .expect("first put should succeed");
 
-            // Mock the association count, this is currently done twice (for now), the first time we
-            // return 1, the second 0.
-            mock_count_associations(&mut dynamodb_mock, address.hash, 0, false /* fail */);
+        let claimed = Address {
+            hash,
+            context: random(),
+        };
+        store
+            .put(random::<Context>().into(), claimed, fragment, None, false)
+            .await
+            .expect_err("a hash alone is not evidence the caller holds the content");
 
-            mock_remove_association(
-                &mut dynamodb_mock,
-                repository,
+        assert_eq!(fake.association_count(hash), 1);
+    }
+
+    #[tokio::test]
+    async fn get_reads_the_fragment_from_the_object_it_returns() {
+        let fake = Fake::default();
+        let address = Address {
+            hash: random(),
+            context: random(),
+        };
+        let repository: Context = random();
+        let (fragment, payload) = representation(FragmentFlags::PayloadCompressedZstd, 64, 256);
+
+        let store = store(&fake).await;
+        store
+            .clone()
+            .put(
+                repository.into(),
                 address,
-                false, /* fail */
-            );
+                fragment,
+                Some(payload.clone()),
+                false,
+            )
+            .await
+            .expect("put should succeed");
 
-            let version_id = Some("some-version".to_string());
-            mock_list_versions(&mut s3mock, address.hash, version_id.clone(), false);
+        let (loaded, bytes) = store
+            .get(repository.into(), address, StoreMatch::MatchFull)
+            .await
+            .expect("get should succeed");
 
-            mock_delete_payload(
-                &mut s3mock,
-                address.hash,
-                version_id,
-                i == 1, /* fail for the second sub-fragment */
-            );
+        assert_eq!(bytes, payload);
+        assert_eq!(loaded.size_payload, fragment.size_payload);
+        assert_eq!(loaded.size_content, fragment.size_content);
+        assert_eq!(
+            loaded.flags & FragmentFlags::PayloadStoredDurable,
+            FragmentFlags::PayloadStoredDurable,
+            "durability is derived from the object existing, not read from a record"
+        );
+    }
 
-            let reference = FragmentReference {
-                hash: address.hash,
-                offset_content: i * SUB_FRAGMENT_SIZE,
-            };
-            payload.extend_from_slice(reference.as_bytes());
-        }
+    /// Query answers from `DynamoDB` alone. It is on the ingress write path, once per fragment
+    /// stored, so it must not reach S3 — which means it reports whether the payload is there and
+    /// durable, not what representation is stored.
+    #[tokio::test]
+    async fn query_reports_a_match_without_reading_s3() {
+        let fake = Fake::default();
+        let address = Address {
+            hash: random(),
+            context: random(),
+        };
+        let repository: Context = random();
+        let (fragment, payload) = representation(FragmentFlags::PayloadCompressedZstd, 64, 256);
 
-        let fragment = Fragment {
-            flags: (FragmentFlags::PayloadStoredDurable | FragmentFlags::PayloadFragmented).bits(),
-            size_payload: payload.len() as u32,
-            size_content: SUB_FRAGMENT_SIZE * SUB_FRAGMENT_COUNT,
+        let store = store(&fake).await;
+        store
+            .clone()
+            .put(repository.into(), address, fragment, Some(payload), false)
+            .await
+            .expect("put should succeed");
+
+        let result = store
+            .query(repository.into(), address, StoreMatch::MatchFull)
+            .await
+            .expect("query should succeed");
+
+        assert_eq!(result.match_made, StoreMatch::MatchFull);
+        assert_eq!(
+            result.fragment.flags & FragmentFlags::PayloadStoredDurable,
+            FragmentFlags::PayloadStoredDurable
+        );
+        assert_eq!(
+            fake.object_reads(),
+            0,
+            "query must not touch S3; it is called once per fragment on the ingress write path"
+        );
+    }
+
+    /// The representation a put stored must come back from a later metadata read — the whole
+    /// reason this path exists separately from `query`, which cannot report it.
+    #[tokio::test]
+    async fn get_metadata_returns_the_representation_that_was_stored() {
+        let fake = Fake::default();
+        let address = Address {
+            hash: random(),
+            context: random(),
+        };
+        let repository: Context = random();
+        let (fragment, payload) = representation(FragmentFlags::PayloadCompressedZstd, 64, 256);
+
+        let store = store(&fake).await;
+        store
+            .clone()
+            .put(repository.into(), address, fragment, Some(payload), false)
+            .await
+            .expect("put should succeed");
+
+        let result = store
+            .get_metadata(repository.into(), address)
+            .await
+            .expect("get_metadata should succeed");
+
+        assert_eq!(result.match_made, StoreMatch::MatchFull);
+        assert_eq!(result.fragment.size_payload, fragment.size_payload);
+        assert_eq!(result.fragment.size_content, fragment.size_content);
+        assert_eq!(
+            result.fragment.flags & PAYLOAD_FLAGS,
+            fragment.flags & PAYLOAD_FLAGS,
+            "the stored compression must survive the round trip"
+        );
+        assert_eq!(
+            result.fragment.flags & FragmentFlags::PayloadStoredDurable,
+            FragmentFlags::PayloadStoredDurable
+        );
+        assert_eq!(
+            fake.object_reads(),
+            1,
+            "exactly one HeadObject, and only on this path"
+        );
+    }
+
+    #[tokio::test]
+    async fn get_metadata_reads_a_preexisting_object_from_the_fragment_metadata_table() {
+        let fake = Fake::default();
+        let address = Address {
+            hash: random(),
+            context: random(),
+        };
+        let repository: Context = random();
+        let (fragment, _) = preexisting_object(&fake, repository, address);
+
+        let result = migrated_store(&fake)
+            .await
+            .get_metadata(repository.into(), address)
+            .await
+            .expect("get_metadata should succeed");
+
+        assert_eq!(result.match_made, StoreMatch::MatchFull);
+        assert_eq!(result.fragment.size_payload, fragment.size_payload);
+        assert_eq!(result.fragment.size_content, fragment.size_content);
+    }
+
+    #[tokio::test]
+    async fn get_metadata_reports_a_miss_for_an_unknown_address() {
+        let fake = Fake::default();
+        let address = Address {
+            hash: random(),
+            context: random(),
         };
 
-        let metadata_entry = FragmentMetadataEntry::new(address.hash);
-        let av_map: HashMap<String, AttributeValue> =
-            serde_dynamo::to_item(metadata_entry.clone()).unwrap();
-        let full_entry_av_map =
-            serde_dynamo::to_item(metadata_entry.with_fragment(fragment)).unwrap();
+        let result = store(&fake)
+            .await
+            .get_metadata(random::<Context>().into(), address)
+            .await
+            .expect("get_metadata should succeed");
 
-        // Mock loading the fragment metadata
-        dynamodb_mock
-            .expect_get_item()
-            .times(1)
-            .with(
-                eq(Arc::<str>::from(METADATA_TABLE_NAME)),
-                eq(av_map),
-                eq(true),
-            )
-            .return_once(move |_, _, _| {
-                Ok(GetItemOutput::builder()
-                    .set_item(Some(full_entry_av_map))
-                    .build())
-            });
-
-        // Mock reading the payload to get the sub-fragments
-        s3mock
-            .expect_get_object()
-            .with(eq(BUCKET), eq(format!("{}", address.hash)), eq(None))
-            .return_once(move |_, _, _| {
-                Ok(GetObjectOutput::builder()
-                    .body(payload.to_vec().into())
-                    .build())
-            });
-
-        mock_acquire_obliterate_lock(
-            &mut dynamodb_mock,
-            fragment,
-            address.hash,
-            MockLockMode::None,
-            // We do not mock the expectations in sequence because order of obliterates for each
-            // sub-fragment is non-deterministic.
-            false, /* in sequence */
-        );
-
-        let store = initialize_immutable_store(s3mock, dynamodb_mock).await;
-
-        let stats: Arc<StoreObliterateStats> = Default::default();
-        assert!(
-            Arc::new(store)
-                .obliterate(repository.into(), address, stats.clone())
-                .await
-                .unwrap_err()
-                .is_internal()
-        );
-
-        // The rest of the necessary assertions are handled by expectations on the Dynamo and S3
-        // mocks.
-        assert_eq!(
-            stats.num_fragments.load(Ordering::Relaxed),
-            // We deleted associations for both sub-fragments, but not the parent fragment
-            SUB_FRAGMENT_COUNT as usize
-        );
-        assert_eq!(
-            stats.num_payloads.load(Ordering::Relaxed),
-            // We deleted payloads for one sub-fragment, but failed on the second which should
-            // prevent the parent payload from being deleted as well
-            (SUB_FRAGMENT_COUNT - 1) as usize
-        );
+        assert_eq!(result.match_made, StoreMatch::MatchNone);
+        assert_eq!(fake.object_reads(), 0, "a miss must not reach S3");
     }
 
     #[tokio::test]
-    async fn test_copy_not_found() {
-        let source_repository = random::<Context>();
-        let source_address = random::<Address>();
-        let destination_repository = random::<Context>();
+    async fn query_reports_a_miss_when_no_state_row_exists() {
+        let fake = Fake::default();
+        let address = Address {
+            hash: random(),
+            context: random(),
+        };
+        let repository: Context = random();
 
-        let s3mock = MockS3Impl::default();
-        let mut dynamodb_mock = MockDynamoDb::default();
+        fake.add_association(repository, address);
 
-        // Source does not exist — lookup returns MatchNone.
-        mock_lookup_fragments(
-            &mut dynamodb_mock,
-            FragmentsEntry::new(source_repository, source_address),
-            StoreMatch::MatchFull,
-            StoreMatch::MatchNone,
-        );
+        let result = store(&fake)
+            .await
+            .query(repository.into(), address, StoreMatch::MatchFull)
+            .await
+            .expect("query should succeed");
 
-        let store = initialize_immutable_store(s3mock, dynamodb_mock).await;
-        let store = Arc::new(store);
+        assert_eq!(result.match_made, StoreMatch::MatchNone);
+    }
 
-        let err = store
-            .copy(
-                source_repository.into(),
-                source_address,
-                destination_repository.into(),
-                source_address.context,
+    #[tokio::test]
+    async fn force_write_replaces_the_stored_representation() {
+        let fake = Fake::default();
+        let address = Address {
+            hash: random(),
+            context: random(),
+        };
+        let repository: Context = random();
+        let (fragment, payload) = representation(FragmentFlags::PayloadCompressedZstd, 64, 256);
+
+        store(&fake)
+            .await
+            .put(repository.into(), address, fragment, Some(payload), false)
+            .await
+            .expect("put should succeed");
+
+        let (replacement, replacement_payload) =
+            representation(FragmentFlags::PayloadCompressedLZ4, 96, 256);
+        store_with(&fake, true, false)
+            .await
+            .put(
+                repository.into(),
+                address,
+                replacement,
+                Some(replacement_payload.clone()),
                 false,
             )
             .await
-            .expect_err("copy should have returned NotFound");
+            .expect("forced put should succeed");
 
-        assert!(
-            err.is_address_not_found(),
-            "Expected AddressNotFound, got {err:?}"
+        assert_eq!(fake.stored_fragment(address.hash), Some(replacement));
+        assert_eq!(
+            fake.object(address.hash).unwrap().0,
+            replacement_payload.as_ref()
         );
     }
 
     #[tokio::test]
-    async fn test_copy_partial_match_returns_not_found() {
-        let source_repository = random::<Context>();
-        let source_address = random::<Address>();
-        let destination_repository = random::<Context>();
+    async fn put_backs_off_while_an_obliteration_holds_the_hash() {
+        let fake = Fake::default();
+        let address = Address {
+            hash: random(),
+            context: random(),
+        };
+        let (fragment, payload) = representation(FragmentFlags::PayloadCompressedZstd, 64, 256);
 
-        let s3mock = MockS3Impl::default();
-        let mut dynamodb_mock = MockDynamoDb::default();
+        fake.set_state(address.hash, FragmentState::Obliterating);
 
-        // Fragment exists by hash globally but not in source_repository (MatchHash).
-        mock_lookup_fragments(
-            &mut dynamodb_mock,
-            FragmentsEntry::new(source_repository, source_address),
-            StoreMatch::MatchFull,
-            StoreMatch::MatchHash,
-        );
-
-        let store = initialize_immutable_store(s3mock, dynamodb_mock).await;
-        let store = Arc::new(store);
-
-        let err = store
-            .copy(
-                source_repository.into(),
-                source_address,
-                destination_repository.into(),
-                source_address.context,
+        let error = store(&fake)
+            .await
+            .put(
+                random::<Context>().into(),
+                address,
+                fragment,
+                Some(payload),
                 false,
             )
             .await
-            .expect_err("copy should have returned NotFound for partial match");
+            .expect_err("a put racing an obliteration must back off");
 
-        assert!(
-            err.is_address_not_found(),
-            "Expected AddressNotFound, got {err:?}"
-        );
+        assert!(error.is_slow_down(), "expected a retryable back-off");
+        assert_eq!(fake.association_count(address.hash), 0);
+    }
+
+    /// Sets up an object as it was stored before the fragment moved onto it: bare bytes in S3, the
+    /// fragment in a table row.
+    fn preexisting_object(fake: &Fake, repository: Context, address: Address) -> (Fragment, Bytes) {
+        let (fragment, payload) = representation(FragmentFlags::PayloadCompressedZstd, 64, 256);
+
+        fake.put_object_without_metadata(address.hash, payload.as_ref());
+        fake.set_fragment_metadata_row(address.hash, fragment);
+        fake.add_association(repository, address);
+
+        (fragment, payload)
     }
 
     #[tokio::test]
-    async fn test_copy_success() {
-        let source_repository = random::<Context>();
-        let (fragment, source_address, _) = fragment::generate_random();
-        let destination_repository = random::<Context>();
+    async fn get_falls_back_to_the_legacy_row_for_an_object_with_no_metadata() {
+        let fake = Fake::default();
+        let address = Address {
+            hash: random(),
+            context: random(),
+        };
+        let repository: Context = random();
+        let (fragment, payload) = preexisting_object(&fake, repository, address);
 
-        let s3mock = MockS3Impl::default();
-        let mut dynamodb_mock = MockDynamoDb::default();
+        let (loaded, bytes) = migrated_store(&fake)
+            .await
+            .get(repository.into(), address, StoreMatch::MatchFull)
+            .await
+            .expect("an object written before the cut-over must still be readable");
 
-        // Source exists at MatchFull.
-        mock_lookup_fragments(
-            &mut dynamodb_mock,
-            FragmentsEntry::new(source_repository, source_address),
-            StoreMatch::MatchFull,
-            StoreMatch::MatchFull,
+        assert_eq!(bytes, payload);
+        assert_eq!(loaded.size_payload, fragment.size_payload);
+        assert_eq!(loaded.size_content, fragment.size_content);
+        assert_eq!(
+            loaded.flags & FragmentFlags::PayloadStoredDurable,
+            FragmentFlags::PayloadStoredDurable
         );
+    }
 
-        // Metadata load required by do_query when match_made != MatchNone.
-        let metadata_entry = FragmentMetadataEntry::new(source_address.hash);
-        let av_map: HashMap<String, AttributeValue> =
-            serde_dynamo::to_item(metadata_entry.clone()).unwrap();
-        let full_entry_av_map =
-            serde_dynamo::to_item(metadata_entry.with_fragment(fragment)).unwrap();
+    /// A pre-cut-over object is answered from its state row like any other, with no fallback read:
+    /// query never needs the representation, so it never needs the fragment metadata table either.
+    #[tokio::test]
+    async fn query_matches_a_preexisting_object_without_reading_s3() {
+        let fake = Fake::default();
+        let address = Address {
+            hash: random(),
+            context: random(),
+        };
+        let repository: Context = random();
+        preexisting_object(&fake, repository, address);
 
-        dynamodb_mock
-            .expect_get_item()
-            .with(
-                eq(Arc::<str>::from(METADATA_TABLE_NAME)),
-                eq(av_map),
-                eq(true),
+        let result = migrated_store(&fake)
+            .await
+            .query(repository.into(), address, StoreMatch::MatchFull)
+            .await
+            .expect("query should succeed");
+
+        assert_eq!(result.match_made, StoreMatch::MatchFull);
+        assert_eq!(fake.object_reads(), 0, "query must not touch S3");
+    }
+
+    /// A deployment that never wrote an object without metadata should not go looking for a row
+    /// describing one. An object in that shape is damaged, not old.
+    #[tokio::test]
+    async fn get_refuses_an_object_with_no_metadata_when_no_legacy_table_is_configured() {
+        let fake = Fake::default();
+        let address = Address {
+            hash: random(),
+            context: random(),
+        };
+        let repository: Context = random();
+        preexisting_object(&fake, repository, address);
+
+        store(&fake)
+            .await
+            .get(repository.into(), address, StoreMatch::MatchFull)
+            .await
+            .expect_err("without a legacy table configured there is nothing to fall back to");
+    }
+
+    /// Metadata that is present but unreadable means a damaged object. Describing it from a
+    /// separate record is exactly the mismatch this design removes, so it must not fall back even
+    /// where a legacy row exists.
+    #[tokio::test]
+    async fn get_does_not_fall_back_for_an_object_with_damaged_metadata() {
+        let fake = Fake::default();
+        let address = Address {
+            hash: random(),
+            context: random(),
+        };
+        let repository: Context = random();
+        let (fragment, payload) = representation(FragmentFlags::PayloadCompressedZstd, 64, 256);
+
+        fake.put_object_with_damaged_metadata(address.hash, payload.as_ref());
+        fake.set_fragment_metadata_row(address.hash, fragment);
+        fake.add_association(repository, address);
+
+        migrated_store(&fake)
+            .await
+            .get(repository.into(), address, StoreMatch::MatchFull)
+            .await
+            .expect_err("a damaged object must not be described by a legacy row");
+    }
+
+    /// A lost payload must not stay lost. Clearing the state row is what lets the next put stop
+    /// short-circuiting on "already durable" and upload the content again.
+    #[tokio::test]
+    async fn a_read_of_a_lost_payload_clears_its_state_so_a_put_can_restore_it() {
+        let fake = Fake::default();
+        let address = Address {
+            hash: random(),
+            context: random(),
+        };
+        let repository: Context = random();
+        let (fragment, payload) = representation(FragmentFlags::PayloadCompressedZstd, 64, 256);
+
+        let store = store(&fake).await;
+        store
+            .clone()
+            .put(
+                repository.into(),
+                address,
+                fragment,
+                Some(payload.clone()),
+                false,
             )
-            .return_once(move |_, _, _| {
-                Ok(GetItemOutput::builder()
-                    .set_item(Some(full_entry_av_map))
-                    .build())
-            });
+            .await
+            .expect("put should succeed");
 
-        // The destination association should be written to DynamoDB.
-        let destination_entry = FragmentsEntry::new(destination_repository, source_address);
-        mock_associate_fragment(&mut dynamodb_mock, &destination_entry);
+        fake.lose_object(address.hash);
 
-        let store = initialize_immutable_store(s3mock, dynamodb_mock).await;
-        let store = Arc::new(store);
+        let error = store
+            .clone()
+            .get(repository.into(), address, StoreMatch::MatchFull)
+            .await
+            .expect_err("a lost payload reads as not found");
+        assert!(error.is_address_not_found());
+
+        assert_eq!(
+            fake.state_of(address.hash),
+            None,
+            "the state row must be cleared so the hash stops looking durable"
+        );
 
         store
-            .copy(
-                source_repository.into(),
-                source_address,
-                destination_repository.into(),
-                source_address.context,
+            .clone()
+            .put(
+                repository.into(),
+                address,
+                fragment,
+                Some(payload.clone()),
                 false,
+            )
+            .await
+            .expect("re-put should succeed");
+
+        assert_eq!(fake.object(address.hash).unwrap().0, payload.as_ref());
+        assert_eq!(fake.state_of(address.hash), Some(FragmentState::Stored));
+
+        let (_, restored) = store
+            .get(repository.into(), address, StoreMatch::MatchFull)
+            .await
+            .expect("the payload should be readable again");
+        assert_eq!(restored, payload);
+    }
+
+    /// A lost payload must be reported however it is found. `get_metadata` is the cheaper call, so
+    /// a client that only ever reads metadata would otherwise never raise the alarm.
+    #[tokio::test]
+    async fn get_metadata_of_a_lost_payload_reports_and_repairs_it() {
+        let fake = Fake::default();
+        let address = Address {
+            hash: random(),
+            context: random(),
+        };
+        let repository: Context = random();
+        let (fragment, payload) = representation(FragmentFlags::PayloadCompressedZstd, 64, 256);
+
+        let store = store(&fake).await;
+        store
+            .clone()
+            .put(repository.into(), address, fragment, Some(payload), false)
+            .await
+            .expect("put should succeed");
+
+        fake.lose_object(address.hash);
+
+        let result = store
+            .get_metadata(repository.into(), address)
+            .await
+            .expect("a lost payload reports a miss");
+
+        assert_eq!(result.match_made, StoreMatch::MatchNone);
+        assert_eq!(
+            fake.state_of(address.hash),
+            None,
+            "get_metadata must repair the loss it found, exactly as get does"
+        );
+    }
+
+    /// An obliteration in flight owns the hash. Its mark must survive a read that races the payload
+    /// deletion, or a put could republish underneath it.
+    #[tokio::test]
+    async fn a_read_of_a_lost_payload_leaves_an_obliteration_mark_alone() {
+        let fake = Fake::default();
+        let address = Address {
+            hash: random(),
+            context: random(),
+        };
+        let repository: Context = random();
+        let (fragment, payload) = representation(FragmentFlags::PayloadCompressedZstd, 64, 256);
+
+        let store = store(&fake).await;
+        store
+            .clone()
+            .put(repository.into(), address, fragment, Some(payload), false)
+            .await
+            .expect("put should succeed");
+
+        fake.lose_object(address.hash);
+        fake.set_state(address.hash, FragmentState::Obliterating);
+
+        store
+            .get(repository.into(), address, StoreMatch::MatchFull)
+            .await
+            .expect_err("a lost payload reads as not found");
+
+        assert_eq!(
+            fake.state_of(address.hash),
+            Some(FragmentState::Obliterating),
+            "a read must not clear a mark an obliteration is holding"
+        );
+    }
+
+    #[tokio::test]
+    async fn put_revives_a_tombstoned_hash() {
+        let fake = Fake::default();
+        let address = Address {
+            hash: random(),
+            context: random(),
+        };
+        let repository: Context = random();
+        let (fragment, payload) = representation(FragmentFlags::PayloadCompressedZstd, 64, 256);
+
+        fake.set_state(address.hash, FragmentState::Obliterated);
+
+        store(&fake)
+            .await
+            .put(repository.into(), address, fragment, Some(payload), false)
+            .await
+            .expect("re-upload over a tombstone is allowed");
+
+        assert_eq!(fake.state_of(address.hash), Some(FragmentState::Stored));
+        assert_eq!(fake.stored_fragment(address.hash), Some(fragment));
+        assert_eq!(fake.association_count(address.hash), 1);
+    }
+
+    /// Store a fragmented parent whose payload is a list of references to `leaves`, all under one
+    /// repository and context so obliteration walks from the parent into each leaf.
+    async fn store_fragmented(
+        store: &Arc<AwsImmutableStore>,
+        repository: Context,
+        context: Context,
+        leaves: &[Hash],
+    ) -> Address {
+        const LEAF_CONTENT: u64 = 256;
+
+        for (index, hash) in leaves.iter().enumerate() {
+            let (fragment, payload) = representation(
+                FragmentFlags::PayloadCompressedZstd,
+                64 + index,
+                LEAF_CONTENT,
+            );
+            store
+                .clone()
+                .put(
+                    repository.into(),
+                    Address {
+                        hash: *hash,
+                        context,
+                    },
+                    fragment,
+                    Some(payload),
+                    false,
+                )
+                .await
+                .expect("leaf put should succeed");
+        }
+
+        let references: Vec<FragmentReference> = leaves
+            .iter()
+            .enumerate()
+            .map(|(index, hash)| FragmentReference {
+                hash: *hash,
+                offset_content: index as u64 * LEAF_CONTENT,
+            })
+            .collect();
+
+        let payload = Bytes::from(references.as_bytes().to_vec());
+        let parent = Address {
+            hash: random(),
+            context,
+        };
+        let fragment = Fragment {
+            flags: FragmentFlags::PayloadFragmented.bits(),
+            size_payload: u32::try_from(payload.len()).unwrap(),
+            size_content: LEAF_CONTENT * leaves.len() as u64,
+        };
+
+        store
+            .clone()
+            .put(repository.into(), parent, fragment, Some(payload), false)
+            .await
+            .expect("parent put should succeed");
+
+        parent
+    }
+
+    #[tokio::test]
+    async fn obliterate_recurses_into_sub_fragments() {
+        let fake = Fake::default();
+        let repository: Context = random();
+        let context: Context = random();
+        let leaves = [random::<Hash>(), random::<Hash>()];
+
+        let store = store(&fake).await;
+        let parent = store_fragmented(&store, repository, context, &leaves).await;
+
+        let stats = Arc::new(StoreObliterateStats::default());
+        store
+            .obliterate(repository.into(), parent, stats.clone())
+            .await
+            .expect("obliterate should succeed");
+
+        assert!(fake.object(parent.hash).is_none(), "parent payload remains");
+        assert_eq!(fake.association_count(parent.hash), 0);
+
+        for leaf in leaves {
+            assert!(
+                fake.object(leaf).is_none(),
+                "a sub-fragment payload was not obliterated"
+            );
+            assert_eq!(fake.association_count(leaf), 0);
+            assert_eq!(fake.state_of(leaf), Some(FragmentState::Obliterated));
+        }
+
+        assert_eq!(
+            stats.num_fragments.load(Ordering::Relaxed),
+            3,
+            "the parent and both sub-fragments should each be counted"
+        );
+        assert_eq!(stats.num_payloads.load(Ordering::Relaxed), 3);
+    }
+
+    /// Recursion must respect each sub-fragment's own reference count. A leaf another partition
+    /// still holds survives, and its mark is released so the hash stays writable.
+    #[tokio::test]
+    async fn obliterate_keeps_a_sub_fragment_another_partition_references() {
+        let fake = Fake::default();
+        let repository: Context = random();
+        let context: Context = random();
+        let shared = random::<Hash>();
+        let leaves = [shared, random::<Hash>()];
+
+        let store = store(&fake).await;
+        let parent = store_fragmented(&store, repository, context, &leaves).await;
+
+        let other = Address {
+            hash: shared,
+            context: random(),
+        };
+        let (fragment, payload) = representation(FragmentFlags::PayloadCompressedZstd, 64, 256);
+        store
+            .clone()
+            .put(
+                random::<Context>().into(),
+                other,
+                fragment,
+                Some(payload),
+                false,
+            )
+            .await
+            .expect("second partition put should succeed");
+
+        store
+            .obliterate(
+                repository.into(),
+                parent,
+                Arc::new(StoreObliterateStats::default()),
+            )
+            .await
+            .expect("obliterate should succeed");
+
+        assert!(
+            fake.object(shared).is_some(),
+            "a sub-fragment referenced elsewhere must survive"
+        );
+        assert_eq!(fake.association_count(shared), 1);
+        assert_eq!(
+            fake.state_of(shared),
+            Some(FragmentState::Stored),
+            "the surviving sub-fragment must not be left marked"
+        );
+
+        assert!(fake.object(leaves[1]).is_none(), "unshared leaf remains");
+        assert!(fake.object(parent.hash).is_none(), "parent remains");
+    }
+
+    /// The parent's payload must still be readable when recursion runs, since that is where the
+    /// reference list comes from — it is deleted only after the sub-fragments are handled.
+    #[tokio::test]
+    async fn obliterate_reads_the_reference_list_before_deleting_the_parent() {
+        let fake = Fake::default();
+        let repository: Context = random();
+        let context: Context = random();
+        let leaves = [random::<Hash>()];
+
+        let store = store(&fake).await;
+        let parent = store_fragmented(&store, repository, context, &leaves).await;
+
+        store
+            .obliterate(
+                repository.into(),
+                parent,
+                Arc::new(StoreObliterateStats::default()),
+            )
+            .await
+            .expect("obliterate should succeed");
+
+        assert!(
+            fake.object(leaves[0]).is_none(),
+            "the reference list was not read, so the sub-fragment survived"
+        );
+    }
+
+    #[tokio::test]
+    async fn obliterate_removes_the_reference_and_the_payload() {
+        let fake = Fake::default();
+        let address = Address {
+            hash: random(),
+            context: random(),
+        };
+        let repository: Context = random();
+        let (fragment, payload) = representation(FragmentFlags::PayloadCompressedZstd, 64, 256);
+
+        let store = store(&fake).await;
+        store
+            .clone()
+            .put(repository.into(), address, fragment, Some(payload), false)
+            .await
+            .expect("put should succeed");
+
+        let stats = Arc::new(StoreObliterateStats::default());
+        store
+            .obliterate(repository.into(), address, stats.clone())
+            .await
+            .expect("obliterate should succeed");
+
+        assert_eq!(fake.association_count(address.hash), 0);
+        assert!(fake.object(address.hash).is_none());
+        assert_eq!(
+            fake.state_of(address.hash),
+            Some(FragmentState::Obliterated)
+        );
+        assert_eq!(stats.num_fragments.load(Ordering::Relaxed), 1);
+        assert_eq!(stats.num_payloads.load(Ordering::Relaxed), 1);
+    }
+
+    #[tokio::test]
+    async fn obliterate_keeps_the_payload_while_another_partition_references_it() {
+        let fake = Fake::default();
+        let hash: Hash = random();
+        let mine = Address {
+            hash,
+            context: random(),
+        };
+        let theirs = Address {
+            hash,
+            context: random(),
+        };
+        let repository: Context = random();
+        let other_repository: Context = random();
+        let (fragment, payload) = representation(FragmentFlags::PayloadCompressedZstd, 64, 256);
+
+        let store = store(&fake).await;
+        store
+            .clone()
+            .put(
+                repository.into(),
+                mine,
+                fragment,
+                Some(payload.clone()),
+                false,
+            )
+            .await
+            .expect("put should succeed");
+        store
+            .clone()
+            .put(
+                other_repository.into(),
+                theirs,
+                fragment,
+                Some(payload),
+                false,
+            )
+            .await
+            .expect("second put should succeed");
+
+        store
+            .obliterate(
+                repository.into(),
+                mine,
+                Arc::new(StoreObliterateStats::default()),
+            )
+            .await
+            .expect("obliterate should succeed");
+
+        assert_eq!(fake.association_count(hash), 1);
+        assert!(
+            fake.object(hash).is_some(),
+            "compliance only requires the obliterated partition's reference to be gone"
+        );
+        assert_eq!(
+            fake.state_of(hash),
+            Some(FragmentState::Stored),
+            "the mark must be released so the hash stays writable"
+        );
+    }
+
+    // ---------------------------------------------------------------------
+    // Failure paths
+    // ---------------------------------------------------------------------
+
+    /// A timeout means the answer is unknown, so the caller must be told to retry. Any other
+    /// `DynamoDB` failure means the hash could not be resolved, which reads as not found.
+    #[tokio::test]
+    async fn a_state_read_timeout_asks_the_caller_to_retry() {
+        let fake = Fake::default();
+        let address = Address {
+            hash: random(),
+            context: random(),
+        };
+        let (fragment, payload) = representation(FragmentFlags::PayloadCompressedZstd, 64, 256);
+
+        fake.fail(Fault::StateReadTimeout);
+
+        let error = store(&fake)
+            .await
+            .put(
+                random::<Context>().into(),
+                address,
+                fragment,
+                Some(payload),
+                false,
+            )
+            .await
+            .expect_err("a timeout must not be reported as a definite answer");
+
+        assert!(error.is_slow_down(), "expected a retryable back-off");
+    }
+
+    #[tokio::test]
+    async fn a_throttled_state_read_asks_the_caller_to_retry() {
+        let fake = Fake::default();
+        fake.fail(Fault::StateRead);
+
+        let error = store(&fake)
+            .await
+            .load_state(random())
+            .await
+            .expect_err("throttling is not an answer");
+
+        assert!(error.is_slow_down(), "throttling must be retryable");
+    }
+
+    /// A failed read must never read as a miss. A caller told "not found" for a hash it references
+    /// treats the content as lost, which counts data loss and clears the state row — off a
+    /// `DynamoDB` error that says nothing about whether the content is there.
+    #[tokio::test]
+    async fn a_broken_state_read_is_an_error_not_a_miss() {
+        let fake = Fake::default();
+        fake.fail(Fault::StateReadBroken);
+
+        let error = store(&fake)
+            .await
+            .load_state(random())
+            .await
+            .expect_err("a broken read is not an empty table");
+
+        assert!(!error.is_address_not_found(), "must not read as a miss");
+        assert!(!error.is_slow_down(), "and is not retryable either");
+    }
+
+    /// The same rule on the fallback path, where the consequence is sharpest: this read only
+    /// happens for a hash a partition references, so a miss here is what triggers the repair.
+    #[tokio::test]
+    async fn a_failed_fragment_metadata_read_does_not_clear_the_state_row() {
+        let fake = Fake::default();
+        let address = Address {
+            hash: random(),
+            context: random(),
+        };
+        let repository: Context = random();
+        preexisting_object(&fake, repository, address);
+
+        let store = migrated_store(&fake).await;
+        fake.fail(Fault::StateRead);
+
+        let error = store
+            .get(repository.into(), address, StoreMatch::MatchFull)
+            .await
+            .expect_err("the metadata read is throttled");
+
+        assert!(error.is_slow_down());
+        assert!(
+            fake.state_of(address.hash).is_some(),
+            "a throttle must not be mistaken for a lost payload and clear the row"
+        );
+    }
+
+    /// Two writers reviving the same tombstone both want the hash stored. The one that loses the
+    /// compare-and-set has already uploaded its bytes and got the state it wanted, so it must not
+    /// fail.
+    #[tokio::test]
+    async fn reviving_a_hash_another_writer_already_revived_succeeds() {
+        let fake = Fake::default();
+        let hash: Hash = random();
+
+        fake.set_state(hash, FragmentState::Stored);
+
+        store(&fake)
+            .await
+            .revive_state(hash)
+            .await
+            .expect("losing the revival race is not a failure");
+    }
+
+    #[tokio::test]
+    async fn reviving_a_hash_an_obliteration_retook_backs_off() {
+        let fake = Fake::default();
+        let hash: Hash = random();
+
+        fake.set_state(hash, FragmentState::Obliterating);
+
+        let error = store(&fake)
+            .await
+            .revive_state(hash)
+            .await
+            .expect_err("an obliteration holds the hash again");
+
+        assert!(error.is_slow_down(), "the mark is transient, so back off");
+    }
+
+    /// The upload and the state row survive an association failure, so a retry finishes the job
+    /// without re-uploading. Nothing is left that a later put would mistake for a complete write.
+    #[tokio::test]
+    async fn a_put_that_cannot_associate_leaves_the_payload_ready_for_a_retry() {
+        let fake = Fake::default();
+        let address = Address {
+            hash: random(),
+            context: random(),
+        };
+        let repository: Context = random();
+        let (fragment, payload) = representation(FragmentFlags::PayloadCompressedZstd, 64, 256);
+
+        fake.fail(Fault::AssociationWrite);
+
+        store(&fake)
+            .await
+            .put(
+                repository.into(),
+                address,
+                fragment,
+                Some(payload.clone()),
+                false,
+            )
+            .await
+            .expect_err("the association write fails");
+
+        assert_eq!(fake.object(address.hash).unwrap().0, payload.as_ref());
+        assert_eq!(fake.state_of(address.hash), Some(FragmentState::Stored));
+        assert_eq!(fake.association_count(address.hash), 0);
+
+        let recovered = Fake::default();
+        recovered.set_state(address.hash, FragmentState::Stored);
+        recovered.put_object_without_metadata(address.hash, payload.as_ref());
+        store(&recovered)
+            .await
+            .put(repository.into(), address, fragment, Some(payload), false)
+            .await
+            .expect("a retry associates without re-uploading");
+        assert_eq!(recovered.association_count(address.hash), 1);
+    }
+
+    /// Compliance is discharged by the association delete. If the count that follows fails, the
+    /// obliteration reports failure and holds its mark — but the reference is already gone.
+    #[tokio::test]
+    async fn an_obliterate_that_cannot_count_references_still_removed_the_reference() {
+        let fake = Fake::default();
+        let address = Address {
+            hash: random(),
+            context: random(),
+        };
+        let repository: Context = random();
+        let (fragment, payload) = representation(FragmentFlags::PayloadCompressedZstd, 64, 256);
+
+        let store = store(&fake).await;
+        store
+            .clone()
+            .put(repository.into(), address, fragment, Some(payload), false)
+            .await
+            .expect("put should succeed");
+
+        fake.fail(Fault::AssociationCount);
+
+        store
+            .obliterate(
+                repository.into(),
+                address,
+                Arc::new(StoreObliterateStats::default()),
+            )
+            .await
+            .expect_err("counting references fails");
+
+        assert_eq!(
+            fake.association_count(address.hash),
+            0,
+            "the compliance obligation is discharged before anything that can fail after it"
+        );
+        assert_eq!(
+            fake.state_of(address.hash),
+            Some(FragmentState::Obliterating),
+            "the mark is held, which is the known crashed-obliteration gap"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_obliterate_that_cannot_delete_the_payload_does_not_tombstone_it() {
+        let fake = Fake::default();
+        let address = Address {
+            hash: random(),
+            context: random(),
+        };
+        let repository: Context = random();
+        let (fragment, payload) = representation(FragmentFlags::PayloadCompressedZstd, 64, 256);
+
+        let store = store(&fake).await;
+        store
+            .clone()
+            .put(repository.into(), address, fragment, Some(payload), false)
+            .await
+            .expect("put should succeed");
+
+        fake.fail(Fault::ObjectDelete);
+
+        store
+            .obliterate(
+                repository.into(),
+                address,
+                Arc::new(StoreObliterateStats::default()),
+            )
+            .await
+            .expect_err("deleting the payload fails");
+
+        assert!(
+            fake.object(address.hash).is_some(),
+            "the payload survives a failed delete"
+        );
+        assert_eq!(
+            fake.state_of(address.hash),
+            Some(FragmentState::Obliterating),
+            "it must not be tombstoned while its payload is still there"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_obliterate_that_cannot_list_versions_does_not_tombstone_the_payload() {
+        let fake = Fake::default();
+        let address = Address {
+            hash: random(),
+            context: random(),
+        };
+        let repository: Context = random();
+        let (fragment, payload) = representation(FragmentFlags::PayloadCompressedZstd, 64, 256);
+
+        let store = store(&fake).await;
+        store
+            .clone()
+            .put(repository.into(), address, fragment, Some(payload), false)
+            .await
+            .expect("put should succeed");
+
+        fake.fail(Fault::ObjectList);
+
+        store
+            .obliterate(
+                repository.into(),
+                address,
+                Arc::new(StoreObliterateStats::default()),
+            )
+            .await
+            .expect_err("listing versions fails");
+
+        assert_ne!(
+            fake.state_of(address.hash),
+            Some(FragmentState::Obliterated)
+        );
+    }
+
+    /// Recursion must not report success when a sub-fragment could not be obliterated, or the
+    /// parent would be tombstoned over content that is still referenced.
+    #[tokio::test]
+    async fn obliterate_fails_when_a_sub_fragment_fails() {
+        let fake = Fake::default();
+        let repository: Context = random();
+        let context: Context = random();
+        let leaves = [random::<Hash>(), random::<Hash>()];
+
+        let store = store(&fake).await;
+        let parent = store_fragmented(&store, repository, context, &leaves).await;
+
+        fake.fail(Fault::ObjectDelete);
+
+        store
+            .obliterate(
+                repository.into(),
+                parent,
+                Arc::new(StoreObliterateStats::default()),
+            )
+            .await
+            .expect_err("a sub-fragment failure must fail the parent");
+
+        assert_ne!(fake.state_of(parent.hash), Some(FragmentState::Obliterated));
+    }
+
+    /// The repair is best effort: failing to clear the row must not turn a not-found into an error,
+    /// because the caller's answer does not depend on the repair succeeding.
+    #[tokio::test]
+    async fn a_failed_repair_still_reports_the_lost_payload_as_not_found() {
+        let fake = Fake::default();
+        let address = Address {
+            hash: random(),
+            context: random(),
+        };
+        let repository: Context = random();
+        let (fragment, payload) = representation(FragmentFlags::PayloadCompressedZstd, 64, 256);
+
+        let store = store(&fake).await;
+        store
+            .clone()
+            .put(repository.into(), address, fragment, Some(payload), false)
+            .await
+            .expect("put should succeed");
+
+        fake.lose_object(address.hash);
+        fake.fail(Fault::StateDelete);
+
+        let error = store
+            .get(repository.into(), address, StoreMatch::MatchFull)
+            .await
+            .expect_err("the payload is gone");
+
+        assert!(error.is_address_not_found());
+        assert_eq!(
+            fake.state_of(address.hash),
+            Some(FragmentState::Stored),
+            "the row survives a failed repair, unchanged"
+        );
+    }
+
+    /// The probe saw nothing, the upload landed, and an obliteration took the hash in between. The
+    /// put must not associate, or it would restore a reference the obliteration is removing.
+    #[tokio::test]
+    async fn a_put_that_loses_the_hash_mid_upload_backs_off_without_associating() {
+        let fake = Fake::default();
+        let address = Address {
+            hash: random(),
+            context: random(),
+        };
+        let repository: Context = random();
+        let (fragment, payload) = representation(FragmentFlags::PayloadCompressedZstd, 64, 256);
+
+        fake.obliterate_during_upload(address.hash, FragmentState::Obliterating);
+
+        let error = store(&fake)
+            .await
+            .put(repository.into(), address, fragment, Some(payload), false)
+            .await
+            .expect_err("an obliteration holds the hash by the time the put publishes");
+
+        assert!(
+            error.is_slow_down(),
+            "the mark is transient, so this is a back-off"
+        );
+        assert_eq!(
+            fake.association_count(address.hash),
+            0,
+            "no reference may be created while an obliteration holds the hash"
+        );
+        assert_eq!(
+            fake.state_of(address.hash),
+            Some(FragmentState::Obliterating),
+            "the put must not disturb the mark"
+        );
+    }
+
+    /// Racing a *completed* obliteration is different: the tombstone is not a lock, and re-upload
+    /// over one is allowed, so the put finishes and revives the hash.
+    #[tokio::test]
+    async fn a_put_that_lands_on_a_fresh_tombstone_revives_it() {
+        let fake = Fake::default();
+        let address = Address {
+            hash: random(),
+            context: random(),
+        };
+        let repository: Context = random();
+        let (fragment, payload) = representation(FragmentFlags::PayloadCompressedZstd, 64, 256);
+
+        fake.obliterate_during_upload(address.hash, FragmentState::Obliterated);
+
+        store(&fake)
+            .await
+            .put(repository.into(), address, fragment, Some(payload), false)
+            .await
+            .expect("re-upload over a tombstone is allowed");
+
+        assert_eq!(fake.state_of(address.hash), Some(FragmentState::Stored));
+        assert_eq!(fake.association_count(address.hash), 1);
+    }
+
+    /// The drain exists so a put that had already passed its state probe can land its association
+    /// and be counted. Without the wait the count runs immediately, sees nothing, and the payload
+    /// is deleted underneath a partition that legitimately stored it.
+    #[tokio::test]
+    async fn the_drain_lets_an_in_flight_association_be_counted() {
+        let fake = Fake::default();
+        let hash: Hash = random();
+        let mine = Address {
+            hash,
+            context: random(),
+        };
+        let repository: Context = random();
+        let (fragment, payload) = representation(FragmentFlags::PayloadCompressedZstd, 64, 256);
+
+        let store = store(&fake).await;
+        store
+            .clone()
+            .put(repository.into(), mine, fragment, Some(payload), false)
+            .await
+            .expect("put should succeed");
+
+        let injector = fake.clone();
+        let racing_repository: Context = random();
+        let racing = Address {
+            hash,
+            context: random(),
+        };
+        let mut tasks = JoinSet::new();
+        lore_base::lore_spawn!(tasks, async move {
+            tokio::time::sleep(Duration::from_millis(20)).await;
+            injector.add_association(racing_repository, racing);
+        });
+
+        store
+            .obliterate(
+                repository.into(),
+                mine,
+                Arc::new(StoreObliterateStats::default()),
+            )
+            .await
+            .expect("obliterate should succeed");
+
+        while tasks.join_next().await.is_some() {}
+
+        assert!(
+            fake.object(hash).is_some(),
+            "an association that landed during the drain must keep the payload alive"
+        );
+        assert_eq!(fake.association_count(hash), 1);
+        assert_eq!(
+            fake.state_of(hash),
+            Some(FragmentState::Stored),
+            "the mark must be released so the surviving reference stays usable"
+        );
+    }
+
+    // ---------------------------------------------------------------------
+    // Surface that had coverage on main
+    // ---------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn copy_associates_the_destination_without_touching_the_payload() {
+        let fake = Fake::default();
+        let source = Address {
+            hash: random(),
+            context: random(),
+        };
+        let repository: Context = random();
+        let (fragment, payload) = representation(FragmentFlags::PayloadCompressedZstd, 64, 256);
+
+        let store = store(&fake).await;
+        store
+            .clone()
+            .put(
+                repository.into(),
+                source,
+                fragment,
+                Some(payload.clone()),
+                false,
+            )
+            .await
+            .expect("put should succeed");
+
+        let destination_context: Context = random();
+        store
+            .copy(
+                repository.into(),
+                source,
+                repository.into(),
+                destination_context,
+                true,
             )
             .await
             .expect("copy should succeed");
+
+        assert_eq!(fake.association_count(source.hash), 2);
+        assert_eq!(
+            fake.object(source.hash).unwrap().0,
+            payload.as_ref(),
+            "copy must not rewrite the payload"
+        );
+        assert_eq!(fake.object_reads(), 0, "copy must not read S3");
+    }
+
+    #[tokio::test]
+    async fn copy_of_an_unknown_address_is_not_found() {
+        let fake = Fake::default();
+        let source = Address {
+            hash: random(),
+            context: random(),
+        };
+        let repository: Context = random();
+
+        store(&fake)
+            .await
+            .copy(
+                repository.into(),
+                source,
+                repository.into(),
+                random::<Context>(),
+                true,
+            )
+            .await
+            .expect_err("nothing to copy");
+
+        assert_eq!(fake.association_count(source.hash), 0);
+    }
+
+    /// A hash present in another context is not a full match, so it must not be copyable from this
+    /// one — the copy would otherwise fabricate a reference from a partial match.
+    #[tokio::test]
+    async fn copy_of_a_partial_match_is_not_found() {
+        let fake = Fake::default();
+        let hash: Hash = random();
+        let stored = Address {
+            hash,
+            context: random(),
+        };
+        let repository: Context = random();
+        let (fragment, payload) = representation(FragmentFlags::PayloadCompressedZstd, 64, 256);
+
+        let store = store(&fake).await;
+        store
+            .clone()
+            .put(repository.into(), stored, fragment, Some(payload), false)
+            .await
+            .expect("put should succeed");
+
+        let other_context = Address {
+            hash,
+            context: random(),
+        };
+        store
+            .copy(
+                repository.into(),
+                other_context,
+                repository.into(),
+                random::<Context>(),
+                true,
+            )
+            .await
+            .expect_err("a different context is not a full match");
+
+        assert_eq!(fake.association_count(hash), 1);
+    }
+
+    #[tokio::test]
+    async fn exist_batch_reports_a_match_per_address_in_order() {
+        let fake = Fake::default();
+        let repository: Context = random();
+        let absent = Address {
+            hash: random(),
+            context: random(),
+        };
+        let (fragment, payload) = representation(FragmentFlags::PayloadCompressedZstd, 64, 256);
+
+        let store = store(&fake).await;
+        let mut stored = Vec::new();
+        for _ in 0..2 {
+            let address = Address {
+                hash: random(),
+                context: random(),
+            };
+            store
+                .clone()
+                .put(
+                    repository.into(),
+                    address,
+                    fragment,
+                    Some(payload.clone()),
+                    false,
+                )
+                .await
+                .expect("put should succeed");
+            stored.push(address);
+        }
+
+        let results = store
+            .exist_batch(
+                repository.into(),
+                &[stored[0], absent, stored[1]],
+                StoreMatch::MatchFull,
+            )
+            .await
+            .expect("exist_batch should succeed");
+
+        assert_eq!(
+            results,
+            vec![
+                StoreMatch::MatchFull,
+                StoreMatch::MatchNone,
+                StoreMatch::MatchFull
+            ],
+            "results must line up with the addresses given, misses included"
+        );
+    }
+
+    /// The corruption this design exists to make impossible.
+    ///
+    /// Writers race on one hash with different representations, each a valid encoding of the same
+    /// content. Under a model that stores the fragment separately from the bytes, an interleaving
+    /// can leave one writer's fragment describing another writer's payload. Here the fragment
+    /// travels on the object, so whichever upload lands last is the one that is read back — whole.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn concurrent_writers_cannot_tear_the_fragment_from_its_payload() {
+        const CONTENT_SIZE: u64 = 4096;
+
+        for _ in 0..64 {
+            let fake = Fake::default();
+            let hash: Hash = random();
+            let store = store(&fake).await;
+
+            let representations = [
+                representation(FragmentFlags::PayloadCompressedZstd, 64, CONTENT_SIZE),
+                representation(FragmentFlags::PayloadCompressedLZ4, 512, CONTENT_SIZE),
+                representation(FragmentFlags::PayloadCompressedOodle2, 1024, CONTENT_SIZE),
+                representation(FragmentFlags::PayloadFragmented, 2048, CONTENT_SIZE),
+            ];
+
+            let mut writers = JoinSet::new();
+            for (fragment, payload) in representations {
+                let store = store.clone();
+                let address = Address {
+                    hash,
+                    context: random(),
+                };
+                let repository: Context = random();
+
+                lore_base::lore_spawn!(writers, async move {
+                    store
+                        .put(repository.into(), address, fragment, Some(payload), false)
+                        .await
+                });
+            }
+
+            while let Some(result) = writers.join_next().await {
+                result
+                    .expect("writer task should not panic")
+                    .expect("every writer should succeed");
+            }
+
+            let (body, metadata) = fake.object(hash).expect("a payload must be stored");
+            let stored = from_object_metadata(Some(&metadata))
+                .expect("the stored object must carry a fragment");
+
+            assert_eq!(
+                stored.size_payload as usize,
+                body.len(),
+                "the fragment on the object must describe the bytes on that same object"
+            );
+            assert_eq!(stored.size_content, CONTENT_SIZE);
+            assert_eq!(
+                fake.state_of(hash),
+                Some(FragmentState::Stored),
+                "the state row must not be left mid-flight"
+            );
+            assert_eq!(
+                fake.association_count(hash),
+                4,
+                "every writer's partition must end up referencing the payload"
+            );
+
+            let expected_byte = (stored.flags & PAYLOAD_FLAGS) as u8;
+            assert!(
+                body.iter().all(|byte| *byte == expected_byte),
+                "the bytes must be the ones the winning writer uploaded, not a mix"
+            );
+        }
     }
 }

--- a/lore-aws/src/store/mod.rs
+++ b/lore-aws/src/store/mod.rs
@@ -3,6 +3,7 @@
 pub mod immutable_store;
 pub mod lock_store;
 pub mod mutable_store;
+pub mod object_metadata;
 
 #[cfg(test)]
 pub fn address_with_random_context(address: lore_storage::Address) -> lore_storage::Address {

--- a/lore-aws/src/store/object_metadata.rs
+++ b/lore-aws/src/store/object_metadata.rs
@@ -1,0 +1,308 @@
+// SPDX-FileCopyrightText: 2026 Epic Games, Inc.
+// SPDX-License-Identifier: MIT
+//! Encoding of a [`Fragment`] as S3 object metadata.
+//!
+//! The fragment describing a payload travels on the S3 object holding that payload, as an
+//! `x-amz-meta-*` header, rather than in a separate `DynamoDB` record. Object metadata is part of
+//! the object version: it cannot be changed without rewriting the object, and a `GetObject`
+//! returns headers and body from the same version. A reader therefore always sees the fragment
+//! that was written with the bytes it is reading, which is what makes the two impossible to tear
+//! apart — no write protocol is involved, only S3's own object atomicity.
+//!
+//! Only the representation is carried here. Obliteration state is mutable and lives in
+//! `DynamoDB`; see [`crate::store::immutable_store`].
+
+use std::collections::HashMap;
+
+use lore_base::types::Fragment;
+use lore_base::types::FragmentFlags;
+
+/// The flags that describe the payload itself, and therefore the only ones the object carries.
+///
+/// Everything outside this mask falls into one of three groups, none of which belongs on an
+/// immutable object:
+///
+/// - `PayloadObliterating` / `PayloadObliterated` are lifecycle state. They change while the bytes
+///   do not, and object metadata cannot be edited without rewriting the object, so they live in
+///   `DynamoDB`.
+/// - `PayloadStoredDurable` / `PayloadStoredLocal` are facts about *which store* holds the payload,
+///   not about the payload. Each store derives its own on read; writing them down lets one store's
+///   answer be served for another.
+/// - `PayloadLocalCachePriority` is a per-machine caching hint. It says what one host should keep,
+///   which is not a property of the content and is not the same answer for every reader.
+/// - `PayloadDoNotReplicate` is a request about the transfer in hand, stripped before storage by
+///   `sanitise_fragment_behavior_flags`.
+///
+/// `PayloadRevisionState` does travel here: it says what the payload *is*, which is the same for
+/// every reader of those bytes.
+pub const PAYLOAD_FLAGS: u32 = FragmentFlags::PayloadFragmented.bits()
+    | FragmentFlags::PayloadCompressed.bits()
+    | FragmentFlags::PayloadRevisionState.bits();
+
+/// The single object metadata key holding the whole fragment.
+///
+/// One key rather than one per field: a key name is spelled out in full on every request and every
+/// response, so three of them cost several times what the values do. S3 lowercases metadata keys,
+/// so this is written lowercase to make the round trip an identity.
+const KEY_FRAGMENT: &str = "lore-fragment";
+
+/// Separator between the fragment's fields within [`KEY_FRAGMENT`].
+const SEPARATOR: char = ':';
+
+/// Names for the parts of the value, used only to say which one failed to parse.
+const FIELD_COUNT: &str = "field count";
+const FIELD_FLAGS: &str = "flags";
+const FIELD_SIZE_PAYLOAD: &str = "size_payload";
+const FIELD_SIZE_CONTENT: &str = "size_content";
+
+/// Why a stored object did not yield a usable fragment.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ObjectMetadataError {
+    /// The object carries no lore metadata at all. An object written before fragments moved onto
+    /// the object has this shape, so this is the discriminator a migration reads.
+    Absent,
+    /// The object carries lore metadata that could not be parsed. Names the offending field.
+    Malformed(&'static str),
+}
+
+impl std::error::Error for ObjectMetadataError {}
+
+impl std::fmt::Display for ObjectMetadataError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Absent => write!(f, "object carries no fragment metadata"),
+            Self::Malformed(field) => write!(f, "fragment metadata field {field} is malformed"),
+        }
+    }
+}
+
+/// Render a fragment as the object metadata to attach to its object.
+///
+/// The value is `<flags>:<size_payload>:<size_content>` — flags in hex, because it is a bit field
+/// and hex is how bits are read; the sizes in decimal, because they are magnitudes. Plain text
+/// rather than a packed encoding, so an object's shape stays legible from `aws s3api head-object`
+/// with no lore tooling.
+///
+/// Flags are reduced to [`PAYLOAD_FLAGS`] on the way out, so the object describes the payload and
+/// nothing else.
+pub fn to_object_metadata(fragment: &Fragment) -> HashMap<String, String> {
+    HashMap::from([(KEY_FRAGMENT.to_owned(), encode(fragment))])
+}
+
+/// The value itself. The map is the S3 SDK's currency, not this module's — the fragment is a fixed
+/// triplet with no room for anything else, so the format is a string and the map exists only to
+/// hand it over.
+fn encode(fragment: &Fragment) -> String {
+    let flags = fragment.flags & PAYLOAD_FLAGS;
+
+    format!(
+        "{flags:x}{SEPARATOR}{}{SEPARATOR}{}",
+        fragment.size_payload, fragment.size_content
+    )
+}
+
+/// Recover the fragment from the object metadata returned by a `GetObject` or `HeadObject`.
+pub fn from_object_metadata(
+    metadata: Option<&HashMap<String, String>>,
+) -> Result<Fragment, ObjectMetadataError> {
+    decode(
+        metadata
+            .and_then(|metadata| metadata.get(KEY_FRAGMENT))
+            .ok_or(ObjectMetadataError::Absent)?,
+    )
+}
+
+/// Parse the value. Split rather than collected: there are exactly three fields and a fourth is an
+/// error, so there is nothing to gather.
+fn decode(value: &str) -> Result<Fragment, ObjectMetadataError> {
+    let mut fields = value.split(SEPARATOR);
+    let malformed = || ObjectMetadataError::Malformed(FIELD_COUNT);
+
+    let flags = fields.next().ok_or_else(malformed)?;
+    let size_payload = fields.next().ok_or_else(malformed)?;
+    let size_content = fields.next().ok_or_else(malformed)?;
+
+    if fields.next().is_some() {
+        return Err(malformed());
+    }
+
+    Ok(Fragment {
+        flags: u32::from_str_radix(flags, 16)
+            .map_err(|_parse| ObjectMetadataError::Malformed(FIELD_FLAGS))?
+            & PAYLOAD_FLAGS,
+        size_payload: size_payload
+            .parse()
+            .map_err(|_parse| ObjectMetadataError::Malformed(FIELD_SIZE_PAYLOAD))?,
+        size_content: size_content
+            .parse()
+            .map_err(|_parse| ObjectMetadataError::Malformed(FIELD_SIZE_CONTENT))?,
+    })
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    fn fragment() -> Fragment {
+        Fragment {
+            flags: FragmentFlags::PayloadCompressedZstd.bits(),
+            size_payload: 4096,
+            size_content: 16384,
+        }
+    }
+
+    #[test]
+    fn round_trips_a_fragment() {
+        let encoded = to_object_metadata(&fragment());
+
+        assert_eq!(from_object_metadata(Some(&encoded)), Ok(fragment()));
+    }
+
+    #[test]
+    fn the_format_round_trips_without_a_map() {
+        assert_eq!(decode(&encode(&fragment())), Ok(fragment()));
+        assert_eq!(encode(&fragment()), "8:4096:16384");
+    }
+
+    #[test]
+    fn writes_one_key_holding_hex_flags_and_decimal_sizes() {
+        let encoded = to_object_metadata(&fragment());
+
+        assert_eq!(encoded.len(), 1, "one key, not one per field");
+        assert_eq!(encoded.get(KEY_FRAGMENT).unwrap(), "8:4096:16384");
+    }
+
+    #[test]
+    fn round_trips_the_extreme_values() {
+        let extreme = Fragment {
+            flags: PAYLOAD_FLAGS,
+            size_payload: u32::MAX,
+            size_content: u64::MAX,
+        };
+        let encoded = to_object_metadata(&extreme);
+
+        assert_eq!(from_object_metadata(Some(&encoded)), Ok(extreme));
+    }
+
+    #[test]
+    fn keeps_every_flag_that_describes_the_payload() {
+        for flag in [
+            FragmentFlags::PayloadFragmented,
+            FragmentFlags::PayloadCompressedLZ4,
+            FragmentFlags::PayloadCompressedOodle2,
+            FragmentFlags::PayloadCompressedZstd,
+            FragmentFlags::PayloadRevisionState,
+        ] {
+            let carried = Fragment {
+                flags: flag.bits(),
+                ..fragment()
+            };
+
+            assert_eq!(
+                from_object_metadata(Some(&to_object_metadata(&carried))),
+                Ok(carried),
+                "{flag:?} describes the payload and must travel on the object"
+            );
+        }
+    }
+
+    #[test]
+    fn drops_state_store_location_and_per_machine_flags() {
+        for flag in [
+            FragmentFlags::PayloadObliterating,
+            FragmentFlags::PayloadObliterated,
+            FragmentFlags::PayloadStoredDurable,
+            FragmentFlags::PayloadStoredLocal,
+            FragmentFlags::PayloadLocalCachePriority,
+            FragmentFlags::PayloadDoNotReplicate,
+        ] {
+            let mut tainted = fragment();
+            tainted.flags |= flag.bits();
+
+            assert_eq!(
+                from_object_metadata(Some(&to_object_metadata(&tainted))),
+                Ok(fragment()),
+                "{flag:?} is not a property of the payload and must not travel on the object"
+            );
+        }
+    }
+
+    #[test]
+    fn masks_flags_that_reached_the_object_some_other_way() {
+        let encoded = HashMap::from([(KEY_FRAGMENT.to_owned(), format!("{:x}:1:1", u32::MAX))]);
+
+        let recovered = from_object_metadata(Some(&encoded)).unwrap();
+
+        assert_eq!(recovered.flags, PAYLOAD_FLAGS);
+    }
+
+    #[test]
+    fn reports_an_object_with_no_metadata_as_absent() {
+        assert_eq!(from_object_metadata(None), Err(ObjectMetadataError::Absent));
+        assert_eq!(
+            from_object_metadata(Some(&HashMap::new())),
+            Err(ObjectMetadataError::Absent)
+        );
+        assert_eq!(
+            from_object_metadata(Some(&HashMap::from([(
+                "unrelated".to_owned(),
+                "8:1:1".to_owned()
+            )]))),
+            Err(ObjectMetadataError::Absent)
+        );
+    }
+
+    #[test]
+    fn reports_the_wrong_number_of_fields_as_malformed() {
+        for value in ["", "8", "8:1", "8:1:1:1"] {
+            let encoded = HashMap::from([(KEY_FRAGMENT.to_owned(), value.to_owned())]);
+
+            assert_eq!(
+                from_object_metadata(Some(&encoded)),
+                Err(ObjectMetadataError::Malformed(FIELD_COUNT)),
+                "{value:?} does not hold three fields"
+            );
+        }
+    }
+
+    #[test]
+    fn names_the_field_that_failed_to_parse() {
+        for (value, field) in [
+            ("zz:1:1", FIELD_FLAGS),
+            ("8:nope:1", FIELD_SIZE_PAYLOAD),
+            ("8:1:nope", FIELD_SIZE_CONTENT),
+        ] {
+            let encoded = HashMap::from([(KEY_FRAGMENT.to_owned(), value.to_owned())]);
+
+            assert_eq!(
+                from_object_metadata(Some(&encoded)),
+                Err(ObjectMetadataError::Malformed(field))
+            );
+        }
+    }
+
+    #[test]
+    fn reports_an_overflowing_value_as_malformed() {
+        let encoded = HashMap::from([(
+            KEY_FRAGMENT.to_owned(),
+            format!("8:{}:1", u64::from(u32::MAX) + 1),
+        )]);
+
+        assert_eq!(
+            from_object_metadata(Some(&encoded)),
+            Err(ObjectMetadataError::Malformed(FIELD_SIZE_PAYLOAD))
+        );
+    }
+
+    /// Decimal flags would silently decode as a different bit pattern for any value above 9, so
+    /// the base is part of the format rather than an incidental choice.
+    #[test]
+    fn reads_flags_as_hex() {
+        let encoded = HashMap::from([(KEY_FRAGMENT.to_owned(), "a:1:1".to_owned())]);
+
+        assert_eq!(
+            from_object_metadata(Some(&encoded)).unwrap().flags,
+            0xa & PAYLOAD_FLAGS
+        );
+    }
+}

--- a/lore-integration-tests/src/aws_store_test.rs
+++ b/lore-integration-tests/src/aws_store_test.rs
@@ -2,10 +2,13 @@
 // SPDX-License-Identifier: MIT
 #[cfg(all(test, feature = "integration_tests"))]
 mod aws_store_tests {
+    use std::collections::HashMap;
     use std::error::Error;
     use std::sync::Arc;
 
     use async_trait::async_trait;
+    use aws_sdk_dynamodb::primitives::Blob;
+    use aws_sdk_dynamodb::types::AttributeValue;
     use bytes::Bytes;
     use lore_aws::store::immutable_store::AwsImmutableStore;
     use lore_aws::store::immutable_store::AwsImmutableStoreSettings;
@@ -71,6 +74,14 @@ mod aws_store_tests {
 
     #[async_trait]
     impl ImmutableStore for LocalStore {
+        async fn get_metadata(
+            self: Arc<Self>,
+            partition: Partition,
+            address: Address,
+        ) -> Result<StoreQueryResult, StoreError> {
+            self.query(partition, address, StoreMatch::MatchFull).await
+        }
+
         async fn exist(
             self: Arc<Self>,
             _repository: Partition,
@@ -176,6 +187,154 @@ mod aws_store_tests {
         fn max_query_batch(&self) -> Option<usize> {
             Some(100)
         }
+    }
+
+    /// An object stored before the fragment moved onto it: bare bytes in S3, the fragment in a row
+    /// of the fragment metadata table. Reading one must still work, since the cut-over does not
+    /// rewrite the existing population — this is the whole of the migration's read path.
+    #[tokio::test]
+    async fn test_get_immutable_falls_back_to_the_fragment_metadata_table() -> TestResult {
+        let repository = random::<RepositoryId>();
+        let (fragment, address, payload) = fragment::generate_random();
+
+        let execution = setup_execution("test".to_string());
+        LORE_CONTEXT
+            .scope(execution, async move {
+                let (s3, dynamo, _) = setup(vec![
+                    MUTABLE_STORE_TABLE_NAME,
+                    FRAGMENTS_TABLE_NAME,
+                    FRAGMENT_METADATA_TABLE_NAME,
+                ])
+                .await?;
+
+                let settings = AwsImmutableStoreSettings::new(
+                    S3StoreSettings::new(STORE_BUCKET_NAME.to_string()),
+                    DynamoDbImmutableStoreSettings::new(
+                        FRAGMENTS_TABLE_NAME.to_string(),
+                        FRAGMENT_METADATA_TABLE_NAME.to_string(),
+                    )
+                    .with_fragment_metadata_table(FRAGMENT_METADATA_TABLE_NAME.to_string()),
+                    false,
+                );
+                let store = Arc::new(AwsImmutableStore::new(s3, dynamo, &settings));
+
+                // Store it the current way first, so the association and the keys are real.
+                store
+                    .clone()
+                    .put(repository, address, fragment, Some(payload.clone()), false)
+                    .await?;
+
+                let (raw_s3, raw_dynamo, _) = setup(vec![]).await?;
+
+                // Then put it back the way that era stored it: bare bytes, no object metadata.
+                let mut dst = [0u8; 64];
+                let key = lore_revision::util::to_hex_str(address.hash.data(), &mut dst);
+                raw_s3
+                    .put_object(STORE_BUCKET_NAME, key, payload.to_vec(), None)
+                    .await
+                    .expect("rewriting the object without metadata should succeed");
+
+                // And the row that era wrote: the whole fragment flattened, with no state attribute.
+                let row = HashMap::from([
+                    (
+                        "hash".to_string(),
+                        AttributeValue::B(Blob::new(address.hash.data().to_vec())),
+                    ),
+                    (
+                        "flags".to_string(),
+                        AttributeValue::N(fragment.flags.to_string()),
+                    ),
+                    (
+                        "size_payload".to_string(),
+                        AttributeValue::N(fragment.size_payload.to_string()),
+                    ),
+                    (
+                        "size_content".to_string(),
+                        AttributeValue::N(fragment.size_content.to_string()),
+                    ),
+                ]);
+                raw_dynamo
+                    .put_item(&Arc::<str>::from(FRAGMENT_METADATA_TABLE_NAME), row)
+                    .await
+                    .expect("writing the pre-cut-over row should succeed");
+
+                let (got_fragment, got_payload) = store
+                    .get(repository, address, StoreMatch::MatchFull)
+                    .await?;
+
+                assert_eq!(got_payload, payload, "the payload must read back intact");
+                assert_eq!(got_fragment.size_payload, fragment.size_payload);
+                assert_eq!(got_fragment.size_content, fragment.size_content);
+                assert_eq!(
+                    got_fragment.flags & FragmentFlags::PayloadStoredDurable,
+                    FragmentFlags::PayloadStoredDurable,
+                    "durability is derived, not read from the row"
+                );
+
+                Ok(())
+            })
+            .await
+    }
+
+    /// The same object on a deployment that never stored one that way. Leaving the fragment
+    /// metadata table unconfigured declares no such object exists, so this one is damaged rather
+    /// than old — and must be reported, not described from a row that cannot be about it.
+    #[tokio::test]
+    async fn test_get_immutable_without_a_fragment_metadata_table_reports_the_object_as_damaged()
+    -> TestResult {
+        let repository = random::<RepositoryId>();
+        let (fragment, address, payload) = fragment::generate_random();
+
+        let execution = setup_execution("test".to_string());
+        LORE_CONTEXT
+            .scope(execution, async move {
+                let (s3, dynamo, _) = setup(vec![
+                    MUTABLE_STORE_TABLE_NAME,
+                    FRAGMENTS_TABLE_NAME,
+                    FRAGMENT_METADATA_TABLE_NAME,
+                ])
+                .await?;
+
+                let settings = AwsImmutableStoreSettings::new(
+                    S3StoreSettings::new(STORE_BUCKET_NAME.to_string()),
+                    DynamoDbImmutableStoreSettings::new(
+                        FRAGMENTS_TABLE_NAME.to_string(),
+                        FRAGMENT_METADATA_TABLE_NAME.to_string(),
+                    ),
+                    false,
+                );
+                let store = Arc::new(AwsImmutableStore::new(s3, dynamo, &settings));
+
+                store
+                    .clone()
+                    .put(repository, address, fragment, Some(payload.clone()), false)
+                    .await?;
+
+                let (raw_s3, _, _) = setup(vec![]).await?;
+                let mut dst = [0u8; 64];
+                let key = lore_revision::util::to_hex_str(address.hash.data(), &mut dst);
+                raw_s3
+                    .put_object(STORE_BUCKET_NAME, key, payload.to_vec(), None)
+                    .await
+                    .expect("rewriting the object without metadata should succeed");
+
+                let error = store
+                    .get(repository, address, StoreMatch::MatchFull)
+                    .await
+                    .expect_err("an object with no metadata and nowhere to look is damaged");
+
+                assert!(
+                    error.is_internal(),
+                    "must be reported as an error, not as a miss that a client would retry into"
+                );
+                assert!(
+                    format!("{error:?}").contains("carries no fragment metadata"),
+                    "the error should say what is wrong with the object, got: {error:?}"
+                );
+
+                Ok(())
+            })
+            .await
     }
 
     async fn initialize_store() -> Result<
@@ -346,7 +505,7 @@ mod aws_store_tests {
 
                 let result = immutable_store
                     .clone()
-                    .query(repository, address, StoreMatch::MatchFull)
+                    .get_metadata(repository, address)
                     .await
                     .unwrap();
 
@@ -382,9 +541,10 @@ mod aws_store_tests {
                 let mut address = address;
                 address.context = random::<Context>();
 
-                let mut want_fragment = fragment;
-                want_fragment.flags = FragmentFlags::PayloadStoredDurable.bits()
-                    | (fragment.flags & FragmentFlags::PayloadCompressed);
+                let want_fragment = Fragment {
+                    flags: FragmentFlags::PayloadStoredDurable.bits(),
+                    ..Default::default()
+                };
                 assert_eq!(
                     StoreQueryResult {
                         fragment: want_fragment,
@@ -417,9 +577,10 @@ mod aws_store_tests {
                 let mut address = address;
                 address.context = random::<Context>();
 
-                let mut want_fragment = fragment;
-                want_fragment.flags = FragmentFlags::PayloadStoredDurable.bits()
-                    | (fragment.flags & FragmentFlags::PayloadCompressed);
+                let want_fragment = Fragment {
+                    flags: FragmentFlags::PayloadStoredDurable.bits(),
+                    ..Default::default()
+                };
                 assert_eq!(
                     StoreQueryResult {
                         fragment: want_fragment,
@@ -492,43 +653,6 @@ mod aws_store_tests {
                         .clone()
                         .query(repository, address, StoreMatch::MatchFull)
                         .await?
-                );
-
-                Ok(())
-            })
-            .await
-    }
-
-    #[tokio::test]
-    async fn test_put_immutable_partial_hash_collision() -> TestResult {
-        let repository = random::<RepositoryId>();
-        let (fragment, address, payload) = fragment::generate_random();
-
-        let (immutable_store, _mutable_store, execution) = initialize_store().await?;
-        LORE_CONTEXT
-            .scope(execution.clone(), async move {
-                // Put the fragment with an initial context.
-                immutable_store
-                    .clone()
-                    .put(repository, address, fragment, Some(payload.clone()), false)
-                    .await?;
-
-                let mut invalid_fragment = fragment;
-                invalid_fragment.size_content *= 2;
-
-                assert!(
-                    immutable_store
-                        .clone()
-                        .put(
-                            repository,
-                            address,
-                            invalid_fragment,
-                            Some(payload.clone()),
-                            false
-                        )
-                        .await
-                        .expect_err("should have returned an error")
-                        .is_internal()
                 );
 
                 Ok(())

--- a/lore-revision/src/branch.rs
+++ b/lore-revision/src/branch.rs
@@ -904,7 +904,7 @@ pub async fn store_latest_history(
         previous: old_history_latest,
     };
 
-    let (address, _) = entry
+    let address = entry
         .write_to_immutable(
             repository.clone(),
             Context::default(),

--- a/lore-revision/src/commit.rs
+++ b/lore-revision/src/commit.rs
@@ -43,7 +43,6 @@ use crate::link;
 use crate::lore::Address;
 use crate::lore::BranchId;
 use crate::lore::Context;
-use crate::lore::Fragment;
 use crate::lore::Hash;
 use crate::lore::RepositoryId;
 use crate::lore::TypedBytes;
@@ -1993,7 +1992,7 @@ async fn commit_file(
                 );
             }
 
-            let (address, fragment) = immutable::write_from_file_with_tracker(
+            let (address, size_content) = immutable::write_from_file_with_tracker(
                 repository.clone(),
                 absolute_path.as_path(),
                 node.address.context,
@@ -2011,7 +2010,7 @@ async fn commit_file(
             stats
                 .complete
                 .bytes_transferred
-                .fetch_add(fragment.size_content, Ordering::Relaxed);
+                .fetch_add(size_content, Ordering::Relaxed);
 
             let Ok(metadata) = tokio::fs::metadata(absolute_path.as_path()).await else {
                 return Err(CommitError::internal(format!(
@@ -2022,7 +2021,7 @@ async fn commit_file(
 
             (
                 address,
-                fragment.size_content,
+                size_content,
                 util::fs::metadata_to_mode(&metadata, node.mode),
             )
         };
@@ -2686,7 +2685,7 @@ async fn generate_delta_block(
     };
     let delta_count = delta.count::<NodeDelta>();
 
-    let (address, _fragment) = if !delta.is_empty() {
+    let address = if !delta.is_empty() {
         immutable::write_with_tracker(
             repository.clone(),
             Context::default(),
@@ -2699,7 +2698,7 @@ async fn generate_delta_block(
         .await
         .forward::<CommitError>("Failed writing delta block to immutable store")?
     } else {
-        (Address::default(), Fragment::default())
+        Address::default()
     };
 
     state

--- a/lore-revision/src/dependency/mod.rs
+++ b/lore-revision/src/dependency/mod.rs
@@ -687,7 +687,7 @@ pub async fn store_dependency_data(
                     .set_binary(key, &blob)
                     .internal("setting inline dependency blob")?;
             } else {
-                let (address, _) = immutable::write(
+                let address = immutable::write(
                     repository.clone(),
                     Context::default(),
                     blob,

--- a/lore-revision/src/immutable.rs
+++ b/lore-revision/src/immutable.rs
@@ -292,7 +292,7 @@ pub async fn store_raw(
     buffer: Bytes,
     cache_local: bool,
     remote_write: bool,
-) -> Result<(Address, Fragment), ImmutableError> {
+) -> Result<Address, ImmutableError> {
     store_raw_with_tracker(
         repository,
         address,
@@ -318,7 +318,7 @@ pub async fn store_raw_with_tracker(
     cache_local: bool,
     remote_write: bool,
     tracker: Option<Arc<lore_storage::write_tracker::WriteTracker>>,
-) -> Result<(Address, Fragment), ImmutableError> {
+) -> Result<Address, ImmutableError> {
     let session = if remote_write {
         Some(resolve_session(&repository))
     } else {
@@ -339,7 +339,7 @@ pub async fn store_raw_with_tracker(
     .await
     .forward::<ImmutableError>("storing fragment")?;
 
-    Ok((result.address, result.fragment))
+    Ok(result.address)
 }
 
 // ---------------------------------------------------------------------------
@@ -351,7 +351,7 @@ pub async fn write(
     context: Context,
     buffer: Bytes,
     flags: WriteOptions,
-) -> Result<(Address, Fragment), ImmutableError> {
+) -> Result<Address, ImmutableError> {
     write_with_tracker(repository, context, buffer, flags, None).await
 }
 
@@ -362,7 +362,7 @@ pub async fn write_with_tracker(
     buffer: Bytes,
     flags: WriteOptions,
     tracker: Option<Arc<lore_storage::write_tracker::WriteTracker>>,
-) -> Result<(Address, Fragment), ImmutableError> {
+) -> Result<Address, ImmutableError> {
     let session = if flags.remote_write {
         Some(resolve_session(&repository))
     } else {
@@ -382,12 +382,14 @@ pub async fn write_with_tracker(
     .forward("writing immutable content")
 }
 
+/// Write a file to the immutable store, returning its address and the size of the content that
+/// address stands for.
 pub async fn write_from_file(
     repository: Arc<RepositoryContext>,
     path: &Path,
     context: Context,
     flags: WriteOptions,
-) -> Result<(Address, Fragment), ImmutableError> {
+) -> Result<(Address, u64), ImmutableError> {
     write_from_file_with_tracker(repository, path, context, flags, None).await
 }
 
@@ -398,7 +400,7 @@ pub async fn write_from_file_with_tracker(
     context: Context,
     flags: WriteOptions,
     tracker: Option<Arc<lore_storage::write_tracker::WriteTracker>>,
-) -> Result<(Address, Fragment), ImmutableError> {
+) -> Result<(Address, u64), ImmutableError> {
     let session = if flags.remote_write {
         Some(resolve_session(&repository))
     } else {
@@ -742,7 +744,7 @@ pub trait WriteToImmutable: zerocopy::IntoBytes + zerocopy::Immutable + std::mar
         repository: Arc<RepositoryContext>,
         context: Context,
         flags: WriteOptions,
-    ) -> Result<(Address, Fragment), ImmutableError> {
+    ) -> Result<Address, ImmutableError> {
         let self_slice = self.as_bytes();
         // Unsafe extension of the lifetime of the self-as-buffer memory. Since
         // we await the task and no shared references of the buffer will be kept

--- a/lore-revision/src/merge_carry.rs
+++ b/lore-revision/src/merge_carry.rs
@@ -97,7 +97,7 @@ pub async fn store(
         bytes.extend_from_slice(s.as_bytes());
     }
 
-    let (address, _fragment) = immutable::write(
+    let address = immutable::write(
         repository.clone(),
         Context::default(),
         Bytes::from(bytes),

--- a/lore-revision/src/metadata.rs
+++ b/lore-revision/src/metadata.rs
@@ -293,7 +293,7 @@ impl Metadata {
         }
 
         let buffer = self.buffer.clone();
-        let (address, _) = immutable::write_with_tracker(
+        let address = immutable::write_with_tracker(
             repository.clone(),
             Context::default(),
             buffer.freeze(),
@@ -327,7 +327,7 @@ impl Metadata {
         }
 
         let buffer = self.buffer.clone();
-        let (address, _) = immutable::write(
+        let address = immutable::write(
             repository.clone(),
             Context::default(),
             buffer.freeze(),

--- a/lore-revision/src/metadata/branch.rs
+++ b/lore-revision/src/metadata/branch.rs
@@ -325,7 +325,7 @@ pub async fn set(
                     .internal("reading binary metadata file")?
             };
 
-            let (address, _) = immutable::write(
+            let address = immutable::write(
                 repo.clone(),
                 Context::default(),
                 Bytes::from_owner(payload),

--- a/lore-revision/src/metadata/repository.rs
+++ b/lore-revision/src/metadata/repository.rs
@@ -315,7 +315,7 @@ pub async fn set(
                     .internal("reading binary metadata file")?
             };
 
-            let (address, _) = immutable::write(
+            let address = immutable::write(
                 repo.clone(),
                 Context::default(),
                 Bytes::from_owner(payload),

--- a/lore-revision/src/metadata/set.rs
+++ b/lore-revision/src/metadata/set.rs
@@ -136,7 +136,7 @@ pub async fn set_revision(
             // When storing binary data, put it in the immutable store
             // Use a zero context to avoid creating extra entries if multiple
             // revisions use the same metadata blob
-            let (address, _) = {
+            let address = {
                 immutable::write(
                     repository.clone(),
                     Context::default(),
@@ -265,7 +265,7 @@ async fn set_file_task(
                 // When storing binary data, put it in the immutable store
                 // Use a zero context to avoid creating extra entries if multiple
                 // files use the same metadata blob
-                let (address, _) = {
+                let address = {
                     immutable::write(
                         repository.clone(),
                         Context::default(),

--- a/lore-revision/src/state.rs
+++ b/lore-revision/src/state.rs
@@ -727,7 +727,7 @@ impl State {
                         if block.is_nametable_deserialized() {
                             lore_trace!("Serializing dirty node block {} name table", block_index);
                             let name_table = block.read().clone_name_table();
-                            let (name_table, _) = if !name_table.is_empty() {
+                            let name_table = if !name_table.is_empty() {
                                 immutable::write(
                                     repository.clone(),
                                     Context::default(),
@@ -739,7 +739,7 @@ impl State {
                                 .await
                                 .internal("Failed to serialize node block")?
                             } else {
-                                (Address::default(), Fragment::default())
+                                Address::default()
                             };
                             {
                                 let mut writer = block.write();
@@ -751,7 +751,7 @@ impl State {
                     node_block.flags &= !NodeBlockFlags::Dirty;
                     node_block.flags &= !NodeBlockFlags::UpgradeGeneratedNametable;
                     node_block.flags &= !NodeBlockFlags::FirstUnusedNode;
-                    let (address, _) = node_block
+                    let address = node_block
                         .write_to_immutable(
                             repository.clone(),
                             Context::default(),
@@ -796,7 +796,7 @@ impl State {
 
             // Write out the block address list
             let block_hash_bytes = block_hash_bytes.freeze();
-            let (list_address, _) = immutable::write(
+            let list_address = immutable::write(
                 repository.clone(),
                 Context::default(),
                 block_hash_bytes.clone(),
@@ -846,7 +846,7 @@ impl State {
                     // write makes the lock held of an await point
                     let mut node_block = { *block.read().node_block() };
                     node_block.flags &= !NodeBlockFlags::Dirty;
-                    let (address, _) = node_block
+                    let address = node_block
                         .write_to_immutable(
                             repository.clone(),
                             Context::default(),
@@ -891,7 +891,7 @@ impl State {
 
             // Write out the block address list
             let block_hash_bytes = block_hash_bytes.freeze();
-            let (list_address, _) = immutable::write(
+            let list_address = immutable::write(
                 repository.clone(),
                 Context::default(),
                 block_hash_bytes.clone(),
@@ -928,7 +928,7 @@ impl State {
                     Hash::default()
                 } else {
                     let bytes = Bytes::copy_from_slice(link_list.as_bytes());
-                    let (address, _fragment) = immutable::write(
+                    let address = immutable::write(
                         repository.clone(),
                         Context::default(),
                         bytes,
@@ -953,7 +953,7 @@ impl State {
         let tree = { self.runtime.read().tree.unwrap_or_default() };
         if tree.flags & TreeFlags::Dirty != 0 {
             lore_trace!("Serializing dirty tree");
-            let (address, _fragment) = tree
+            let address = tree
                 .write_to_immutable(
                     repository.clone(),
                     Context::default(),
@@ -974,7 +974,7 @@ impl State {
         }
 
         // Serialize the state
-        let (address, fragment) = {
+        let address = {
             let buffer = {
                 let mut data = self.data.write();
                 data.flags &= !StateFlags::Dirty;
@@ -1003,11 +1003,9 @@ impl State {
         }
 
         lore_trace!(
-            "Serialized state to {} in repository {}, {} -> {} bytes",
+            "Serialized state to {} in repository {}",
             address.hash,
-            repository.id,
-            fragment.size_content,
-            fragment.size_payload
+            repository.id
         );
 
         Ok(address.hash)
@@ -3025,7 +3023,7 @@ impl State {
             bytes.extend_from_slice(entry.as_bytes());
         }
 
-        let (address, _fragment) = immutable::write(
+        let address = immutable::write(
             repository.clone(),
             Context::default(),
             Bytes::from(bytes),

--- a/lore-revision/src/store/composite.rs
+++ b/lore-revision/src/store/composite.rs
@@ -1014,6 +1014,26 @@ impl ImmutableStore for CompositeStore {
         best_result.into_counted_result(&self.instruments.counter_query)
     }
 
+    /// Local first, then durable. Unlike `query` this does not fan out to read replicas: a
+    /// representation is the same wherever it is read from, so the first store that has it answers.
+    async fn get_metadata(
+        self: Arc<Self>,
+        repository: Partition,
+        address: Address,
+    ) -> Result<StoreQueryResult, StoreError> {
+        if let Ok(result) = self.local.store().get_metadata(repository, address).await
+            && result.match_made == StoreMatch::MatchFull
+        {
+            return Ok(result);
+        }
+
+        self.durable
+            .target
+            .clone()
+            .get_metadata(repository, address)
+            .await
+    }
+
     async fn get(
         self: Arc<Self>,
         repository: Partition,

--- a/lore-revision/src/store/remote.rs
+++ b/lore-revision/src/store/remote.rs
@@ -207,6 +207,32 @@ impl store::ImmutableStore for RemoteImmutableStore {
         }
     }
 
+    /// Answered by this store's own `query`, so it reports whether the payload is durable rather
+    /// than what representation is stored. Wiring the remote's metadata operation through is
+    /// outstanding.
+    /// Asks the remote for the fragment alone. Unlike [`RemoteImmutableStore::query`], which
+    /// obtains one by fetching the whole payload, this uses the wire operation that exists for it,
+    /// so the representation comes back without the bytes.
+    async fn get_metadata(
+        self: Arc<Self>,
+        repository: Partition,
+        address: Address,
+    ) -> Result<StoreQueryResult, StoreError> {
+        let session = self.session(repository).await?;
+
+        match session.get_metadata(&address).await {
+            Ok(fragment) => Ok(StoreQueryResult {
+                fragment,
+                match_made: StoreMatch::MatchFull,
+            }),
+            Err(ProtocolError::NotFound(_)) => Ok(StoreQueryResult {
+                fragment: Fragment::default(),
+                match_made: StoreMatch::MatchNone,
+            }),
+            Err(error) => Err(error).forward::<StoreError>("Remote store metadata query failed"),
+        }
+    }
+
     async fn get(
         self: Arc<Self>,
         repository: Partition,

--- a/lore-revision/src/store/remote.rs
+++ b/lore-revision/src/store/remote.rs
@@ -207,9 +207,6 @@ impl store::ImmutableStore for RemoteImmutableStore {
         }
     }
 
-    /// Answered by this store's own `query`, so it reports whether the payload is durable rather
-    /// than what representation is stored. Wiring the remote's metadata operation through is
-    /// outstanding.
     /// Asks the remote for the fragment alone. Unlike [`RemoteImmutableStore::query`], which
     /// obtains one by fetching the whole payload, this uses the wire operation that exists for it,
     /// so the representation comes back without the bytes.

--- a/lore-revision/tests/composite_store.rs
+++ b/lore-revision/tests/composite_store.rs
@@ -161,6 +161,14 @@ mod tests {
 
     #[async_trait]
     impl lore_storage::ImmutableStore for TestStore<'static> {
+        async fn get_metadata(
+            self: Arc<Self>,
+            partition: Partition,
+            address: Address,
+        ) -> Result<StoreQueryResult, StoreError> {
+            self.query(partition, address, StoreMatch::MatchFull).await
+        }
+
         async fn exist(
             self: Arc<Self>,
             _repository: Partition,
@@ -1037,6 +1045,14 @@ mod tests {
 
         #[async_trait]
         impl ImmutableStore for DelayStore {
+            async fn get_metadata(
+                self: Arc<Self>,
+                partition: Partition,
+                address: Address,
+            ) -> Result<StoreQueryResult, StoreError> {
+                self.query(partition, address, StoreMatch::MatchFull).await
+            }
+
             async fn is_available(self: Arc<Self>, _timeout: Duration) -> bool {
                 true
             }
@@ -1853,6 +1869,14 @@ mod tests {
 
         #[async_trait]
         impl ImmutableStore for CountingStore {
+            async fn get_metadata(
+                self: Arc<Self>,
+                partition: Partition,
+                address: Address,
+            ) -> Result<StoreQueryResult, StoreError> {
+                self.query(partition, address, StoreMatch::MatchFull).await
+            }
+
             async fn exist(
                 self: Arc<Self>,
                 partition: Partition,

--- a/lore-revision/tests/immutable.rs
+++ b/lore-revision/tests/immutable.rs
@@ -108,7 +108,7 @@ mod tests {
                     .collect();
                 let payload = Bytes::copy_from_slice(payload.as_slice());
 
-                let (address, _fragment) = immutable::write(
+                let address = immutable::write(
                     repository.clone(),
                     context,
                     payload.clone(),
@@ -1098,17 +1098,9 @@ mod tests {
                 let payload = Bytes::copy_from_slice(payload.as_slice());
 
                 let flags = WriteOptions::default().with_fixed_size_chunk(256);
-                let (address, fragment) =
-                    immutable::write(repository.clone(), context, payload.clone(), flags)
-                        .await
-                        .expect("Failed writing to store");
-
-                // Verify the data is fragmented
-                assert!(
-                    fragment.flags & lore_storage::FragmentFlags::PayloadFragmented
-                        == lore_storage::FragmentFlags::PayloadFragmented,
-                    "Expected PayloadFragmented flag"
-                );
+                let address = immutable::write(repository.clone(), context, payload.clone(), flags)
+                    .await
+                    .expect("Failed writing to store");
 
                 // Read into file using the pipeline
                 let output_path = dir.join("output_file");
@@ -1122,6 +1114,12 @@ mod tests {
                 .await
                 .expect("read_into_file failed");
 
+                // Verify the data was stored fragmented
+                assert!(
+                    read_fragment.flags & lore_storage::FragmentFlags::PayloadFragmented
+                        == lore_storage::FragmentFlags::PayloadFragmented,
+                    "Expected PayloadFragmented flag"
+                );
                 assert_eq!(read_fragment.size_content, payload_size as u64);
 
                 // Verify file content matches original payload
@@ -1168,10 +1166,9 @@ mod tests {
                 let payload = Bytes::copy_from_slice(payload.as_slice());
 
                 let flags = WriteOptions::default().with_fixed_size_chunk(256);
-                let (address, _fragment) =
-                    immutable::write(repository.clone(), context, payload.clone(), flags)
-                        .await
-                        .expect("Failed writing to store");
+                let address = immutable::write(repository.clone(), context, payload.clone(), flags)
+                    .await
+                    .expect("Failed writing to store");
 
                 // Read via stream and collect all buffers
                 let (tx, mut rx) = tokio::sync::mpsc::channel::<Bytes>(64);
@@ -1228,7 +1225,7 @@ mod tests {
                     .collect();
                 let payload = Bytes::copy_from_slice(payload.as_slice());
 
-                let (address, _fragment) = immutable::write(
+                let address = immutable::write(
                     repository.clone(),
                     context,
                     payload.clone(),

--- a/lore-revision/tests/node.rs
+++ b/lore-revision/tests/node.rs
@@ -337,7 +337,7 @@ mod tests {
                 v0_set_inline_name(&mut block_v0.node[3], "nested_file.rs");
 
                 // Serialize V0 block to the immutable store
-                let (address, _fragment) = block_v0
+                let address = block_v0
                     .write_to_immutable(
                         repository.clone(),
                         Context::default(),
@@ -593,7 +593,7 @@ mod tests {
                 block_v2.node[3].child = 0;
 
                 // Serialize V2 block to the immutable store
-                let (address, _fragment) = block_v2
+                let address = block_v2
                     .write_to_immutable(
                         repository.clone(),
                         Context::default(),

--- a/lore-server/config/dev-local.toml
+++ b/lore-server/config/dev-local.toml
@@ -63,7 +63,9 @@ s3_endpoint_url = "http://minio:9000"
 s3_region = "us-east-1"
 s3_force_path_style = true
 dynamodb_fragments_table = "lore-fragments-dev"
-dynamodb_metadata_table = "lore-fragment-metadata-dev"
+dynamodb_fragment_state_table = "lore-fragment-state-dev"
+# No objects predate the move of the fragment onto the S3 object here, so no fallback read.
+# dynamodb_fragment_metadata_table = "lore-fragment-metadata-dev"
 dynamodb_endpoint_url = "http://dynamodb:9090"
 dynamodb_region = "us-east-1"
 timeout_millis = 120000

--- a/lore-server/config/local.toml
+++ b/lore-server/config/local.toml
@@ -65,7 +65,9 @@ flush_delay_seconds = 10
 # immutable_store.s3_slow_operation_threshold_millis = 2000
 # immutable_store.dynamodb_endpoint_url = "http://127.0.0.1:9090"
 # immutable_store.dynamodb_fragments_table = "lore-fragments-local"
-# immutable_store.dynamodb_metadata_table = "lore-fragment-metadata-local"
+# immutable_store.dynamodb_fragment_state_table = "lore-fragment-state-local"
+# # Only where objects predating the move of the fragment onto the S3 object may exist:
+# immutable_store.dynamodb_fragment_metadata_table = "lore-fragment-metadata-local"
 # immutable_store.dynamodb_slow_operation_threshold_millis = 500
 #
 # # Mutable store (DynamoDB)

--- a/lore-server/examples/config-aws.toml
+++ b/lore-server/examples/config-aws.toml
@@ -32,14 +32,20 @@ mode = "aws"
 
 # Immutable store settings (S3 + DynamoDB)
 [plugins.aws.immutable_store]
-s3_bucket = "urc-fragments"
+s3_bucket = "lore-fragments"
 # s3_endpoint_url = "http://localhost:4566"
 # s3_region = "us-east-1"
 s3_slow_operation_threshold_millis = 5000
 s3_timeout_millis = 30000
 
-dynamodb_fragments_table = "urc-fragments"
-dynamodb_metadata_table = "urc-metadata"
+dynamodb_fragments_table = "lore-fragments"
+# Holds fragment state; a row's presence means the hash exists. Its own table, distinct from the
+# one that held fragment metadata. Required, with no alias.
+dynamodb_fragment_state_table = "lore-fragment-state"
+# Read only where objects stored before the fragment moved onto the S3 object may still exist.
+# Accepts the older dynamodb_metadata_table spelling. Leave unset on a deployment created after
+# that change, as here.
+# dynamodb_fragment_metadata_table = "lore-fragment-metadata"
 # dynamodb_endpoint_url = "http://localhost:4566"
 # dynamodb_region = "us-east-1"
 dynamodb_slow_operation_threshold_millis = 2000
@@ -50,7 +56,7 @@ dynamodb_timeout_millis = 15000
 
 # Mutable store settings (DynamoDB)
 [plugins.aws.mutable_store]
-dynamodb_table = "urc-mutable"
+dynamodb_table = "lore-mutable"
 # dynamodb_endpoint_url = "http://localhost:4566"
 # dynamodb_region = "us-east-1"
 slow_operation_threshold_millis = 2000
@@ -58,7 +64,7 @@ timeout_millis = 15000
 
 # Lock store settings (DynamoDB)
 [plugins.aws.lock_store]
-dynamodb_table = "urc-locks"
+dynamodb_table = "lore-locks"
 # dynamodb_endpoint_url = "http://localhost:4566"
 # dynamodb_region = "us-east-1"
 dynamodb_slow_operation_threshold_millis = 1000

--- a/lore-server/src/cache/revision.rs
+++ b/lore-server/src/cache/revision.rs
@@ -211,7 +211,7 @@ pub(crate) async fn store_cached_list(
     buffer.extend_from_slice(items_bytes);
     let buffer = buffer.freeze();
 
-    let Ok((address, _fragment)) = immutable::write(
+    let Ok(address) = immutable::write(
         repository.clone(),
         Context::default(),
         buffer,

--- a/lore-server/src/grpc/revision/v1/revision_list.rs
+++ b/lore-server/src/grpc/revision/v1/revision_list.rs
@@ -1494,7 +1494,7 @@ mod test {
             let mut buffer = bytes::BytesMut::new();
             buffer.extend_from_slice(bogus_header.as_bytes());
             buffer.extend_from_slice([bogus_item].as_bytes());
-            let (address, _) = lore_revision::immutable::write(
+            let address = lore_revision::immutable::write(
                 repository_context.clone(),
                 lore_storage::Context::default(),
                 buffer.freeze(),

--- a/lore-server/src/grpc/thinclient/v1/revision_diff.rs
+++ b/lore-server/src/grpc/thinclient/v1/revision_diff.rs
@@ -777,7 +777,7 @@ mod test {
         state.set_metadata_hash(metadata_hash);
         for (name, bytes) in files {
             let buffer = bytes::Bytes::copy_from_slice(bytes);
-            let (address, _) = lore_revision::immutable::write(
+            let address = lore_revision::immutable::write(
                 repository.clone(),
                 lore_storage::Context::default(),
                 buffer,

--- a/lore-server/src/http/repositories/repository/contents/put_repository_content.rs
+++ b/lore-server/src/http/repositories/repository/contents/put_repository_content.rs
@@ -78,7 +78,7 @@ pub async fn handler(
             };
 
             let context = uuid::Uuid::now_v7().into();
-            let (address, _fragment) = match immutable::write(
+            let address = match immutable::write(
                 repository.clone(),
                 context,
                 data,

--- a/lore-server/src/lib.rs
+++ b/lore-server/src/lib.rs
@@ -55,6 +55,14 @@ mod tests {
 
     #[async_trait]
     impl ImmutableStore for SlowDownImmutableStore {
+        async fn get_metadata(
+            self: Arc<Self>,
+            partition: Partition,
+            address: Address,
+        ) -> Result<StoreQueryResult, StoreError> {
+            self.query(partition, address, StoreMatch::MatchFull).await
+        }
+
         async fn exist(
             self: Arc<Self>,
             _partition: Partition,

--- a/lore-server/src/plugins/aws.rs
+++ b/lore-server/src/plugins/aws.rs
@@ -69,8 +69,27 @@ pub struct AwsImmutableStorePluginConfig {
     /// `DynamoDB` table name for storing fragment associations.
     pub dynamodb_fragments_table: String,
 
-    /// `DynamoDB` table name for storing fragment metadata.
-    pub dynamodb_metadata_table: String,
+    /// `DynamoDB` table name for storing fragment state, where a row's presence means the hash
+    /// exists.
+    ///
+    /// Required, and deliberately without an alias: this table is its own, distinct from the one
+    /// that held fragment metadata, and which table serves it is a decision rather than something
+    /// to inherit.
+    pub dynamodb_fragment_state_table: String,
+
+    /// Optional `DynamoDB` table to read fragments from for objects written before they moved onto
+    /// the S3 object.
+    ///
+    /// Accepts the older `dynamodb_metadata_table` spelling, which is what a configuration written
+    /// before that change already points at — that table holds fragment metadata, and reading it is
+    /// exactly what it is still needed for.
+    ///
+    /// Leaving it unset declares that no object predating the change exists, so an object carrying
+    /// no metadata of its own is reported as damaged rather than described from a row that cannot
+    /// be about it. Set it only where such objects may still exist; once a backfill has given them
+    /// all their own metadata, removing it retires the fallback read.
+    #[serde(default, alias = "dynamodb_metadata_table")]
+    pub dynamodb_fragment_metadata_table: Option<String>,
 
     /// Optional `DynamoDB` endpoint URL (for `LocalStack` or other `DynamoDB`-compatible services).
     #[serde(default)]
@@ -222,7 +241,7 @@ impl ImmutableStorePluginFactory for AwsImmutableStorePluginFactory {
             plugin_name = plugin_name,
             s3_bucket = %plugin_config.s3_bucket,
             fragments_table = %plugin_config.dynamodb_fragments_table,
-            metadata_table = %plugin_config.dynamodb_metadata_table,
+            fragment_state_table = %plugin_config.dynamodb_fragment_state_table,
             "Creating AWS immutable store: {plugin_config:?}"
         );
 
@@ -277,7 +296,7 @@ impl ImmutableStorePluginFactory for AwsImmutableStorePluginFactory {
                 )
                 .dynamodb()
                 .ensure_table(&plugin_config.dynamodb_fragments_table)
-                .ensure_table(&plugin_config.dynamodb_metadata_table);
+                .ensure_table(&plugin_config.dynamodb_fragment_state_table);
 
                 let dynamodb_client =
                     Box::pin(dynamodb_client_builder.build())
@@ -304,7 +323,8 @@ impl ImmutableStorePluginFactory for AwsImmutableStorePluginFactory {
 
         let dynamodb_settings = DynamoDbImmutableStoreSettings {
             fragments_table_name: plugin_config.dynamodb_fragments_table,
-            metadata_table_name: plugin_config.dynamodb_metadata_table,
+            fragment_state_table_name: plugin_config.dynamodb_fragment_state_table,
+            fragment_metadata_table_name: plugin_config.dynamodb_fragment_metadata_table,
             endpoint_url: plugin_config.dynamodb_endpoint_url,
             region: plugin_config.dynamodb_region,
             slow_operation_threshold_millis: plugin_config.dynamodb_slow_operation_threshold_millis,
@@ -635,7 +655,7 @@ mod tests {
             s3_endpoint_url = "http://localhost:4566"
             s3_region = "us-east-1"
             dynamodb_fragments_table = "fragments"
-            dynamodb_metadata_table = "metadata"
+            dynamodb_fragment_state_table = "fragment-state"
             dynamodb_endpoint_url = "http://localhost:4566"
             dynamodb_region = "us-east-1"
             s3_slow_operation_threshold_millis = 1000
@@ -654,7 +674,10 @@ mod tests {
         );
         assert_eq!(plugin_config.s3_region, Some("us-east-1".to_string()));
         assert_eq!(plugin_config.dynamodb_fragments_table, "fragments");
-        assert_eq!(plugin_config.dynamodb_metadata_table, "metadata");
+        assert_eq!(
+            plugin_config.dynamodb_fragment_state_table,
+            "fragment-state"
+        );
         assert_eq!(
             plugin_config.dynamodb_endpoint_url,
             Some("http://localhost:4566".to_string())
@@ -666,12 +689,50 @@ mod tests {
         assert!(plugin_config.force_write);
     }
 
+    /// A configuration written before this change points at the table holding fragment metadata,
+    /// which is what that table is still read for. It carries over under its new name.
+    #[tokio::test]
+    async fn test_config_reads_the_former_metadata_table_key_as_the_fragment_metadata_table() {
+        let config_str = r#"
+            s3_bucket = "test-bucket"
+            dynamodb_fragments_table = "fragments"
+            dynamodb_fragment_state_table = "state"
+            dynamodb_metadata_table = "metadata"
+        "#;
+
+        let config: toml::Value = toml::from_str(config_str).unwrap();
+        let plugin_config: AwsImmutableStorePluginConfig = config.try_into().unwrap();
+
+        assert_eq!(plugin_config.dynamodb_fragment_state_table, "state");
+        assert_eq!(
+            plugin_config.dynamodb_fragment_metadata_table,
+            Some("metadata".to_string())
+        );
+    }
+
+    /// The state table has no alias on purpose. A configuration that never named one must fail
+    /// rather than silently reuse whichever table used to hold fragment metadata.
+    #[tokio::test]
+    async fn test_config_requires_the_fragment_state_table() {
+        let config_str = r#"
+            s3_bucket = "test-bucket"
+            dynamodb_fragments_table = "fragments"
+            dynamodb_metadata_table = "metadata"
+        "#;
+
+        let config: toml::Value = toml::from_str(config_str).unwrap();
+
+        config
+            .try_into::<AwsImmutableStorePluginConfig>()
+            .expect_err("the fragment state table must be configured explicitly");
+    }
+
     #[tokio::test]
     async fn test_config_deserialization_with_defaults() {
         let config_str = r#"
             s3_bucket = "test-bucket"
             dynamodb_fragments_table = "fragments"
-            dynamodb_metadata_table = "metadata"
+            dynamodb_fragment_state_table = "fragment-state"
         "#;
 
         let config: toml::Value = toml::from_str(config_str).unwrap();
@@ -681,7 +742,10 @@ mod tests {
         assert!(plugin_config.s3_endpoint_url.is_none());
         assert!(plugin_config.s3_region.is_none());
         assert_eq!(plugin_config.dynamodb_fragments_table, "fragments");
-        assert_eq!(plugin_config.dynamodb_metadata_table, "metadata");
+        assert_eq!(
+            plugin_config.dynamodb_fragment_state_table,
+            "fragment-state"
+        );
         assert!(plugin_config.dynamodb_endpoint_url.is_none());
         assert!(plugin_config.dynamodb_region.is_none());
         assert_eq!(plugin_config.s3_slow_operation_threshold_millis, u64::MAX);

--- a/lore-server/src/plugins/registry.rs
+++ b/lore-server/src/plugins/registry.rs
@@ -754,6 +754,14 @@ mod tests {
 
     #[async_trait]
     impl ImmutableStore for MockImmutableStore {
+        async fn get_metadata(
+            self: Arc<Self>,
+            partition: Partition,
+            address: Address,
+        ) -> Result<StoreQueryResult, StoreError> {
+            self.query(partition, address, StoreMatch::MatchFull).await
+        }
+
         async fn exist(
             self: Arc<Self>,
             _partition: Partition,

--- a/lore-server/src/protocol/storage/copy.rs
+++ b/lore-server/src/protocol/storage/copy.rs
@@ -197,6 +197,14 @@ mod tests {
 
     #[async_trait]
     impl ImmutableStore for MockCopyFailStore {
+        async fn get_metadata(
+            self: Arc<Self>,
+            partition: Partition,
+            address: Address,
+        ) -> Result<StoreQueryResult, StoreError> {
+            self.query(partition, address, StoreMatch::MatchFull).await
+        }
+
         async fn exist(
             self: Arc<Self>,
             _partition: Partition,
@@ -311,6 +319,14 @@ mod tests {
 
     #[async_trait]
     impl ImmutableStore for MockCopySuccessStore {
+        async fn get_metadata(
+            self: Arc<Self>,
+            partition: Partition,
+            address: Address,
+        ) -> Result<StoreQueryResult, StoreError> {
+            self.query(partition, address, StoreMatch::MatchFull).await
+        }
+
         async fn exist(
             self: Arc<Self>,
             _partition: Partition,

--- a/lore-server/src/protocol/storage/get.rs
+++ b/lore-server/src/protocol/storage/get.rs
@@ -122,7 +122,7 @@ pub async fn handle_get_metadata(
     LORE_CONTEXT
         .scope(execution, async move {
             match immutable_store
-                .query(repository, address, StoreMatch::MatchFull)
+                .get_metadata(repository, address)
                 .await
             {
                 Ok(StoreQueryResult {

--- a/lore-server/src/store/grpc_replica.rs
+++ b/lore-server/src/store/grpc_replica.rs
@@ -556,6 +556,14 @@ impl ImmutableStore for GrpcReplica {
         Err(StoreError::internal("Store does not support operation"))
     }
 
+    async fn get_metadata(
+        self: Arc<Self>,
+        _repository: Partition,
+        _address: Address,
+    ) -> Result<StoreQueryResult, StoreError> {
+        Err(StoreError::internal("Store does not support operation"))
+    }
+
     async fn get(
         self: Arc<Self>,
         _repository: Partition,

--- a/lore-server/src/store/replica.rs
+++ b/lore-server/src/store/replica.rs
@@ -323,6 +323,17 @@ where
         })
     }
 
+    /// Answered by this store's own `query`, so it reports whether the payload is durable rather
+    /// than what representation is stored. Wiring the remote's metadata operation through is
+    /// outstanding; until then a caller wanting a representation must ask the store holding it.
+    async fn get_metadata(
+        self: Arc<Self>,
+        repository: Partition,
+        address: Address,
+    ) -> Result<StoreQueryResult, StoreError> {
+        self.query(repository, address, StoreMatch::MatchFull).await
+    }
+
     #[lore_macro::lore_instrument]
     #[instrument(name = "QuicReplica::Get", skip_all)]
     async fn get(

--- a/lore-server/src/store/replicated_store.rs
+++ b/lore-server/src/store/replicated_store.rs
@@ -358,6 +358,17 @@ where
         })
     }
 
+    /// Answered by this store's own `query`, so it reports whether the payload is durable rather
+    /// than what representation is stored. Wiring the remote's metadata operation through is
+    /// outstanding; until then a caller wanting a representation must ask the store holding it.
+    async fn get_metadata(
+        self: Arc<Self>,
+        partition: Partition,
+        address: Address,
+    ) -> Result<StoreQueryResult, StoreError> {
+        self.query(partition, address, StoreMatch::MatchFull).await
+    }
+
     #[lore_macro::lore_instrument]
     #[instrument(name = "ReplicatedStore::Get", skip_all)]
     async fn get(

--- a/lore-storage/src/fragment_engine.rs
+++ b/lore-storage/src/fragment_engine.rs
@@ -59,7 +59,7 @@ fn chunk_boundaries(
 /// Uses `FastCDC` (content-defined chunking) when `flags.fixed_size_chunk` is 0,
 /// or fixed-size chunking when it is >0. Each chunk is hashed, stored as a
 /// content-addressed fragment in the immutable `store`, and assembled into a
-/// fragment list (Merklized). Returns the root address and fragment.
+/// fragment list. Returns the root address.
 ///
 /// When the entire buffer fits in a single chunk, the single-fragment fast path
 /// is used and no fragment list is created. In `hash_only` mode, fragments are
@@ -75,7 +75,7 @@ pub async fn write_fragmented(
     remote_session: Option<Arc<StorageSession>>,
     tracker: Option<Arc<crate::write_tracker::WriteTracker>>,
     permit: Option<tokio::sync::OwnedSemaphorePermit>,
-) -> Result<(Address, Fragment), StorageError> {
+) -> Result<Address, StorageError> {
     let size = buffer.len();
     let mut read_permit = permit;
     let mut tasks = JoinSet::<Result<StoredChunk, StorageError>>::new();
@@ -120,7 +120,7 @@ pub async fn write_fragmented(
                 chunk_permit,
             )
             .await?;
-            return Ok((result.address, result.fragment));
+            return Ok(result.address);
         }
 
         let store = store.clone();
@@ -206,7 +206,7 @@ pub async fn write_fragmented_from_file(
     hash_only: bool,
     remote_session: Option<Arc<StorageSession>>,
     tracker: Option<Arc<crate::write_tracker::WriteTracker>>,
-) -> Result<(Address, Fragment), StorageError> {
+) -> Result<Address, StorageError> {
     let mut tasks = JoinSet::<Result<StoredChunk, StorageError>>::new();
 
     lore_base::lore_trace!(
@@ -354,7 +354,7 @@ async fn write_chunk_list(
     hash_only: bool,
     remote_session: Option<Arc<StorageSession>>,
     tracker: Option<Arc<crate::write_tracker::WriteTracker>>,
-) -> Result<(Address, Fragment), StorageError> {
+) -> Result<Address, StorageError> {
     results.drain(&mut tasks).await;
 
     if let Some(err) = results.failure {
@@ -419,7 +419,7 @@ async fn write_fragmentlist_impl(
     remote_session: Option<Arc<StorageSession>>,
     tracker: Option<Arc<crate::write_tracker::WriteTracker>>,
     permit: Option<tokio::sync::OwnedSemaphorePermit>,
-) -> Result<(Address, Fragment), StorageError> {
+) -> Result<Address, StorageError> {
     let size = buffer.len();
 
     if size <= FRAGMENT_SIZE_THRESHOLD {
@@ -430,7 +430,7 @@ async fn write_fragmentlist_impl(
             size_content: content_size as u64,
         };
         if hash_only {
-            Ok((Address { context, hash }, fragment))
+            Ok(Address { context, hash })
         } else {
             let permit = match permit {
                 Some(permit) => Some(permit),
@@ -448,7 +448,7 @@ async fn write_fragmentlist_impl(
                 permit,
             )
             .await?;
-            Ok((result.address, result.fragment))
+            Ok(result.address)
         }
     } else {
         // Fixed size chunking for fragment list
@@ -595,9 +595,7 @@ pub fn write_fragmentlist(
     remote_session: Option<Arc<StorageSession>>,
     tracker: Option<Arc<crate::write_tracker::WriteTracker>>,
     permit: Option<tokio::sync::OwnedSemaphorePermit>,
-) -> std::pin::Pin<
-    Box<dyn std::future::Future<Output = Result<(Address, Fragment), StorageError>> + Send>,
-> {
+) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Address, StorageError>> + Send>> {
     Box::pin(write_fragmentlist_impl(
         store,
         partition,

--- a/lore-storage/src/immutable_store.rs
+++ b/lore-storage/src/immutable_store.rs
@@ -319,6 +319,25 @@ pub trait ImmutableStore: Any + Send + Sync {
         match_requested: StoreMatch,
     ) -> Result<StoreQueryResult, StoreError>;
 
+    /// Query the fragment describing the payload stored for the given address.
+    ///
+    /// Where [`ImmutableStore::query`] answers whether a payload exists and where it is stored,
+    /// this answers *what it is* — its compression and its sizes. The two are separate because a
+    /// store that keeps the fragment beside the payload rather than in an index has to go and read
+    /// it, which costs a round trip that `query` deliberately avoids: `query` sits on the ingress
+    /// write path and runs once per fragment stored.
+    ///
+    /// Required rather than defaulted. A default delegating to `query` is right for a store whose
+    /// `query` already reports the representation, and silently wrong for a wrapper that forwards
+    /// `query` alone — the wrapper's own `query` would answer, the inner store's override would
+    /// never run, and the caller would get a well-formed fragment with no sizes and no error. Every
+    /// implementor decides instead.
+    async fn get_metadata(
+        self: Arc<Self>,
+        partition: Partition,
+        address: Address,
+    ) -> Result<StoreQueryResult, StoreError>;
+
     /// Get the immutable data for the given address within the partition.
     /// Match requirement controls cross-partition and cross-context load behavior.
     /// Returns `StoreError::AddressNotFound` if no match is made.

--- a/lore-storage/src/local/immutable_store.rs
+++ b/lore-storage/src/local/immutable_store.rs
@@ -3171,6 +3171,16 @@ impl crate::immutable_store::ImmutableStore for LocalImmutableStore {
         })
     }
 
+    /// This store's `query` reads the fragment it stored, so it already reports the representation
+    /// and there is nothing further to fetch.
+    async fn get_metadata(
+        self: Arc<Self>,
+        partition: Partition,
+        address: Address,
+    ) -> Result<StoreQueryResult, StoreError> {
+        self.query(partition, address, StoreMatch::MatchFull).await
+    }
+
     async fn get(
         self: Arc<Self>,
         partition: Partition,
@@ -4573,7 +4583,7 @@ mod tests {
             .await
             .unwrap();
 
-            let (address, _) = write_content(
+            let address = write_content(
                 store.clone(),
                 partition,
                 context,
@@ -4638,7 +4648,7 @@ mod tests {
             "originally stored content must be reported missing after recovery"
         );
 
-        let (new_address, _) = write_content(
+        let new_address = write_content(
             store.clone(),
             partition,
             context,
@@ -4821,7 +4831,7 @@ mod tests {
         // Prime target (uncompressed).
         let prev_mode =
             COMPRESSION_MODE.swap(CompressionMode::NoCompression as u32, Ordering::AcqRel);
-        let (target_address, _target_fragment) = write_content(
+        let target_address = write_content(
             store.clone(),
             target_partition,
             context,
@@ -4836,7 +4846,7 @@ mod tests {
 
         // Prime source (compressed).
         COMPRESSION_MODE.store(CompressionMode::Zstd as u32, Ordering::Release);
-        let (source_address, _source_fragment) = write_content(
+        let source_address = write_content(
             store.clone(),
             source_partition,
             context,
@@ -4911,7 +4921,7 @@ mod tests {
         let payload: Vec<u8> = b"in-partition new-context dedup payload".to_vec();
 
         // Seed the source tuple `(partition, hash, source_context)`.
-        let (source_address, _) = write_content(
+        let source_address = write_content(
             store.clone(),
             partition,
             source_context,

--- a/lore-storage/src/write.rs
+++ b/lore-storage/src/write.rs
@@ -169,9 +169,24 @@ pub async fn wait_if_in_flight(partition: Partition, address: Address) {
 }
 
 /// Result of a [`store_fragment`] operation.
+///
+/// The stored representation is deliberately not reported. A dispatched write returns before its
+/// leader has compressed anything, so the only representation available at that point is the one
+/// the caller passed in, and handing that back says nothing the caller did not already know. What
+/// the caller cannot know is where the payload ended up, which is what this carries instead.
+///
+/// The two storage flags describe the state as of this call returning, so a dispatched write
+/// reports both as `false`: its leader has not run yet.
 pub struct StoreResult {
     pub address: Address,
-    pub fragment: Fragment,
+    /// Size of the uncompressed and reassembled content the address stands for. Invariant across
+    /// compression, chunking and deduplication, so it is the one size worth reporting.
+    pub size_content: u64,
+    /// Whether the local store holds the payload.
+    pub stored_local: bool,
+    /// Whether the payload reached durable storage.
+    pub stored_durable: bool,
+    /// Whether the content was already stored, so no upload was needed.
     pub deduplicated: bool,
 }
 
@@ -286,9 +301,26 @@ pub async fn store_fragment(
     };
 
     if let (Some(tracker), Ok(result)) = (observer, &result) {
-        tracker.notify_fragment(&result.fragment, result.deduplicated);
+        tracker.notify_fragment(&observed_fragment(fragment, result), result.deduplicated);
     }
     result
+}
+
+/// The fragment to hand a write observer: the caller's representation, marked with where the
+/// payload ended up.
+///
+/// The representation has to come from the caller. An observer is only installed on a tracker, a
+/// tracker always dispatches, and a dispatched write reports before its leader compresses, so
+/// there is no stored representation to report yet.
+fn observed_fragment(fragment: Fragment, result: &StoreResult) -> Fragment {
+    let mut flags = fragment.flags;
+    if result.stored_local {
+        flags |= FragmentFlags::PayloadStoredLocal;
+    }
+    if result.stored_durable {
+        flags |= FragmentFlags::PayloadStoredDurable;
+    }
+    Fragment { flags, ..fragment }
 }
 
 /// Backward-compatible synchronous fragment store. Acquires the in-flight
@@ -324,7 +356,9 @@ async fn store_fragment_inline(
     ) {
         return Ok(StoreResult {
             address,
-            fragment: query.fragment,
+            size_content: fragment.size_content,
+            stored_local,
+            stored_durable,
             deduplicated: true,
         });
     }
@@ -332,7 +366,7 @@ async fn store_fragment_inline(
     // Local-only fast path: skip STORE_IN_FLIGHT entirely. No follower notification needed,
     // no leader-token rendezvous — just compress+write inline.
     if remote_session.is_none() {
-        let (_, final_fragment) = leader_body(
+        let (stored_local, stored_durable) = leader_body(
             store,
             partition,
             address,
@@ -347,7 +381,9 @@ async fn store_fragment_inline(
         .await?;
         return Ok(StoreResult {
             address,
-            fragment: final_fragment,
+            size_content: fragment.size_content,
+            stored_local,
+            stored_durable,
             deduplicated,
         });
     }
@@ -362,16 +398,14 @@ async fn store_fragment_inline(
         drop(permit);
         return Ok(StoreResult {
             address,
-            fragment: if query.match_made == StoreMatch::MatchFull {
-                query.fragment
-            } else {
-                fragment
-            },
+            size_content: fragment.size_content,
+            stored_local,
+            stored_durable,
             deduplicated: true,
         });
     };
 
-    let (_, final_fragment) = leader_body(
+    let (stored_local, stored_durable) = leader_body(
         store,
         partition,
         address,
@@ -386,7 +420,9 @@ async fn store_fragment_inline(
     .await?;
     Ok(StoreResult {
         address,
-        fragment: final_fragment,
+        size_content: fragment.size_content,
+        stored_local,
+        stored_durable,
         deduplicated,
     })
 }
@@ -414,7 +450,9 @@ async fn store_fragment_dispatched(
             tracker.register_follower(follower_future(store.clone(), partition, address, token));
             return Ok(StoreResult {
                 address,
-                fragment,
+                size_content: fragment.size_content,
+                stored_local: false,
+                stored_durable: false,
                 deduplicated: true,
             });
         }
@@ -435,7 +473,9 @@ async fn store_fragment_dispatched(
         drop(permit);
         return Ok(StoreResult {
             address,
-            fragment: query.fragment,
+            size_content: fragment.size_content,
+            stored_local,
+            stored_durable,
             deduplicated: true,
         });
     }
@@ -456,10 +496,13 @@ async fn store_fragment_dispatched(
             permit,
         )
         .await
+        .map(|_stored| ())
     });
     Ok(StoreResult {
         address,
-        fragment,
+        size_content: fragment.size_content,
+        stored_local: false,
+        stored_durable: false,
         deduplicated,
     })
 }
@@ -502,11 +545,13 @@ fn is_fully_satisfied(
 /// The "work" portion of [`store_fragment`]: optionally load existing local
 /// payload, compress, attempt remote upload, and write the terminal entry.
 ///
+/// Returns where the payload ended up, as `(stored_local, stored_durable)`.
+///
 /// `guard` is the in-flight token the caller acquired before invoking this function. When
 /// `None`, no in-flight machinery is in play (the local-only fast path that bypasses the
 /// dedup token entirely — see [`store_fragment_inline`]). When `Some`, dropping the guard at
 /// the end cancels the token and wakes any followers subscribed to this write.
-#[allow(clippy::too_many_arguments, unused_assignments)]
+#[allow(clippy::too_many_arguments)]
 async fn leader_body(
     store: Arc<dyn ImmutableStore>,
     partition: Partition,
@@ -518,7 +563,7 @@ async fn leader_body(
     query: StoreQueryResult,
     guard: Option<StoreInFlightGuard>,
     permit: Option<OwnedSemaphorePermit>,
-) -> Result<(Address, Fragment), StorageError> {
+) -> Result<(bool, bool), StorageError> {
     let (mut stored_local, mut stored_durable) = stored_flags(&query);
 
     // For a partial match try loading the payload from local store instead of recompressing
@@ -589,12 +634,13 @@ async fn leader_body(
         drop(permit);
         (None, None)
     };
+    stored_local |= payload.is_some();
 
     write_raw(store, partition, address, fragment, payload).await?;
 
     drop(permit);
     drop(guard);
-    Ok((address, fragment))
+    Ok((stored_local, stored_durable))
 }
 
 /// Store a raw fragment locally (no remote, no event emission).
@@ -606,7 +652,7 @@ pub async fn store_raw_local(
     fragment: Fragment,
     buffer: Bytes,
     cache_local: bool,
-) -> Result<(Address, Fragment), StorageError> {
+) -> Result<Address, StorageError> {
     let result = store_fragment(
         store,
         partition,
@@ -619,7 +665,7 @@ pub async fn store_raw_local(
         None,
     )
     .await?;
-    Ok((result.address, result.fragment))
+    Ok(result.address)
 }
 
 /// Content writes running now, and the most that have run at once since the peak was reset.
@@ -677,7 +723,7 @@ pub async fn write_content(
     remote_session: Option<Arc<StorageSession>>,
     tracker: Option<Arc<WriteTracker>>,
     permit: Option<OwnedSemaphorePermit>,
-) -> Result<(Address, Fragment), StorageError> {
+) -> Result<Address, StorageError> {
     let _in_flight = ContentWriteGuard::new();
     // Check if data should be a single fragment
     if buffer.len() <= crate::compress::FRAGMENT_SIZE_THRESHOLD {
@@ -707,7 +753,7 @@ pub async fn write_content(
             permit,
         )
         .await?;
-        Ok((result.address, result.fragment))
+        Ok(result.address)
     } else {
         write_fragmented(
             store,
@@ -727,6 +773,11 @@ pub async fn write_content(
 /// Write content from a file.
 ///
 /// Takes a store, partition, and optional remote session directly.
+///
+/// Returns the address and the size of the content behind it. The size is reported because a
+/// caller that hands over a path has no other way to learn what was actually written: stating the
+/// file again afterwards answers for the file as it is then, not for the bytes this address
+/// stands for.
 #[allow(clippy::too_many_arguments)]
 pub async fn write_from_file(
     store: Arc<dyn ImmutableStore>,
@@ -736,7 +787,7 @@ pub async fn write_from_file(
     flags: WriteOptions,
     remote_session: Option<Arc<StorageSession>>,
     tracker: Option<Arc<WriteTracker>>,
-) -> Result<(Address, Fragment), StorageError> {
+) -> Result<(Address, u64), StorageError> {
     let _in_flight = ContentWriteGuard::new();
     let _count_permit = file_count_limit_acquire()
         .await
@@ -767,7 +818,7 @@ pub async fn write_from_file(
                 context,
                 hash: Hash::new_zeroed(),
             },
-            Fragment::new_zeroed(),
+            0,
         ));
     }
 
@@ -780,7 +831,7 @@ pub async fn write_from_file(
             .map_err(|e| {
                 StorageError::internal_with_context(e, &format!("read file: {}", path.display()))
             })?;
-        return write_content(
+        let address = write_content(
             store,
             partition,
             context,
@@ -790,10 +841,11 @@ pub async fn write_from_file(
             tracker,
             read_permit,
         )
-        .await;
+        .await?;
+        return Ok((address, size as u64));
     }
 
-    crate::fragment_engine::write_fragmented_from_file(
+    let address = crate::fragment_engine::write_fragmented_from_file(
         store,
         partition,
         context,
@@ -804,7 +856,8 @@ pub async fn write_from_file(
         remote_session,
         tracker,
     )
-    .await
+    .await?;
+    Ok((address, size as u64))
 }
 
 /// Hash a file's content, using previous fragmentation hints when available.
@@ -917,7 +970,7 @@ pub async fn hash_file(
         }
     }
 
-    let (address, _) = crate::fragment_engine::write_fragmented_from_file(
+    let address = crate::fragment_engine::write_fragmented_from_file(
         store,
         partition,
         previous.context,
@@ -1178,7 +1231,7 @@ async fn previous_chunks_still_match(
 /// Follower future: waits for the leader token to fire, then observes the
 /// terminal store state for `address`.
 ///
-/// Returns `Ok((address, fragment))` if the store now holds a full-match entry
+/// Returns `Ok(())` if the store now holds a full-match entry
 /// with either [`PayloadStoredDurable`](FragmentFlags::PayloadStoredDurable) or
 /// [`PayloadStoredLocal`](FragmentFlags::PayloadStoredLocal) set. Returns an
 /// internal error if no terminal entry exists — that means the leader errored
@@ -1191,7 +1244,7 @@ pub async fn follower_future(
     partition: Partition,
     address: Address,
     token: CancellationToken,
-) -> Result<(Address, Fragment), StorageError> {
+) -> Result<(), StorageError> {
     token.cancelled().await;
     match store.query(partition, address, StoreMatch::MatchFull).await {
         Ok(result)
@@ -1201,7 +1254,7 @@ pub async fn follower_future(
                         | FragmentFlags::PayloadStoredLocal.bits()))
                     != 0 =>
         {
-            Ok((address, result.fragment))
+            Ok(())
         }
         _ => Err(StorageError::internal(format!(
             "leader upload failed for {address}"
@@ -1280,14 +1333,9 @@ mod tests {
 
         let token = CancellationToken::new();
         token.cancel();
-        let result = follower_future(store, partition, address, token).await;
-        let (addr, frag) = result.expect("follower should observe terminal entry");
-        assert_eq!(addr, address);
-        assert_ne!(
-            frag.flags & FragmentFlags::PayloadStoredLocal.bits(),
-            0,
-            "expected PayloadStoredLocal flag"
-        );
+        follower_future(store, partition, address, token)
+            .await
+            .expect("follower should observe terminal entry stored locally");
     }
 
     #[tokio::test]
@@ -1340,16 +1388,10 @@ mod tests {
             .expect("put terminal entry");
         token.cancel();
 
-        let (addr, frag) = follower
+        follower
             .await
             .expect("join follower")
-            .expect("follower observed terminal entry");
-        assert_eq!(addr, address);
-        assert_ne!(
-            frag.flags & FragmentFlags::PayloadStoredDurable.bits(),
-            0,
-            "expected PayloadStoredDurable flag"
-        );
+            .expect("follower observed terminal entry stored durably");
     }
 
     fn make_input(seed: u8) -> (Partition, Address, Fragment, Bytes) {
@@ -1436,10 +1478,9 @@ mod tests {
         .expect("store_fragment against already-durable entry");
 
         assert!(result.deduplicated, "should dedup on already-durable");
-        assert_ne!(
-            result.fragment.flags & FragmentFlags::PayloadStoredDurable.bits(),
-            0,
-            "returned fragment should carry PayloadStoredDurable"
+        assert!(
+            result.stored_durable,
+            "result should report the entry as durable"
         );
         // Tracker should have no outstanding work.
         assert!(tracker.await_all().await.is_ok());
@@ -1530,6 +1571,14 @@ mod tests {
 
     #[async_trait::async_trait]
     impl ImmutableStore for FailingPutStore {
+        async fn get_metadata(
+            self: Arc<Self>,
+            partition: Partition,
+            address: Address,
+        ) -> Result<StoreQueryResult, StoreError> {
+            self.query(partition, address, StoreMatch::MatchFull).await
+        }
+
         fn is_local(&self) -> bool {
             self.inner.clone().is_local()
         }
@@ -1824,6 +1873,14 @@ mod tests {
 
     #[async_trait::async_trait]
     impl ImmutableStore for DelayingPutStore {
+        async fn get_metadata(
+            self: Arc<Self>,
+            partition: Partition,
+            address: Address,
+        ) -> Result<StoreQueryResult, StoreError> {
+            self.query(partition, address, StoreMatch::MatchFull).await
+        }
+
         fn is_local(&self) -> bool {
             self.inner.clone().is_local()
         }
@@ -2071,6 +2128,14 @@ mod tests {
 
     #[async_trait::async_trait]
     impl ImmutableStore for CountingPutStore {
+        async fn get_metadata(
+            self: Arc<Self>,
+            partition: Partition,
+            address: Address,
+        ) -> Result<StoreQueryResult, StoreError> {
+            self.query(partition, address, StoreMatch::MatchFull).await
+        }
+
         fn is_local(&self) -> bool {
             self.inner.clone().is_local()
         }

--- a/lore-storage/src/write_tracker.rs
+++ b/lore-storage/src/write_tracker.rs
@@ -20,11 +20,13 @@ use parking_lot::Mutex;
 use tokio::sync::Notify;
 
 use crate::error::StorageError;
-use crate::types::Address;
 use crate::types::Fragment;
 
 /// Result type every leader / follower task yields.
-pub type TrackedResult = Result<(Address, Fragment), StorageError>;
+///
+/// Success carries nothing: the tracker only ever asks whether the write landed, and the caller
+/// that dispatched it already has the address.
+pub type TrackedResult = Result<(), StorageError>;
 
 /// Callback invoked per stored fragment with its header and dedup status.
 pub type FragmentObserver = Arc<dyn Fn(&Fragment, bool) + Send + Sync>;
@@ -210,24 +212,10 @@ mod tests {
     use std::sync::atomic::Ordering;
     use std::time::Duration;
 
-    use zerocopy::FromZeros;
-
     use super::*;
-    use crate::types::Context;
-    use crate::types::Hash;
 
     fn ok_result() -> TrackedResult {
-        Ok((
-            Address {
-                context: Context::new_zeroed(),
-                hash: Hash::new_zeroed(),
-            },
-            Fragment {
-                flags: 0,
-                size_payload: 1,
-                size_content: 1,
-            },
-        ))
+        Ok(())
     }
 
     #[tokio::test]
@@ -282,11 +270,11 @@ mod tests {
         let tracker = Arc::new(WriteTracker::new());
         tracker.spawn_leader(async {
             tokio::time::sleep(Duration::from_millis(5)).await;
-            Err::<(Address, Fragment), _>(StorageError::internal("first"))
+            Err::<(), _>(StorageError::internal("first"))
         });
         tracker.spawn_leader(async {
             tokio::time::sleep(Duration::from_millis(30)).await;
-            Err::<(Address, Fragment), _>(StorageError::internal("second"))
+            Err::<(), _>(StorageError::internal("second"))
         });
         let err = tracker
             .await_all()

--- a/lore/src/storage/get_metadata.rs
+++ b/lore/src/storage/get_metadata.rs
@@ -205,7 +205,7 @@ async fn resolve_local(
     match store
         .immutable
         .clone()
-        .query(item.partition, item.address, StoreMatch::MatchFull)
+        .get_metadata(item.partition, item.address)
         .await
     {
         Ok(result) if result.match_made == StoreMatch::MatchFull => {

--- a/lore/src/storage/put.rs
+++ b/lore/src/storage/put.rs
@@ -227,7 +227,7 @@ async fn resolve_put_item(
     )
     .await
     {
-        Ok((address, _fragment)) => (address, LoreErrorCode::None),
+        Ok(address) => (address, LoreErrorCode::None),
         Err(err) => (
             Address::default(),
             crate::storage::storage_error_to_code(&err),

--- a/lore/src/storage/put_file.rs
+++ b/lore/src/storage/put_file.rs
@@ -226,7 +226,7 @@ async fn resolve_put_file_item(
     )
     .await
     {
-        Ok((address, _fragment)) => (address, LoreErrorCode::None),
+        Ok((address, _size)) => (address, LoreErrorCode::None),
         Err(err) => (
             Address::default(),
             crate::storage::storage_error_to_code(&err),


### PR DESCRIPTION
## Problem
The AWS store keys S3 objects by the *content* hash while the object holds one *representation* of that content. Two writers may hold different valid representations of the same content (LZ4 and Zstd of the same bytes) and both address the same key. The fragment describing which representation is stored lives in a separate DynamoDB record, so two independently written records are required to agree. They can fail to:

1. **Concurrent cross-partition writers** — two writers upload different representations and publish different fragments. The interleaving leaving writer A's fragment beside writer B's payload is permanent and requires no failure.
2. **A lost metadata write** — a writer replaces the object, then fails to publish. The stored fragment describes bytes that are gone, and the affected partition cannot repair it: its re-put sees a full match and does nothing.

Both yield a payload that cannot be decompressed, reported as an internal size mismatch, undetected until a read fails.

Separately, `lookup` short-circuits to `MatchNone` when `MatchFull` is requested, so `put`'s
`MatchPartition` and `MatchHash` arms are unreachable — content already durable in one partition is uploaded again for another.

## Change
The fragment travels on the object as `x-amz-meta-lore-fragment:
<flags hex>:<size_payload>:<size_content>`. Object metadata is part of the object version, so a `GetObject` returns headers and body from the same version, and a full-object PUT is atomic. Last-writer-wins becomes safe; the disagreement is removed rather than policed.

The DynamoDB fragment metadata table becomes a **fragment state table**: row presence means the hash exists, plus obliteration state. The existence probe stays a single `GetItem` with no S3 request.

**No S3 or DynamoDB feature beyond the plainest ones** — no conditional S3 write, no ETag
compare-and-set, no object-age heuristic, no transaction. The one conditional DynamoDB write is an `attribute_not_exists` create guarding an obliteration mark.

## Flows

**Put** — probe association ∥ state, in parallel:
| Probe | Action |
| --- | --- |
| state = Obliterating | `SLOWDOWN` |
| state present, associated | `OK` |
| state present, not associated, payload supplied | associate only, **no S3** |
| state present, not associated, no payload | `Payload buffer required` |
| no state, or Obliterated | upload → conditional create → associate |

Ordering is load-bearing: object, then state row, then association. The reverse leaves a hash claiming to exist with no bytes, *unrepairable by retry* because the next put takes the
already-stored branch. Every step is idempotent, so a retry converges from any interruption.

**Get** — association `GetItem` ∥ `GetObject`. The fragment arrives on the response carrying the bytes; the size check is self-consistency on one object.

**Query** — association ∥ state, **no S3**. It is called once per fragment stored on the ingress path (`query_match_full`), which ADR-00008 identifies as the busiest path in the server.

**`ImmutableStore::get_metadata`** — new, defaulting to a `MatchFull` query; the AWS store overrides it with a `HeadObject`. The only path spending an S3 request purely on metadata.

**Obliterate** — mark → delete association (compliance discharged) → drain → count → release mark, or recurse sub-fragments, delete payload, tombstone.

## Costs
| Operation | main | This branch |
| --- | --- | --- |
| Put, new content | 1–3 DDB reads, 1 S3 PUT, 2 DDB writes | 2 DDB reads (parallel), 1 S3 PUT, 2 DDB writes |
| Put, dedup across partitions | not supported — re-uploads | 2 DDB reads, 1 DDB write, **no S3** |
| Get | 2 DDB reads, 1 S3 GET | **1 DDB read**, 1 S3 GET (parallel) |
| Query | 2 DDB reads | 2 DDB reads (parallel), **no S3** |
| Copy | 2 DDB reads, 1 DDB write | **1 DDB read**, 1 DDB write |
| get_metadata | 2 DDB reads | 2 DDB reads + 1 `HeadObject` |

Production code in `lore-aws` grows ~460 lines; `dynamodb.rs` is untouched. This is not a
simplification measured in lines.

## Rollout

**Full stop, then full start — no mixed fleet.** That removes the dual-write phase: nothing writes the old shape, and the guarantee holds from the first write. **There is no clean rollback once writes are served** — content written after cut-over is described only on its object.

Configuration is non-breaking: `dynamodb_metadata_table` is accepted as an alias for
`dynamodb_fragment_state_table`. The optional `dynamodb_fragment_metadata_table` gates the fallback read for pre-cut-over objects; leaving it unset declares no such object exists, so an object with no metadata is reported as damaged rather than described from a row that cannot be about it.

## Testing
94 tests in `lore-aws`. The fake supports fault injection across nine operations, which makes error paths reachable. Every behavioural guard was verified by removing it and confirming the test fails.

Notable: `concurrent_writers_cannot_tear_the_fragment_from_its_payload` (4 writers × 4
representations × 64 randomized rounds), sub-fragment obliteration and its failure aggregation, the drain window, the post-upload obliteration race, and lost-payload detection and repair.

## Known limitations
A lost payload (object gone, reference remains) is detected on both reads and repaired by clearing the state row; reconciling the whole population is left to the planned obliteration work table. A crashed obliteration leaves a mark that nothing clears. The obliteration drain narrows but does not close its race.

Design and migration: `docs/proposals/2026-08-03-fragment-metadata-on-the-s3-object.md`. Decision and alternatives: ADR-00018, which supersedes ADR-00006.
