### PR TITLE
repository: honor --dry-run in repository delete

### DIFF
--- a/lore-client/src/cli/commands/repository.rs
+++ b/lore-client/src/cli/commands/repository.rs
@@ -930,14 +930,24 @@ pub fn handle_repository_delete(globals: LoreGlobalArgs, args: &RepositoryDelete
 
     let args = LoreRepositoryDeleteArgs { repository_url };
 
+    let dry_run = globals.dry_run();
+
     let callback = output_formatter().unwrap_or(Some(
         (Box::new(move |event: &LoreEvent| match event {
             LoreEvent::Complete(data) if data.status == 0 => {
-                println!(
-                    "{}Repository deleted successfully{}",
-                    CommonStyles::SUCCESS,
-                    anstyle::Reset
-                );
+                if dry_run {
+                    println!(
+                        "{}Repository would be deleted{}",
+                        CommonStyles::SUCCESS,
+                        anstyle::Reset
+                    );
+                } else {
+                    println!(
+                        "{}Repository deleted successfully{}",
+                        CommonStyles::SUCCESS,
+                        anstyle::Reset
+                    );
+                }
             }
             LoreEvent::Maintenance(data) => {
                 util::handle_maintenance_event(data);

--- a/lore-revision/src/repository/delete.rs
+++ b/lore-revision/src/repository/delete.rs
@@ -6,6 +6,7 @@ use lore_error_set::prelude::*;
 
 use super::RepositoryError;
 use crate::lore::RepositoryId;
+use crate::lore::execution_context;
 use crate::protocol;
 use crate::repository;
 
@@ -41,10 +42,12 @@ pub async fn delete(repository_url: &str, identity: &str) -> Result<(), Reposito
         id = data.id;
     }
 
-    repository_service
-        .delete(id)
-        .await
-        .forward::<RepositoryError>("Failed to delete repository")?;
+    if !execution_context().globals().dry_run() {
+        repository_service
+            .delete(id)
+            .await
+            .forward::<RepositoryError>("Failed to delete repository")?;
+    }
 
     Ok(())
 }


### PR DESCRIPTION
## What

`lore repository delete --dry-run` now actually performs a dry run instead
of deleting the repository. The CLI also reports "Repository would be
deleted" rather than "Repository deleted successfully" when `--dry-run` is
set.

## Why

`lore-revision/src/repository/delete.rs::delete()` never checked
`dry_run` — it called `repository_service.delete(id)` unconditionally.
Every other destructive command in this codebase (`revision commit`,
`branch push/switch`, `clone`) gates its mutating call behind
`globals.dry_run()` / `execution_context().globals().dry_run()`; `delete`
was simply missing that check. This is a safety-flag correctness bug: a
user relying on `--dry-run` before a destructive operation gets no warning
and no protection.

## How

- `lore-revision/src/repository/delete.rs`: wrap the
  `repository_service.delete(id)` call in
  `if !execution_context().globals().dry_run()`, following the same pattern
  already used in `repository/clone.rs` and `branch/push.rs` in this crate.
  The repository name/ID is still resolved and validated either way, so a
  dry run still surfaces a bad URL/name the same way a real delete would.
- `lore-client/src/cli/commands/repository.rs`: the delete callback's
  success message now distinguishes `dry_run` (prints "Repository would be
  deleted") from a real delete ("Repository deleted successfully"),
  matching the message style already used by `revision commit`
  ("Previewing commit" vs "Committing").

## Testing

- [x] `cargo +nightly fmt --all`
- [x] `cargo clippy -p lore-revision -p lore-client --all-targets -- -D warnings --no-deps` (full-workspace clippy currently fails on an unrelated pre-existing issue in `lore-revision/src/util/fs.rs`, not touched by this PR)
- [x] `cargo test -p lore-revision -p lore-client`
- [ ] No test included in this PR. There was no existing test coverage for
      `repository delete` at all, and none of this crate's tests spin up a
      real server, so covering this properly meant adding new test
      infrastructure rather than a single test function. That's split out
      into a companion PR (in-process gRPC server harness + dry-run/real-delete
      tests for `repository::delete::delete()`) so it can be reviewed on its
      own.

## Notes for reviewers

Small, mechanical, non-security change — no auth/crypto paths touched.

## AI assistance disclosure

This change (code and this PR description) was developed with Claude (Anthropic) assistance. I reviewed and tested the change myself and am responsible for its correctness.
