### PR TITLE
fix(filter): an unsupported rule in .loreignore is a hard error naming the line

### DIFF
--- a/lore-revision/src/filter.rs
+++ b/lore-revision/src/filter.rs
@@ -215,12 +215,25 @@ pub fn load_view(view_path: impl AsRef<Path>) -> Result<Filter, FilterError> {
     })
 }
 
+/// Reads a filter file, one rule per line.
+///
+/// A rule this filter cannot express is reported and skipped, and the rest of
+/// the file still applies. Aborting instead would discard every rule in the
+/// file, including the ones before the offending line, and a filter that
+/// silently excludes nothing is far more damaging than one missing rule: the
+/// only signal the author gets is that everything they meant to ignore turns up
+/// as changed.
 pub fn load_filter(path: impl AsRef<Path>) -> Result<FilterInstance, FilterError> {
+    let path = path.as_ref();
     let mut filter = FilterInstance::default();
     if let Ok(file) = File::open(path) {
         let mut has_include = false;
         let mut has_exclude = false;
-        for line in BufReader::new(file).lines().map_while(Result::ok) {
+        for (index, line) in BufReader::new(file)
+            .lines()
+            .map_while(Result::ok)
+            .enumerate()
+        {
             let mut glob = line.trim();
             if glob.is_empty() || glob.starts_with('#') {
                 continue;
@@ -237,12 +250,28 @@ pub fn load_filter(path: impl AsRef<Path>) -> Result<FilterInstance, FilterError
                 glob = &glob[1..];
             }
 
-            if negated {
-                filter.add_inclusion(glob)?;
-                has_include = true;
+            let added = if negated {
+                filter.add_inclusion(glob)
             } else {
-                filter.add_exclusion(glob)?;
-                has_exclude = true;
+                filter.add_exclusion(glob)
+            };
+
+            match added {
+                Ok(()) => {
+                    if negated {
+                        has_include = true;
+                    } else {
+                        has_exclude = true;
+                    }
+                }
+                Err(error) => {
+                    lore_warn!(
+                        "{}:{}: ignoring unsupported rule `{}`: {error}. The remaining rules in this file still apply.",
+                        path.display(),
+                        index + 1,
+                        line.trim(),
+                    );
+                }
             }
         }
 

--- a/lore-revision/src/filter.rs
+++ b/lore-revision/src/filter.rs
@@ -217,12 +217,13 @@ pub fn load_view(view_path: impl AsRef<Path>) -> Result<Filter, FilterError> {
 
 /// Reads a filter file, one rule per line.
 ///
-/// A rule this filter cannot express is reported and skipped, and the rest of
-/// the file still applies. Aborting instead would discard every rule in the
-/// file, including the ones before the offending line, and a filter that
-/// silently excludes nothing is far more damaging than one missing rule: the
-/// only signal the author gets is that everything they meant to ignore turns up
-/// as changed.
+/// A rule this filter cannot express is a hard error, and the error names the
+/// file, the 1-based line number and the rule as written. Skipping the line
+/// instead would leave a filter that no longer represents the author's intent
+/// and whose inclusions and exclusions may differ arbitrarily from what was
+/// meant, which is at least as bad as having no filter; and the only signal a
+/// warning gives is a line in a log the author of an integration toolchain
+/// never reads.
 pub fn load_filter(path: impl AsRef<Path>) -> Result<FilterInstance, FilterError> {
     let path = path.as_ref();
     let mut filter = FilterInstance::default();
@@ -265,12 +266,17 @@ pub fn load_filter(path: impl AsRef<Path>) -> Result<FilterInstance, FilterError
                     }
                 }
                 Err(error) => {
-                    lore_warn!(
-                        "{}:{}: ignoring unsupported rule `{}`: {error}. The remaining rules in this file still apply.",
+                    // The line info goes in the message rather than in
+                    // `internal_with_context`: `Display for Traced` forwards to
+                    // the inner error and never prints the trace, so a context
+                    // string would name the line somewhere the reader of the
+                    // error never looks.
+                    return Err(FilterError::internal(format!(
+                        "{}:{}: unsupported rule `{}`: {error}",
                         path.display(),
                         index + 1,
                         line.trim(),
-                    );
+                    )));
                 }
             }
         }

--- a/lore-revision/src/repository.rs
+++ b/lore-revision/src/repository.rs
@@ -2531,10 +2531,17 @@ pub fn load_filter(root_path: &Path) -> Option<Arc<filter::Filter>> {
 
     let view_path = root_path.join(format.dot_dir()).join(VIEW_FILTER);
 
-    if let Ok(filter) = filter::load(&ignore_path, &view_path) {
-        Some(Arc::new(filter))
-    } else {
-        None
+    match filter::load(&ignore_path, &view_path) {
+        Ok(filter) => Some(Arc::new(filter)),
+        Err(error) => {
+            // Returning `None` here means nothing is filtered at all, which looks
+            // to the user like every ignored file suddenly changed. Say why.
+            lore_warn!(
+                "Failed to load the filter from {}: {error}. Nothing will be ignored until this is fixed.",
+                ignore_path.display(),
+            );
+            None
+        }
     }
 }
 

--- a/lore-revision/tests/filter.rs
+++ b/lore-revision/tests/filter.rs
@@ -1068,37 +1068,57 @@ mod tests {
     /// it. Regression for the `.loreignore` that stopped ignoring anything at
     /// all because one line held an unanchored multi-component re-inclusion.
     #[test]
-    fn unsupported_rule_does_not_discard_the_file() {
+    fn unsupported_rule_fails_the_load_and_names_the_line() {
         use std::io::Write as _;
 
         let dir = tempfile::tempdir().expect("temp dir");
         let path = dir.path().join(".loreignore");
         let mut file = std::fs::File::create(&path).expect("create");
         // Line 2 is valid .gitignore but unsupported by lore: an unanchored
-        // multi-component re-inclusion, refused by `add_inclusion`.
+        // multi-component re-inclusion, refused by `add_inclusion`. Line 3 is
+        // valid and sits after it, so a load that reports success would have to
+        // have carried on past the refusal.
         file.write_all(b"**/DerivedDataCache/\n!**/Plugins/*/Binaries/\n**/Intermediate/\n")
             .expect("write");
         drop(file);
 
-        let filter = lore_revision::filter::load_filter(&path).expect("load");
+        let error = lore_revision::filter::load_filter(&path)
+            .expect_err("an unsupported rule must fail the load, not be skipped");
 
-        // The rule before the unsupported line still applies.
+        // The message has to be enough to fix the file without bisecting it:
+        // which file, which line, and the rule as the author wrote it.
+        let message = error.to_string();
+        assert!(
+            message.contains(&format!("{}:2:", path.display())),
+            "error must name the file and the 1-based line: {message}"
+        );
+        assert!(
+            message.contains("!**/Plugins/*/Binaries/"),
+            "error must quote the rule as written: {message}"
+        );
+    }
+
+    #[test]
+    fn a_file_of_supported_rules_still_loads() {
+        use std::io::Write as _;
+
+        // Positive control for the test above: the failure has to come from the
+        // unsupported rule, not from every load of a file.
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = dir.path().join(".loreignore");
+        let mut file = std::fs::File::create(&path).expect("create");
+        file.write_all(b"**/DerivedDataCache/\n**/Intermediate/\n")
+            .expect("write");
+        drop(file);
+
+        let filter = lore_revision::filter::load_filter(&path).expect("load");
         assert!(filter.excludes(
             &RelativePath::new_from_initial_path("Unreal/DerivedDataCache").expect("Path create"),
             true
         ));
-        // So does the rule after it.
         assert!(filter.excludes(
             &RelativePath::new_from_initial_path("Unreal/Intermediate").expect("Path create"),
             true
         ));
-        // The unsupported rule itself is skipped, not honoured.
-        assert!(
-            filter.excludes(
-                &RelativePath::new_from_initial_path("Unreal/DerivedDataCache/VT")
-                    .expect("Path create"),
-                true
-            )
-        );
     }
 }

--- a/lore-revision/tests/filter.rs
+++ b/lore-revision/tests/filter.rs
@@ -1063,4 +1063,42 @@ mod tests {
             true
         ));
     }
+
+    /// A rule the filter cannot express must not take the rest of the file with
+    /// it. Regression for the `.loreignore` that stopped ignoring anything at
+    /// all because one line held an unanchored multi-component re-inclusion.
+    #[test]
+    fn unsupported_rule_does_not_discard_the_file() {
+        use std::io::Write as _;
+
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = dir.path().join(".loreignore");
+        let mut file = std::fs::File::create(&path).expect("create");
+        // Line 2 is valid .gitignore but unsupported by lore: an unanchored
+        // multi-component re-inclusion, refused by `add_inclusion`.
+        file.write_all(b"**/DerivedDataCache/\n!**/Plugins/*/Binaries/\n**/Intermediate/\n")
+            .expect("write");
+        drop(file);
+
+        let filter = lore_revision::filter::load_filter(&path).expect("load");
+
+        // The rule before the unsupported line still applies.
+        assert!(filter.excludes(
+            &RelativePath::new_from_initial_path("Unreal/DerivedDataCache").expect("Path create"),
+            true
+        ));
+        // So does the rule after it.
+        assert!(filter.excludes(
+            &RelativePath::new_from_initial_path("Unreal/Intermediate").expect("Path create"),
+            true
+        ));
+        // The unsupported rule itself is skipped, not honoured.
+        assert!(
+            filter.excludes(
+                &RelativePath::new_from_initial_path("Unreal/DerivedDataCache/VT")
+                    .expect("Path create"),
+                true
+            )
+        );
+    }
 }


### PR DESCRIPTION
Fixes #182.

### What goes wrong

`filter::load_filter` reads the ignore file line by line and propagates the rule error with `?`:

```rust
if negated {
    filter.add_inclusion(glob)?;
} else {
    filter.add_exclusion(glob)?;
}
```

So one rule the filter cannot express aborts the read and discards **every** rule in the file, including the ones *before* the offending line — and it does so with nothing naming the line at fault. `repository::load_filter` then turns that `Err` into `None`:

```rust
if let Ok(filter) = filter::load(&ignore_path, &view_path) { Some(...) } else { None }
```

with no log at any level, so the repository ends up with no filter at all and the only signal reaching the user is that everything they meant to ignore shows up as changed. In #182 that was `**/DerivedDataCache/` going dead because a later line said `!**/Plugins/*/Binaries/`.

### The change

The refusal itself is untouched — `add_inclusion` still rejects an unanchored multi-component re-inclusion, and `unanchored_multi_component_inclusion_is_refused` still passes. What changes is that the failure now says which line caused it instead of vanishing:

```
.loreignore:2: unsupported rule `!**/Plugins/*/Binaries/`: filter inclusions
cannot start with ** as that will force traversal of the entire revision tree
```

- `filter::load_filter` raises a hard error naming the path, the 1-based line number, and the rule as written. Per review (@mjansson): Lore hard-errors on invalid config rather than skipping it, and a filter that kept some rules and dropped others is not a smaller version of what the author wrote but a different filter, with no way for the reader to tell which one they got.
- The line info is in the error *message*, not in `FilterError::internal_with_context`. `Display for Traced` forwards to the inner error and never renders the trace, so a context string would have recorded the line somewhere no reader of the error looks. There is a comment at the call site saying so.
- `repository::load_filter` logs the failure instead of swallowing it, for the errors that can still come out of `filter::load`.

This gives the reporter's items 1 and 2. Item 3 — documenting which gitignore subset `.loreignore` supports — is not in this PR; happy to follow up if you want it in `docs/`.

### Still open, deliberately outside this diff

`repository::load_filter` returns `Option<Arc<Filter>>` and `repository.rs:2122` does `.unwrap_or_default()`, so the hard error is raised, logged with the line, and then turned into an empty filter one level up. Propagating it is `Option` -> `Result` through that call site; say the word and it goes in here, or in a separate PR.

### Verification

`unsupported_rule_fails_the_load_and_names_the_line` in `lore-revision/tests/filter.rs` writes the reporter's file plus a third rule after the bad line, asserts the load fails, and asserts the message names both the line and the rule as written. `a_file_of_supported_rules_still_loads` beside it is the positive control, so a failure is attributable to the unsupported rule rather than to every load.

```
cargo test -p lore-revision --test filter
test result: ok. 12 passed; 0 failed
```

Negative control — tests kept, `lore-revision/src/filter.rs` reverted to warn-and-skip:

```
test tests::unsupported_rule_fails_the_load_and_names_the_line ... FAILED
test tests::a_file_of_supported_rules_still_loads ... ok
test result: FAILED. 11 passed; 1 failed
```
