### PR TITLE
Build a native arm64 image instead of emulating amd64

### DIFF
--- a/contrib/aws/README.md
+++ b/contrib/aws/README.md
@@ -13,8 +13,14 @@ This example uses **c8gd.8xlarge** Graviton instances (32 vCPU, 64 GB RAM, 1.9 T
 From the Lore repo root:
 
 ```sh
-docker buildx build --platform linux/arm64 -f lore-server/Dockerfile -t loreserver:v0.8.7 --load .
+docker buildx build --platform linux/arm64 \
+  --build-arg ARM64_TARGET_CPU=neoverse-512tvb \
+  -f lore-server/Dockerfile -t loreserver:v0.8.7 --load .
 ```
+
+> `ARM64_TARGET_CPU` tunes codegen for Graviton3+, matching the `c8gd` instances below. Without it
+> the build is baseline `armv8-a`, which runs here but leaves performance on the table. The
+> resulting binary uses SVE and will not run on older arm64 hardware.
 
 > If building on an x86 host, [register QEMU](https://docs.docker.com/build/building/multi-platform/#qemu) first:
 > `docker run --rm --privileged multiarch/qemu-user-static --reset -p yes`

--- a/docs/how-to/deploy-local-lore-server.md
+++ b/docs/how-to/deploy-local-lore-server.md
@@ -15,7 +15,7 @@ In this guide, you'll deploy local Lore Servers — with durable storage and a c
 The binary and Docker paths are mutually exclusive, and each is complete on its own — follow one top to bottom.
 
 - **[Run from the binary](#run-from-the-binary):** Fewer moving parts and native performance. Pick this to run `loreserver` directly on the host.
-- **[Run with Docker](#run-with-docker):** An isolated container. Pick this if you'd rather not put a binary on the host — but note the `linux/amd64` emulation caveat on Apple Silicon in the build step.
+- **[Run with Docker](#run-with-docker):** An isolated container. Pick this if you'd rather not put a binary on the host. Builds natively on both `amd64` and `arm64`, Apple Silicon included.
 
 ## Run from the binary
 
@@ -196,11 +196,11 @@ The binary and Docker paths are mutually exclusive, and each is complete on its 
     This needs Docker (and WSL2 on Windows) and the Lore repository cloned locally. Building the image compiles the server, so it needs several GB of free RAM. From the repository root:
 
     ```bash
-    docker build --platform linux/amd64 -f lore-server/Dockerfile -t lore-server .
+    docker build -f lore-server/Dockerfile -t lore-server .
     ```
 
     > [!NOTE]
-    > On Apple Silicon or Windows (both arm64 and amd64), build and run with `--platform linux/amd64` as shown. The `linux/arm64` server image targets AWS Graviton3 (SVE), an instruction set those CPUs lack.
+    > The image builds for your host architecture. On Apple Silicon or Windows on arm64 that is a baseline `armv8-a` build which runs natively — no `--platform` override is needed. To tune arm64 for AWS Graviton3 and newer instead, add `--build-arg ARM64_TARGET_CPU=neoverse-512tvb`; that binary uses SVE and will not run on other arm64 hardware.
 
 2. **Run it with default settings.**
 

--- a/lore-base/build.rs
+++ b/lore-base/build.rs
@@ -28,8 +28,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .define("ENABLE_OVERRIDE", "0")
         .includes(Some(native_dir.join("thirdparty")));
 
+    // Mirrors the -C target-cpu .cargo/config.toml pins, and settable to empty
+    // for a baseline build: neoverse-512tvb raises the architecture floor too,
+    // emitting stlur (armv8.4) that is undefined on Neoverse N1 (Ampere Altra).
+    println!("cargo:rerun-if-env-changed=LORE_ARM64_TARGET_CPU");
     if platform == "linux" && arch == "aarch64" {
-        cc_builder.flag("-mcpu=neoverse-512tvb");
+        let target_cpu =
+            env::var("LORE_ARM64_TARGET_CPU").unwrap_or_else(|_| "neoverse-512tvb".to_string());
+        if !target_cpu.is_empty() {
+            cc_builder.flag(format!("-mcpu={target_cpu}"));
+        }
     }
 
     if cc_builder.get_compiler().is_like_msvc() {

--- a/lore-server/DOCKER.md
+++ b/lore-server/DOCKER.md
@@ -6,19 +6,29 @@ telemetry integration, or replication is configured.
 ## Prerequisites
 
 - Docker with BuildKit support
-- On Apple Silicon (M-series Macs), builds must target `linux/amd64` due to Graviton-specific
-  compiler flags in `.cargo/config.toml` for `aarch64-unknown-linux-gnu`
+
+Both `linux/amd64` and `linux/arm64` build. `.cargo/config.toml` pins `aarch64-unknown-linux-gnu`
+to Graviton3+ via `-C target-cpu=neoverse-512tvb`, which faults on older arm64 parts, so the
+Dockerfile assembles `RUSTFLAGS` itself and leaves that tuning off by default. An arm64 image you
+build here therefore runs on any armv8-a host, Apple Silicon included.
 
 ## Building
 
 From the repository root:
 
 ```sh
-docker build --platform linux/amd64 -f lore-server/Dockerfile -t loreserver .
+docker build -f lore-server/Dockerfile -t loreserver .
 ```
 
-The build compiles the `loreserver` binary and generates self-signed TLS certificates for QUIC
-using `scripts/server/make-certs.sh`.
+Pass `--platform linux/amd64` or `--platform linux/arm64` to cross-build; expect it to be slow,
+since a release Rust build under emulation is far slower than a native one.
+
+To tune arm64 for Graviton3 and newer, as Lore is deployed, pass the microarchitecture. The
+resulting binary will not run on older arm64 hardware:
+
+```sh
+docker build -f lore-server/Dockerfile --build-arg ARM64_TARGET_CPU=neoverse-512tvb -t loreserver .
+```
 
 ## Running
 

--- a/lore-server/Dockerfile
+++ b/lore-server/Dockerfile
@@ -8,10 +8,28 @@ RUN apt-get update && apt-get install -y \
 WORKDIR /build
 COPY . .
 
+# Which arm64 microarchitecture to tune for. Empty is baseline armv8-a, which
+# runs anywhere. Ignored on amd64.
+ARG TARGETARCH
+ARG ARM64_TARGET_CPU=""
+
+# RUSTFLAGS is restated in full because .cargo/config.toml pins Graviton3+ for
+# this target and cargo *joins* config arrays: only RUSTFLAGS replaces [build]
+# and [target.*] outright, so anything less leaves a baseline build SIGILLing.
+# LORE_ARM64_TARGET_CPU carries the same choice to lore-base's cc build of
+# rpmalloc, which RUSTFLAGS cannot reach.
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
     --mount=type=cache,target=/build/target \
-    cargo build --release --bin loreserver && \
+    set -eu; \
+    RUSTFLAGS="--cfg tokio_unstable --cfg uuid_unstable -C force-unwind-tables=yes -C force-frame-pointers=yes"; \
+    if [ "${TARGETARCH}" = "arm64" ] && [ -n "${ARM64_TARGET_CPU}" ]; then \
+      RUSTFLAGS="${RUSTFLAGS} -C target-cpu=${ARM64_TARGET_CPU}"; \
+    fi; \
+    export RUSTFLAGS; \
+    export LORE_ARM64_TARGET_CPU="${ARM64_TARGET_CPU}"; \
+    echo "building with RUSTFLAGS=${RUSTFLAGS} LORE_ARM64_TARGET_CPU=${ARM64_TARGET_CPU}"; \
+    cargo build --release --bin loreserver; \
     cp /build/target/release/loreserver /build/loreserver-bin
 
 FROM debian:trixie-slim
@@ -42,7 +60,7 @@ ENV RUST_LOG=info
 RUN mkdir -p /data
 VOLUME /data
 
-# QUIC + gRPC: 41337, HTTP: 41339
-EXPOSE 41337 41339
+# 41337 carries gRPC over TCP and QUIC over UDP; both are needed.
+EXPOSE 41337/tcp 41337/udp 41339/tcp
 
 ENTRYPOINT ["loreserver"]


### PR DESCRIPTION
## Summary

An arm64 image built from source `SIGILL`s on anything short of Graviton3+, because `.cargo/config.toml` pins `-C target-cpu=neoverse-512tvb` for `aarch64-unknown-linux-gnu`. `DOCKER.md` worked around it by telling Apple Silicon users to build `--platform linux/amd64` and emulate:

```
- On Apple Silicon (M-series Macs), builds must target `linux/amd64` due to Graviton-specific
  compiler flags in `.cargo/config.toml` for `aarch64-unknown-linux-gnu`
```

This builds natively instead. `docker build -f lore-server/Dockerfile .` now produces a baseline `armv8-a` image on Apple Silicon, and `--build-arg ARM64_TARGET_CPU=neoverse-512tvb` opts back into the tuning for a Graviton deployment.

## Two things worth a reviewer's attention

**Overriding the pin needs `RUSTFLAGS` specifically**, not `CARGO_TARGET_<triple>_RUSTFLAGS`. The latter is only another source for the same config key, and cargo *joins* config arrays — the config's `-C target-cpu` would survive and the build would still fault. `RUSTFLAGS` replaces `[build]` and `[target.*]` outright, which is why the flags are restated in full rather than appended to.

**`RUSTFLAGS` does not reach a C compiler.** `lore-base/build.rs` pins the same `-mcpu` for its `cc` build of rpmalloc, so the Rust half alone is not enough. That flag raises the architecture floor as well as the tuning — disassembling both builds with GCC 14:

```
only in the tuned build:  casa casal casl ldadd ldapr madd stlur
```

No SVE, so Apple Silicon was never at risk from the C half. But `stlur` is FEAT_LRCPC2 (armv8.4) and `ldapr` is armv8.3, and Neoverse N1 has neither — so an otherwise-baseline image would still have faulted in the allocator on Ampere Altra and Graviton2. `build.rs` now reads `LORE_ARM64_TARGET_CPU`, defaulting to the value it hardcoded so nothing else changes, and the Dockerfile passes the choice through.

Also here: `EXPOSE` defaults to TCP, so it was not declaring the QUIC listener sharing port 41337 — `docker run -P` left it unreachable.

## Test evidence

- Disassembled rpmalloc both ways on `linux/arm64`; with the tuning off the allocator is clean `armv8-a`, and the instructions above appear only with it on.
- Built the image natively on an M3 Max and ran it — see the comment below for the result.
- `cargo fmt` and `cargo clippy` clean on `build.rs`. (Clippy reports three pre-existing errors in `lore-revision/src/{stage,state}.rs`, untouched here and present on main.)

## Note

Split out of #180, which touches the same two sections of `DOCKER.md` — whichever merges second will need a small conflict resolution.
