### PR TITLE
scripts: Assert what the client reports when a push is missing a fragment

### DIFF
--- a/scripts/test/test_push_missing_fragments.py
+++ b/scripts/test/test_push_missing_fragments.py
@@ -96,7 +96,13 @@ def test_push_missing_fragments(new_lore_repo, missing_fragments_remote_url):
     # Push main branch
     output = repo.push(check=False).strip()
 
-    assert "Missing fragment" in output, "Push failed for unrelated reason"
+    # The client reports the server's AddressNotFound by its own wording and the
+    # missing address; the server's status text is not echoed. Assert on both so
+    # the test pins the error class and that it names a dropped fragment.
+    assert "peer is missing a fragment" in output, "Push failed for unrelated reason"
+    assert any(h in output for h in DROPPED_FRAGMENT_HASHES.split(",")), (
+        "Push failure did not name a dropped fragment"
+    )
 
     # Create source repository
     repo = new_lore_repo(remote_url=missing_fragments_remote_url)


### PR DESCRIPTION
## Problem

`test_push_missing_fragments` (added in 7c3dddc) fails deterministically on `main`, not just on PR branches: the smoke job fails on the dependabot run 34148922667 and on 34085660968, and it fails 3/3 locally on `9a9c24b` with a `failure_generator` build.

The test asserts that the push output contains the server's status text, `"Missing fragment"`. The client never echoes that text: it decodes the `FAILED_PRECONDITION` details into `ProtocolError::AddressNotFound` and reports it in its own words. The actual output is

```
[Error] Address not found: 9d3f226e7cb165563394906ba32e9fc3a6d0f9721287a9485d1e0533112bdd01-…
  at lore-revision/src/branch/push.rs:1078 - pushing branch to remote, peer is missing a fragment
```

— which is the behavior 7c3dddc set out to produce (the address is the first entry of `DROPPED_FRAGMENT_HASHES`), so the server and client are right and the assertion is wrong.

## Change

Assert on what the client actually reports: the `peer is missing a fragment` wording (pins the error class the client reconstructed) and that the output names one of the dropped fragment hashes (pins that the *right* fragment was reported). Both are stronger than the prose match they replace.

## Checks

The test passes 3/3 locally against a `failure_generator` build of `main`, including the follow-on push/clone/delete steps in the same test.
