### PR TITLE
lore-revision: Compare all 4 tag bytes when detecting Unreal packages

### DIFF
--- a/lore-revision/src/infer.rs
+++ b/lore-revision/src/infer.rs
@@ -33,12 +33,12 @@ pub fn infer_is_upackage_by_slice(buffer: &[u8]) -> bool {
     // Is it containing an unreal magic marker?
     if buffer.len() >= 4 {
         let package_file_tag = vec![0x9E, 0x2A, 0x83, 0xC1];
-        if buffer[..3] == package_file_tag {
+        if buffer[..4] == package_file_tag {
             return true;
         }
 
         let package_file_tag_swapped = vec![0xC1, 0x83, 0x2A, 0x9E];
-        if buffer[..3] == package_file_tag_swapped {
+        if buffer[..4] == package_file_tag_swapped {
             return true;
         }
     }
@@ -232,6 +232,7 @@ mod tests {
     use super::SCAN_WINDOW;
     use super::infer_is_conflicted_by_path;
     use super::infer_is_diffable_by_slice;
+    use super::infer_is_upackage_by_slice;
     use super::infer_is_utf8_by_slice;
 
     /// A file holding `contents`, alive for as long as the returned directory is.
@@ -287,6 +288,40 @@ mod tests {
         assert!(
             !infer_is_diffable_by_slice(&bytes),
             "UTF-16 BE BOM must be non-diffable so merge falls into the binary-conflict path that preserves bytes"
+        );
+    }
+
+    #[test]
+    fn upackage_tag_is_detected() {
+        let mut bytes = vec![0x9E, 0x2A, 0x83, 0xC1];
+        bytes.extend_from_slice(&[0u8; 16]);
+        assert!(
+            infer_is_upackage_by_slice(&bytes),
+            "An Unreal package file tag must be detected"
+        );
+
+        let mut bad_tag = vec![0x9E, 0x2A, 0x83, 0xC2];
+        bad_tag.extend_from_slice(&[0u8; 16]);
+        assert!(
+            !infer_is_upackage_by_slice(&bad_tag),
+            "A buffer that only shares the first three tag bytes is not an Unreal package"
+        );
+    }
+
+    #[test]
+    fn upackage_swapped_tag_is_detected() {
+        let mut bytes = vec![0xC1, 0x83, 0x2A, 0x9E];
+        bytes.extend_from_slice(&[0u8; 16]);
+        assert!(
+            infer_is_upackage_by_slice(&bytes),
+            "A byte swapped Unreal package file tag must be detected"
+        );
+
+        let mut bad_tag = vec![0xC1, 0x83, 0x2A, 0x9F];
+        bad_tag.extend_from_slice(&[0u8; 16]);
+        assert!(
+            !infer_is_upackage_by_slice(&bad_tag),
+            "A buffer that only shares the first three swapped tag bytes is not an Unreal package"
         );
     }
 


### PR DESCRIPTION
## What

Compare all four bytes of the Unreal package tag in `infer_is_upackage_by_slice`.

## Why

Both branches attempted to compare `buffer[..3]` (3 bytes) with a 4-byte `Vec<u8>`. Since slice equality fails on length mismatches, the function unconditionally returned false for both byte orders, even though the preceding `buffer.len() >= 4` guard was expecting 4 bytes.

Its only caller, `infer_is_diffable_by_slice`, still classified packages as non-diffable, because both tag orders start with an invalid UTF-8 lead byte and the check below rejects them anyway. This restores the intended check rather than changing how any file is classified today.

Fixes #172.

## How

- Compare `buffer[..4]` in both branches.
- Add one test per byte order, each with a near miss buffer that shares only the first three bytes.

## Testing

Ran the nightly fmt check and clippy for `lore-revision` with warnings denied. `cargo test -p lore-revision` passes 272 tests. Both new tests fail when `buffer[..3]` is restored.

AI tools used: Claude Code (Opus 5), for the investigation and the change itself.
